### PR TITLE
Unify server spawns

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
-    "@effection/node": "=1.0.0-preview.4",
+    "@effection/node": "=2.0.0-preview.5",
     "@simulacrum/client": "^0.0.0",
     "assert-ts": "^0.3.2",
     "effection": "=2.0.0-preview.5",

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,13 +1,7 @@
 import { Operation, Task } from 'effection';
 import { IncomingMessage, ServerResponse } from 'http';
-import type { Server as HttpServer } from 'http';
-import type { Server as HttpsServer } from 'https';
-import type { Express } from 'express';
 
-export type HttpServers = HttpServer | HttpsServer | Express;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface Behaviors extends Record<string, any> {
+export interface Behaviors {
   https: (handler: (app: HttpApp) => HttpApp) => Behaviors;
   http: (handler: (app: HttpApp) => HttpApp) => Behaviors;
   services: Service[];
@@ -39,12 +33,6 @@ export interface Simulation {
 
 export interface Server {
   port: number;
-}
-
-export type HttpServerOptions = { onClose?: () => void };
-
-export interface SimulationServer extends Server {
-  availableSimulators: Record<string, Simulator>;
 }
 
 export interface HttpHandler {

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,5 +1,5 @@
 import { createSimulation, spawnHttpServer } from '../server';
-import { Service, Simulation, Simulator, Server } from '../interfaces';
+import { Simulation, Simulator } from '../interfaces';
 import { assert } from 'assert-ts';
 import { Task } from 'effection';
 import express from 'express';

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -1,21 +1,20 @@
 import { spawnSimulationServer } from './server';
 import { main } from '@effection/node';
-import { HttpHandler } from './interfaces';
+import { HttpHandler, Server } from './interfaces';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = (_request, _response) => Promise.resolve();
 
 main(function* (scope) {
-  yield spawnSimulationServer(scope, {
+  let { port }: Server = yield spawnSimulationServer(scope, {
     simulators: {
       echo(simulation) {
-        return simulation.http(app => {
-          app.get('/', echo);
-          return app;
-        });
+        return simulation.http(app => app.get('/', echo));
       },
     }
   });
+
+  console.log(`Simulation server running on http://localhost:${port}/graphql`);
 
   yield;
 });

--- a/packages/server/test/schema.test.ts
+++ b/packages/server/test/schema.test.ts
@@ -49,7 +49,7 @@ mutation CreateSimulation {
 
     it('has the echo service', function* () {
       expect(simulation.services).toEqual([
-        {name: 'echo', url: 'http://localhost:444'}
+        {name: 'echo', url: expect.stringMatching('http://localhost') }
       ]);
     });
   });

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 
 import { createClient, Client, Simulation } from "@simulacrum/client";
 
-import type { HttpHandler, SimulationServer } from '../src/interfaces';
+import type { HttpHandler, Server } from '../src/interfaces';
 import { spawnSimulationServer } from '../src/server';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -11,7 +11,7 @@ const echo: HttpHandler = (_request, _response) => Promise.resolve();
 
 describe("@simulacrum/server", () => {
   let client: Client;
-  let server: SimulationServer;
+  let server: Server;
 
   beforeEach(function*(world) {
     server = yield spawnSimulationServer(world, {
@@ -40,8 +40,4 @@ describe("@simulacrum/server", () => {
   it('starts', function*() {
     expect(typeof server.port).toBe('number');
   });
-
-  it('adds the available simulators', function * () {
-    expect(typeof server.availableSimulators.echo).toBe('function');
-  })
 });


### PR DESCRIPTION
Motivation
-----------

With #2 the low-level `spawnHttpServer()` operation was introduced to make spawning with any http interface work. It was based on the original spawnSimulationServer(), but this makes the original simulation server use it.

Approach
----------

With that in place, and with the actual server managing the servers, we don't need any other type of http server than express, so we can simplify the types.

This also:

- upgrades effection node to the proper version
- fixes the service url testcase