### PR TITLE
Watch dev script and start simulators

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,7 +14,7 @@ export interface Service {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function createClient(_serverURL: string): Client {
   async function createSimulation() {
-    return { services: {} }
+    return { services: {} };
   }
   return { createSimulation };
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "assert-ts": "^0.3.2",
     "effection": "=2.0.0-preview.5",
     "express": "^4.17.1",
+    "get-port": "^5.1.1",
     "graphql": "^15.5.0",
     "nexus": "^1.0.0",
     "uuid": "^8.3.2"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,10 +36,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@effection/channel": "2.0.0-preview.4",
-    "@effection/events": "=2.0.0-preview.4",
     "@effection/mocha": "=2.0.0-preview.3",
-    "@effection/subscription": "=2.0.0-preview.4",
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,9 +4,11 @@
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {
+    "clean": "rimraf tsconfig.tsbuildinfo __generated__ dist",
     "test": "mocha -r ts-node/register --timeout 10000 test/**/*.test.ts",
     "generate": "tsc && ts-node src/schema/schema.ts",
-    "start": "npm run generate && ts-node src/start.ts"
+    "start": "npm run generate && ts-node src/start.ts",
+    "watch": "PORT=3000 NODE_ENV=development ts-node  -P ./watch-tsconfig.json ./watch.ts"
   },
   "repository": {
     "type": "git",
@@ -47,6 +49,7 @@
     "express-graphql": "^0.12.0",
     "graphql-request": "^3.4.0",
     "mocha": "^8.0.0",
+    "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,7 +33,10 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@effection/channel": "2.0.0-preview.4",
+    "@effection/events": "=2.0.0-preview.4",
     "@effection/mocha": "=2.0.0-preview.3",
+    "@effection/subscription": "=2.0.0-preview.4",
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -13,6 +13,7 @@ export interface Simulator {
 
 export interface ServerOptions {
   simulators: Record<string, Simulator>;
+  port?: number;
 }
 
 export type Protocols = 'http' | 'https';

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { Operation, Task } from 'effection';
-import { IncomingMessage, ServerResponse } from 'http';
+import type { Request, Response } from 'express';
 
 export interface Behaviors {
   https: (handler: (app: HttpApp) => HttpApp) => Behaviors;
@@ -37,7 +37,7 @@ export interface Server {
 }
 
 export interface HttpHandler {
-  (request: IncomingMessage, response: ServerResponse): Operation<void>;
+  (request: Request, response: Response): Operation<void>;
 }
 
 export const HttpMethods = ['get', 'post', 'put', 'delete', 'patch'] as const;

--- a/packages/server/src/schema/schema.ts
+++ b/packages/server/src/schema/schema.ts
@@ -2,8 +2,10 @@ import { makeSchema } from 'nexus';
 import path from 'path';
 import { types } from './types';
 
+const parent = path.basename(path.join(__dirname, '..'));
+
 export const schema = makeSchema({
-  shouldGenerateArtifacts: path.basename(__dirname) !== 'dist',
+  shouldGenerateArtifacts: parent !== 'dist',
   types,
   outputs: {
     schema: path.join(__dirname, '../__generated__/schema.graphql'),

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -8,8 +8,8 @@ import { Server, ServerOptions, Simulation, HttpApp, Methods, HttpHandler, HttpM
 import { SimulationContext } from './schema/context';
 
 const createAppHandler = (app: HttpApp) => (method: Methods) => (path: string, handler: HttpHandler): HttpApp => {
-  return {...app, handlers: app.handlers.concat({ method, path, handler })};
-}
+  return { ...app, handlers: app.handlers.concat({ method, path, handler }) };
+};
 
 const createHttpApp = () => {
   let app = {
@@ -23,7 +23,7 @@ const createHttpApp = () => {
   }
 
   return app;
-}
+};
 
 export function createSimulation(scope: Task, id?: string): Simulation {
   // TODO: if id exists, and existing simulation exists then return existing

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -3,7 +3,13 @@ import { main } from '@effection/node';
 import { HttpHandler, Server } from './interfaces';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const echo: HttpHandler = (_request, _response) => Promise.resolve();
+const echo: HttpHandler = function echo(request, response) {
+  return function * () {
+    response.contentType(request.headers['content-type'] ?? "application/octet-stream");
+
+    response.status(200).write(request.body ?? "echo");
+  };
+};
 
 const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
 
@@ -11,7 +17,7 @@ main(function* (scope) {
   let { port }: Server = yield spawnSimulationServer(scope, {
     simulators: {
       echo(simulation) {
-        return simulation.http(app => app.get('/', echo));
+        return simulation.http(app => app.post('/', echo));
       },
     },
     port: serverPort

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -5,13 +5,16 @@ import { HttpHandler, Server } from './interfaces';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = (_request, _response) => Promise.resolve();
 
+const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
+
 main(function* (scope) {
   let { port }: Server = yield spawnSimulationServer(scope, {
     simulators: {
       echo(simulation) {
         return simulation.http(app => app.get('/', echo));
       },
-    }
+    },
+    port: serverPort
   });
 
   console.log(`Simulation server running on http://localhost:${port}/graphql`);

--- a/packages/server/test/schema.test.ts
+++ b/packages/server/test/schema.test.ts
@@ -40,7 +40,7 @@ mutation CreateSimulation {
 }
 `;
       let result = yield client.request(createSimulationMutation);
-      simulation = result.createSimulation
+      simulation = result.createSimulation;
     });
 
     it('creates a simulation', function * () {
@@ -49,7 +49,7 @@ mutation CreateSimulation {
 
     it('has the echo service', function* () {
       expect(simulation.services).toEqual([
-        {name: 'echo', url: expect.stringMatching('http://localhost') }
+        { name: 'echo', url: expect.stringMatching('http://localhost') }
       ]);
     });
   });

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -36,7 +36,6 @@ describe("@simulacrum/server", () => {
     });
   });
 
-
   it('starts', function*() {
     expect(typeof server.port).toBe('number');
   });

--- a/packages/server/watch-tsconfig.json
+++ b/packages/server/watch-tsconfig.json
@@ -1,0 +1,9 @@
+{ 
+  "extends": "@frontside/tsconfig",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "sourceMap": true
+  },
+  "include": ["./watch.ts"]
+}

--- a/packages/server/watch.ts
+++ b/packages/server/watch.ts
@@ -1,0 +1,67 @@
+import type { Operation, Task } from 'effection';
+import type { Process } from '@effection/node';
+import { main, exec, daemon, StdIO } from '@effection/node';
+import { subscribe, Subscription } from '@effection/subscription';
+import type { Channel } from '@effection/channel';
+import { on } from '@effection/events';
+import { watch } from 'chokidar';
+import { Context } from 'vm';
+
+main(function* (task) {
+  let watcher = watch('./src/**/*.ts', { ignoreInitial: true });
+  try {
+    let process: Context = yield task.spawn(buildAndRun(task, 500));
+
+    let events: Subscription<[string]> = yield on(watcher, 'all');
+
+    while (true) {
+      let next: IteratorResult<[string]> = yield events.next();
+
+      if (next.done) {
+        break;
+      } else {
+        console.log('buidling.....');
+        process.halt();
+        process = yield task.spawn(buildAndRun(task, 100));
+      }
+    }
+  } finally {
+    watcher.close();
+  }
+});
+
+function writeOut(task: Task, channel: Channel<string>, out: NodeJS.WriteStream) {
+  return subscribe(task, channel).forEach(function (data) {
+    return new Promise((resolve, reject) => {
+      out.write(data, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+function* executeAndOut(task: Task, command: string): Operation<Context> {
+  let p: Process = yield exec(task, `yarn ${command}`);
+  yield task.spawn(writeOut(task, p.stdout, process.stdout));
+  yield task.spawn(writeOut(task, p.stderr, process.stderr));
+  yield p.expect();
+}
+
+function* buildAndRun(task: Task, delay = 0): Operation<Context> {
+  try {
+    yield executeAndOut(task, 'clean');
+    yield executeAndOut(task, 'generate');
+    yield timeout(delay);
+    let server: StdIO = yield daemon(task, 'node dist/server/server.js');
+    yield task.spawn(writeOut(task, server.stdout, process.stdout));
+    yield task.spawn(writeOut(task, server.stderr, process.stderr));
+  } catch (err) {
+    console.error(err);
+  }
+
+  yield;
+}

--- a/packages/server/watch.ts
+++ b/packages/server/watch.ts
@@ -1,37 +1,28 @@
-import type { Operation, Task } from 'effection';
+import { Operation, Task } from 'effection';
 import type { Process } from '@effection/node';
 import { main, exec, daemon, StdIO } from '@effection/node';
-import { subscribe, Subscription } from '@effection/subscription';
+import { sleep } from 'effection';
 import type { Channel } from '@effection/channel';
 import { on } from '@effection/events';
 import { watch } from 'chokidar';
-import { Context } from 'vm';
 
-main(function* (task) {
-  let watcher = watch('./src/**/*.ts', { ignoreInitial: true });
+main(function* (scope: Task) {
+  let watcher = watch('./src/**/*.ts', { ignoreInitial: true, ignored: 'distå' });
   try {
-    let process: Context = yield task.spawn(buildAndRun(task, 500));
+    let process: Task = scope.spawn(buildAndRun(500));
 
-    let events: Subscription<[string]> = yield on(watcher, 'all');
-
-    while (true) {
-      let next: IteratorResult<[string]> = yield events.next();
-
-      if (next.done) {
-        break;
-      } else {
-        console.log('buidling.....');
-        process.halt();
-        process = yield task.spawn(buildAndRun(task, 100));
-      }
-    }
+    yield on(watcher, 'all').forEach(function () {
+      console.log('buidling.....');
+      process.halt();
+      process = scope.spawn(buildAndRun(500));
+    });
   } finally {
     watcher.close();
   }
 });
 
-function writeOut(task: Task, channel: Channel<string>, out: NodeJS.WriteStream) {
-  return subscribe(task, channel).forEach(function (data) {
+function writeOut(channel: Channel<string>, out: NodeJS.WriteStream) {
+  return channel.forEach(function (data) {
     return new Promise((resolve, reject) => {
       out.write(data, (err) => {
         if (err) {
@@ -44,24 +35,28 @@ function writeOut(task: Task, channel: Channel<string>, out: NodeJS.WriteStream)
   });
 }
 
-function* executeAndOut(task: Task, command: string): Operation<Context> {
-  let p: Process = yield exec(task, `yarn ${command}`);
-  yield task.spawn(writeOut(task, p.stdout, process.stdout));
-  yield task.spawn(writeOut(task, p.stderr, process.stderr));
-  yield p.expect();
+function executeAndOut(command: string): Operation<void> {
+  return function *(task) {
+    let p: Process = exec(task, `npm run ${command}`);
+    task.spawn(writeOut(p.stdout, process.stdout));
+    task.spawn(writeOut(p.stderr, process.stderr));
+    yield p.expect();
+  };
 }
 
-function* buildAndRun(task: Task, delay = 0): Operation<Context> {
-  try {
-    yield executeAndOut(task, 'clean');
-    yield executeAndOut(task, 'generate');
-    yield timeout(delay);
-    let server: StdIO = yield daemon(task, 'node dist/server/server.js');
-    yield task.spawn(writeOut(task, server.stdout, process.stdout));
-    yield task.spawn(writeOut(task, server.stderr, process.stderr));
-  } catch (err) {
-    console.error(err);
-  }
+function buildAndRun(delay: number):Operation<void> {
+  return function*(scope) {
+    try {
+      yield executeAndOut('clean');
+      yield executeAndOut('generate');
+      yield sleep(delay);
+      let server: StdIO = daemon(scope, 'node dist/start.js');
+      scope.spawn(writeOut(server.stdout, process.stdout));
+      scope.spawn(writeOut(server.stderr, process.stderr));
+    } catch (err) {
+      console.error(err);
+    }
 
-  yield;
+    yield;
+  };
 }

--- a/packages/server/watch.ts
+++ b/packages/server/watch.ts
@@ -2,8 +2,8 @@ import { Operation, Task } from 'effection';
 import type { Process } from '@effection/node';
 import { main, exec, daemon, StdIO } from '@effection/node';
 import { sleep } from 'effection';
-import type { Channel } from '@effection/channel';
-import { on } from '@effection/events';
+import type { Channel } from 'effection';
+import { on } from 'effection';
 import { watch } from 'chokidar';
 
 main(function* (scope: Task) {


### PR DESCRIPTION
## Motivation

Add a watch script for development and start the simulator express servers.

## Approach

Used affection and started the simulators imperatively in the `SimulationContext`

### Alternate Designs

When we have the `Atom` we could start the simulators when they are added to the state.
