### PR TITLE
Extract http server logic into its own file

### DIFF
--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -1,15 +1,13 @@
 import { Deferred, Operation, Task, once } from 'effection';
 import { Express } from 'express';
-import type { AddressInfo } from 'net';
 
+import type { AddressInfo } from 'net';
 export type { AddressInfo } from 'net';
+
+import type { Runnable } from './interfaces';
 
 export interface Server {
   listening(): Operation<AddressInfo>;
-}
-
-export interface Runnable<T> {
-  run(scope: Task): T;
 }
 
 export function createServer(app: Express): Runnable<Server> {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -1,0 +1,45 @@
+import { Deferred, Operation, Task, once } from 'effection';
+import { Express } from 'express';
+import type { AddressInfo } from 'net';
+
+export type { AddressInfo } from 'net';
+
+export interface Server {
+  listening(): Operation<AddressInfo>;
+}
+
+export interface Runnable<T> {
+  run(scope: Task): T;
+}
+
+export function createServer(app: Express): Runnable<Server> {
+  return {
+    run(scope: Task) {
+      let server = app.listen();
+
+      let bound = Deferred<void>();
+
+      scope.spawn(function*() {
+        try {
+          yield once(server, 'listening');
+          bound.resolve();
+          yield;
+        } finally {
+          server.close();
+        }
+      });
+
+      scope.spawn(function*() {
+        let error: Error = yield once(server, 'error');
+        throw error;
+      });
+
+      return {
+        async listening() {
+          await bound.promise;
+          return server.address() as unknown as AddressInfo;
+        }
+      };
+    }
+  };
+}

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -21,8 +21,12 @@ export function createServer(app: Express): Runnable<Server> {
 
       scope.spawn(function*() {
         try {
-          yield once(server, 'listening');
-          bound.resolve();
+          if (server.listening) {
+            bound.resolve();
+          } else {
+            yield once(server, 'listening');
+            bound.resolve();
+          }
           yield;
         } finally {
           server.close();

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -1,6 +1,8 @@
 import { Deferred, Operation, Task, once } from 'effection';
 import { Express } from 'express';
+import getPort from 'get-port';
 
+import type { Server as HTTPServer } from 'http';
 import type { AddressInfo } from 'net';
 export type { AddressInfo } from 'net';
 
@@ -10,35 +12,39 @@ export interface Server {
   listening(): Operation<AddressInfo>;
 }
 
-export function createServer(app: Express): Runnable<Server> {
+export interface ServerOptions {
+  port?: number
+}
+
+export function createServer(app: Express, options: ServerOptions = {}): Runnable<Server> {
   return {
     run(scope: Task) {
-      let server = app.listen();
 
-      let bound = Deferred<void>();
+      let bound = Deferred<HTTPServer>();
 
-      scope.spawn(function*() {
+      scope.spawn(function*(task: Task) {
+        let port = yield getPort(options);
+        let server = app.listen(port);
+
+        task.spawn(function*() {
+          let error: Error = yield once(server, 'error');
+          throw error;
+        });
+
         try {
-          if (server.listening) {
-            bound.resolve();
-          } else {
-            yield once(server, 'listening');
-            bound.resolve();
-          }
+          yield once(server, 'listening');
+          bound.resolve(server);
+
           yield;
         } finally {
           server.close();
         }
       });
 
-      scope.spawn(function*() {
-        let error: Error = yield once(server, 'error');
-        throw error;
-      });
 
       return {
         async listening() {
-          await bound.promise;
+          let server = await bound.promise;
           return server.address() as unknown as AddressInfo;
         }
       };

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -9,7 +9,7 @@ export type { AddressInfo } from 'net';
 import type { Runnable } from './interfaces';
 
 export interface Server {
-  listening(): Operation<AddressInfo>;
+  address(): Operation<AddressInfo>;
 }
 
 export interface ServerOptions {
@@ -43,7 +43,7 @@ export function createServer(app: Express, options: ServerOptions = {}): Runnabl
 
 
       return {
-        async listening() {
+        async address() {
           let server = await bound.promise;
           return server.address() as unknown as AddressInfo;
         }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,1 @@
-export { spawnSimulationServer } from './server';
+export { createSimulationServer } from './server';

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,6 +1,10 @@
 import { Operation, Task } from 'effection';
 import type { Request, Response } from 'express';
 
+export interface Runnable<T> {
+  run(scope: Task): T;
+}
+
 export interface Behaviors {
   https: (handler: (app: HttpApp) => HttpApp) => Behaviors;
   http: (handler: (app: HttpApp) => HttpApp) => Behaviors;

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -55,7 +55,7 @@ export class SimulationContext {
         }
 
         let server = createServer(app).run(simulation.scope);
-        let { port } = await simulation.scope.spawn(server.listening());
+        let { port } = await simulation.scope.spawn(server.address());
 
         return {
           name: service.name,

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,4 +1,5 @@
-import { createSimulation, spawnHttpServer } from '../server';
+import { createServer } from '../http';
+import { createSimulation } from '../server';
 import { Simulation, Simulator } from '../interfaces';
 import { assert } from 'assert-ts';
 import { Task } from 'effection';
@@ -53,7 +54,8 @@ export class SimulationContext {
           });
         }
 
-        let { port } = await spawnHttpServer(simulation.scope, app);
+        let server = createServer(app).run(simulation.scope);
+        let { port } = await simulation.scope.spawn(server.listening());
 
         return {
           name: service.name,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -4,12 +4,13 @@ import { graphqlHTTP } from 'express-graphql';
 import { schema } from './schema/schema';
 import { v4 } from 'uuid';
 import { ServerOptions, Simulation, HttpApp, Methods, HttpHandler, HttpMethods, Simulator, Behaviors } from './interfaces';
-import { Runnable, Server, createServer } from './http';
+import { Server, createServer } from './http';
 import { SimulationContext } from './schema/context';
 import getPort from 'get-port';
 
 export { Server, createServer } from './http';
 export type { AddressInfo } from './http';
+import type { Runnable } from './interfaces';
 
 const createAppHandler = (app: HttpApp) => (method: Methods) => (path: string, handler: HttpHandler): HttpApp => {
   return { ...app, handlers: app.handlers.concat({ method, path, handler }) };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -6,7 +6,6 @@ import { v4 } from 'uuid';
 import { ServerOptions, Simulation, HttpApp, Methods, HttpHandler, HttpMethods, Simulator, Behaviors } from './interfaces';
 import { Server, createServer } from './http';
 import { SimulationContext } from './schema/context';
-import getPort from 'get-port';
 
 export { Server, createServer } from './http';
 export type { AddressInfo } from './http';
@@ -62,6 +61,7 @@ export function createSimulation(scope: Task, id?: string): Simulation {
 }
 
 export function createSimulationServer(options: ServerOptions = { simulators: {} }): Runnable<Server> {
+  let { port } = options;
   return {
     run(scope) {
       let context = new SimulationContext(scope, options.simulators);
@@ -70,7 +70,7 @@ export function createSimulationServer(options: ServerOptions = { simulators: {}
         .disable('x-powered-by')
         .use('/graphql', graphqlHTTP({ schema, graphiql: true, context }));
 
-      return createServer(app).run(scope);
+      return createServer(app, { port }).run(scope);
     }
   };
 }

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -16,6 +16,7 @@ const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
 main(function* (scope) {
 
   let server: Server = createSimulationServer({
+    port: serverPort,
     simulators: {
       echo(simulation) {
         return simulation.http(app => app.post('/', echo));

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -1,6 +1,6 @@
-import { spawnSimulationServer } from './server';
+import { createSimulationServer, Server, AddressInfo } from './server';
 import { main } from '@effection/node';
-import { HttpHandler, Server } from './interfaces';
+import { HttpHandler } from './interfaces';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = function echo(request, response) {
@@ -14,14 +14,16 @@ const echo: HttpHandler = function echo(request, response) {
 const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
 
 main(function* (scope) {
-  let { port }: Server = yield spawnSimulationServer(scope, {
+
+  let server: Server = createSimulationServer({
     simulators: {
       echo(simulation) {
         return simulation.http(app => app.post('/', echo));
       },
-    },
-    port: serverPort
-  });
+    }
+  }).run(scope);
+
+  let { port }: AddressInfo = yield server.listening();
 
   console.log(`Simulation server running on http://localhost:${port}/graphql`);
 

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -24,7 +24,7 @@ main(function* (scope) {
     }
   }).run(scope);
 
-  let { port }: AddressInfo = yield server.listening();
+  let { port }: AddressInfo = yield server.address();
 
   console.log(`Simulation server running on http://localhost:${port}/graphql`);
 

--- a/packages/server/test/schema.test.ts
+++ b/packages/server/test/schema.test.ts
@@ -16,7 +16,7 @@ describe('graphql control api', () => {
           return behaviors.http(app => app.get('/', echo));
         }
       }
-    }).run(world).listening();
+    }).run(world).address();
 
     let endpoint = `http://localhost:${port}/graphql`;
     client = new GraphQLClient(endpoint, { headers: {} });

--- a/packages/server/test/schema.test.ts
+++ b/packages/server/test/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect';
-import { HttpHandler, Server } from '../src/interfaces';
-import { spawnSimulationServer } from '../src/server';
+import { HttpHandler } from '../src/interfaces';
+import { createSimulationServer } from '../src/server';
 import { GraphQLClient, gql } from 'graphql-request';
 
 const echo: HttpHandler = (_request, _response) => Promise.resolve();
@@ -10,13 +10,13 @@ describe('graphql control api', () => {
   let client: GraphQLClient;
 
   beforeEach(function * (world) {
-    let { port } = yield spawnSimulationServer(world, {
+    let { port } = yield createSimulationServer({
       simulators: {
         echo(behaviors) {
           return behaviors.http(app => app.get('/', echo));
         }
       }
-    });
+    }).run(world).listening();
 
     let endpoint = `http://localhost:${port}/graphql`;
     client = new GraphQLClient(endpoint, { headers: {} });

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -3,25 +3,26 @@ import expect from 'expect';
 
 import { createClient, Client, Simulation } from "@simulacrum/client";
 
-import type { HttpHandler, Server } from '../src/interfaces';
-import { spawnSimulationServer } from '../src/server';
+import type { HttpHandler } from '../src/interfaces';
+import { createSimulationServer, AddressInfo } from '../src/server';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = (_request, _response) => Promise.resolve();
 
 describe("@simulacrum/server", () => {
   let client: Client;
-  let server: Server;
+  let address: AddressInfo;
 
   beforeEach(function*(world) {
-    server = yield spawnSimulationServer(world, {
+    let server = createSimulationServer({
       simulators: {
         echo({ http }) {
           return http(app => app.get('/', echo));
         },
       }
-    });
-    client = createClient(`http://localhost:${server.port}`);
+    }).run(world);
+    address = yield server.listening();
+    client = createClient(`http://localhost:${address.port}`);
   });
 
   describe.skip('creating a simulation', () => {
@@ -37,6 +38,6 @@ describe("@simulacrum/server", () => {
   });
 
   it('starts', function*() {
-    expect(typeof server.port).toBe('number');
+    expect(typeof address.port).toBe('number');
   });
 });

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -21,7 +21,7 @@ describe("@simulacrum/server", () => {
         },
       }
     }).run(world);
-    address = yield server.listening();
+    address = yield server.address();
     client = createClient(`http://localhost:${address.port}`);
   });
 


### PR DESCRIPTION
## Motivation

One of the things we identified was that whenever you spawn resources into a scope like a server, it makes it much easier to reason about, and also to compose when the actual binding of the resource to a scope is a single, unary function. This is how streams work in that you can define a stream, and map it and modify it, but eventually you call `subscribe(scope)` on it to actually do the iteration. When necessary, you can define an operation on the stream like `forEach` that actually binds to the scope and performs the iteration so that you don't even need to ever call the `subscribe()` method.

We're [refactoring the `exec()` api](https://github.com/thefrontside/effection/pull/269) to follow this pattern. In effect, 

```js
exec(scope, command);
```

becomes

```js
exec(command).run(scope);
```

But more commonly, when you want to get the result of the command immediately, you would say:

```js
let result = yield exec(command).expect();
```
## Approach

This makes our http server creation follow this pattern, so before where we bound the scope and also returned an operation in a single step:

```js
yield spawnServer(scope, app);
```
We now explicitly bind servers to a scope in a single step, and then have a separate operation to wait until they are listening and get the port number

```js
let server = createServer(app).run(scope);

let { port } = yield server.listening();
```