### PR TITLE
Add atom

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
+    "@effection/atom": "^2.0.0-preview.3",
     "@effection/node": "=2.0.0-preview.5",
     "@simulacrum/client": "^0.0.0",
     "assert-ts": "^0.3.2",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,1 @@
-export { spawnSimulationServer } from './server';
+export { spawnSimulationServer } from './server/server';

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -24,10 +24,17 @@ export interface Service {
   app: HttpApp
 }
 
+export interface ServiceInstance {
+  id: string;
+  port: number;
+  name: string;
+  url: string;
+}
+
 export interface Simulation {
   id: string;
-  simulators: Record<string, Simulator>;
   services: Service[];
+  serviceInstances: Record<string, ServiceInstance>;
   addSimulator(name: string, simulator: Simulator): Simulation;
   scope: Task;
 }

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -31,6 +31,7 @@ export class SimulationContext {
 
         assert(!!simulator, `no available simulator for ${sim}`);
 
+
         simulation = simulation.addSimulator(sim, simulator);
       }
 

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -4,6 +4,7 @@ export const types = [
   objectType({
     name: 'Service',
     definition(t) {
+      t.nonNull.id('id');
       t.nonNull.string('name');
       t.nonNull.string('url');
     }
@@ -29,7 +30,7 @@ export const types = [
         resolve(_, { simulators }, ctx) {
           return ctx.createSimulation(simulators);
         }
-      })
+      });
     }
   })
-]
+];

--- a/packages/server/src/server/atom.ts
+++ b/packages/server/src/server/atom.ts
@@ -1,0 +1,13 @@
+import type { Slice } from '@effection/atom';
+import type { Simulation } from '../interfaces';
+import { createAtom } from '@effection/atom';
+
+export interface SimulationState {
+  simulations: Record<string, Simulation>
+}
+
+export const initialSimulationState: SimulationState = { simulations: {} };
+
+export function createSimulationAtom(initialState: SimulationState = initialSimulationState): Slice<SimulationState> {
+  return createAtom<SimulationState>(initialState);
+}

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -52,7 +52,7 @@ export function createSimulation(scope: Task, id?: string): Simulation {
 
       let behaviors = simulator(behavior);
 
-      return { ...simulation, services: simulation.services.concat(behaviors.services) };
+      return { ...this, services: this.services.concat(behaviors.services) };
     }
   };
 

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -1,12 +1,14 @@
+import type { Slice } from '@effection/atom';
 import { once, Task, Deferred } from 'effection';
 import express, { Express } from 'express';
 import { graphqlHTTP } from 'express-graphql';
-import { schema } from './schema/schema';
+import { schema } from '../schema/schema';
 import { assert } from 'assert-ts';
 import { v4 } from 'uuid';
-import { Server, ServerOptions, Simulation, HttpApp, Methods, HttpHandler, HttpMethods, Simulator, Behaviors } from './interfaces';
-import { SimulationContext } from './schema/context';
+import { Server, ServerOptions, Simulation, HttpApp, Methods, HttpHandler, HttpMethods, Simulator, Behaviors } from '../interfaces';
+import { SimulationContext } from '../schema/context';
 import getPort from 'get-port';
+import { SimulationState } from './atom';
 
 const createAppHandler = (app: HttpApp) => (method: Methods) => (path: string, handler: HttpHandler): HttpApp => {
   return { ...app, handlers: app.handlers.concat({ method, path, handler }) };
@@ -95,9 +97,8 @@ export function spawnHttpServer(
   return startup.promise;
 }
 
-export function spawnSimulationServer(scope: Task, { simulators = {}, port = undefined }: ServerOptions): Promise<Server> {
-
-  let context = new SimulationContext(scope, simulators);
+export function spawnSimulationServer(scope: Task, atom: Slice<SimulationState>, { simulators = {}, port = undefined }: ServerOptions): Promise<Server> {
+  let context = new SimulationContext(scope, atom, simulators);
 
   return spawnHttpServer(
     scope,
@@ -105,5 +106,4 @@ export function spawnSimulationServer(scope: Task, { simulators = {}, port = und
       .disable('x-powered-by')
       .use('/graphql', graphqlHTTP({ schema, graphiql: true, context })),
       { port });
-
 }

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -33,7 +33,7 @@ export function createSimulation(scope: Task, id?: string): Simulation {
   let simulation: Simulation = {
     id: id ?? v4(),
     scope,
-    simulators: {},
+    serviceInstances: {},
     services: [],
     addSimulator(name: string, simulator: Simulator): Simulation {
       let behavior: Behaviors = {

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -1,6 +1,7 @@
-import { spawnSimulationServer } from './server';
+import { spawnSimulationServer } from './server/server';
 import { main } from '@effection/node';
 import { HttpHandler, Server } from './interfaces';
+import { createSimulationAtom } from './server/atom';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = function echo(request, response) {
@@ -14,7 +15,9 @@ const echo: HttpHandler = function echo(request, response) {
 const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
 
 main(function* (scope) {
-  let { port }: Server = yield spawnSimulationServer(scope, {
+  let atom = createSimulationAtom();
+
+  let { port }: Server = yield spawnSimulationServer(scope, atom, {
     simulators: {
       echo(simulation) {
         return simulation.http(app => app.post('/', echo));

--- a/packages/server/test/atom.test.ts
+++ b/packages/server/test/atom.test.ts
@@ -54,55 +54,12 @@ mutation CreateSimulation {
     it('should add http behaviour', function*() {
       let { createSimulation: { id } } = result;
 
-      let simulation = atom.slice('simulations', id).get();
+      let instances = atom.slice('simulations', id, 'serviceInstances').get();
 
-      let echo = simulation.services[0];
+      let echo = Object.values(instances)[0];
 
       expect(echo.name).toBe('echo');
-      expect(echo.protocol).toBe('http');
-    });
-  });
-
-  describe('adds a stimulation with an https simulator', () => {
-    beforeEach(function*(world) {
-      atom = createSimulationAtom();
-
-      let { port } = yield spawnSimulationServer(world, atom, {
-        simulators: {
-          auth0({ https }) {
-            return https(app => app.get('/', echo));
-          },
-        }
-      });
-
-      let endpoint = `http://localhost:${port}/graphql`;
-      client = new GraphQLClient(endpoint, { headers: {} });
-    });
-
-    let result: CreateSimulationResult;
-
-    beforeEach(function* () {
-      let createSimulationMutation = gql`
-mutation CreateSimulation {
-  createSimulation(
-    simulators: ["auth0"]
-  ) {
-    id
-  }
-}
-`;
-      result = yield client.request(createSimulationMutation);
-    });
-
-    it('should add https behaviour', function*() {
-      let { createSimulation: { id } } = result;
-
-      let simulation = atom.slice('simulations', id).get();
-
-      let echo = simulation.services[0];
-
-      expect(echo.name).toBe('auth0');
-      expect(echo.protocol).toBe('https');
+      expect(echo.url).toBe(`http://localhost:${echo.port}`);
     });
   });
 });

--- a/packages/server/test/atom.test.ts
+++ b/packages/server/test/atom.test.ts
@@ -1,0 +1,108 @@
+import type { Slice } from '@effection/atom';
+import { describe, it, beforeEach } from '@effection/mocha';
+import expect from 'expect';
+import { gql, GraphQLClient } from 'graphql-request';
+
+import type { HttpHandler } from '../src/interfaces';
+import { createSimulationAtom, SimulationState } from '../src/server/atom';
+import { spawnSimulationServer } from '../src/server/server';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const echo: HttpHandler = (request, response) => Promise.resolve();
+
+type CreateSimulationResult = {
+  createSimulation: {
+    id: string;
+  }
+}
+
+describe("atom", () => {
+  let client: GraphQLClient;
+  let atom: Slice<SimulationState>;
+
+  describe('adds a stimulation with an http simulator', () => {
+    beforeEach(function*(world) {
+      atom = createSimulationAtom();
+
+      let { port } = yield spawnSimulationServer(world, atom, {
+        simulators: {
+          echo({ http }) {
+            return http(app => app.get('/', echo));
+          },
+        }
+      });
+
+      let endpoint = `http://localhost:${port}/graphql`;
+      client = new GraphQLClient(endpoint, { headers: {} });
+    });
+
+    let result: CreateSimulationResult;
+
+    beforeEach(function* () {
+      let createSimulationMutation = gql`
+mutation CreateSimulation {
+  createSimulation(
+    simulators: ["echo"]
+  ) {
+    id
+  }
+}
+`;
+      result = yield client.request(createSimulationMutation);
+    });
+
+    it('should add http behaviour', function*() {
+      let { createSimulation: { id } } = result;
+
+      let simulation = atom.slice('simulations', id).get();
+
+      let echo = simulation.services[0];
+
+      expect(echo.name).toBe('echo');
+      expect(echo.protocol).toBe('http');
+    });
+  });
+
+  describe('adds a stimulation with an https simulator', () => {
+    beforeEach(function*(world) {
+      atom = createSimulationAtom();
+
+      let { port } = yield spawnSimulationServer(world, atom, {
+        simulators: {
+          auth0({ https }) {
+            return https(app => app.get('/', echo));
+          },
+        }
+      });
+
+      let endpoint = `http://localhost:${port}/graphql`;
+      client = new GraphQLClient(endpoint, { headers: {} });
+    });
+
+    let result: CreateSimulationResult;
+
+    beforeEach(function* () {
+      let createSimulationMutation = gql`
+mutation CreateSimulation {
+  createSimulation(
+    simulators: ["auth0"]
+  ) {
+    id
+  }
+}
+`;
+      result = yield client.request(createSimulationMutation);
+    });
+
+    it('should add https behaviour', function*() {
+      let { createSimulation: { id } } = result;
+
+      let simulation = atom.slice('simulations', id).get();
+
+      let echo = simulation.services[0];
+
+      expect(echo.name).toBe('auth0');
+      expect(echo.protocol).toBe('https');
+    });
+  });
+});

--- a/packages/server/test/atom.test.ts
+++ b/packages/server/test/atom.test.ts
@@ -29,6 +29,9 @@ describe("atom", () => {
           echo({ http }) {
             return http(app => app.get('/', echo));
           },
+          secureEcho({ https }) {
+            return https(app => app.get('/', echo));
+          }
         }
       });
 
@@ -42,7 +45,7 @@ describe("atom", () => {
       let createSimulationMutation = gql`
 mutation CreateSimulation {
   createSimulation(
-    simulators: ["echo"]
+    simulators: ["echo", "secureEcho"]
   ) {
     id
   }
@@ -51,7 +54,7 @@ mutation CreateSimulation {
       result = yield client.request(createSimulationMutation);
     });
 
-    it('should add http behaviour', function*() {
+    it('should add an http behaviour', function*() {
       let { createSimulation: { id } } = result;
 
       let instances = atom.slice('simulations', id, 'serviceInstances').get();
@@ -60,6 +63,17 @@ mutation CreateSimulation {
 
       expect(echo.name).toBe('echo');
       expect(echo.url).toBe(`http://localhost:${echo.port}`);
+    });
+
+    it('should add an https behaviour', function*() {
+      let { createSimulation: { id } } = result;
+
+      let instances = atom.slice('simulations', id, 'serviceInstances').get();
+
+      let echo = Object.values(instances)[1];
+
+      expect(echo.name).toBe('secureEcho');
+      expect(echo.url).toBe(`https://localhost:${echo.port}`);
     });
   });
 });

--- a/packages/server/test/schema.test.ts
+++ b/packages/server/test/schema.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect';
-import { HttpHandler, Server } from '../src/interfaces';
-import { spawnSimulationServer } from '../src/server';
+import { HttpHandler } from '../src/interfaces';
+import { spawnSimulationServer } from '../src/server/server';
 import { GraphQLClient, gql } from 'graphql-request';
+import { createSimulationAtom } from '../src/server/atom';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = (_request, _response) => Promise.resolve();
 
 describe('graphql control api', () => {
   let client: GraphQLClient;
 
   beforeEach(function * (world) {
-    let { port } = yield spawnSimulationServer(world, {
+    let atom = createSimulationAtom();
+    let { port } = yield spawnSimulationServer(world, atom, {
       simulators: {
         echo(behaviors) {
           return behaviors.http(app => app.get('/', echo));
@@ -23,6 +26,7 @@ describe('graphql control api', () => {
   });
 
   describe('createSimulation()', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let simulation: Record<string, any>;
 
     beforeEach(function*() {

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -1,10 +1,12 @@
+import type { Slice } from '@effection/atom';
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect';
 
 import { createClient, Client, Simulation } from "@simulacrum/client";
 
 import type { HttpHandler, Server } from '../src/interfaces';
-import { spawnSimulationServer } from '../src/server';
+import { spawnSimulationServer } from '../src/server/server';
+import { createSimulationAtom, SimulationState } from '../src/server/atom';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const echo: HttpHandler = (_request, _response) => Promise.resolve();
@@ -12,9 +14,12 @@ const echo: HttpHandler = (_request, _response) => Promise.resolve();
 describe("@simulacrum/server", () => {
   let client: Client;
   let server: Server;
+  let atom: Slice<SimulationState>;
 
   beforeEach(function*(world) {
-    server = yield spawnSimulationServer(world, {
+    atom = createSimulationAtom();
+
+    server = yield spawnSimulationServer(world, atom, {
       simulators: {
         echo({ http }) {
           return http(app => app.get('/', echo));


### PR DESCRIPTION
## Motivation

We are going to need the atom at some stage but I was adding the auth0 simulator in another branch when I reached this point:

```
const jwksMock = createJWKSMock(`https://localhost:6467`);
```

This `jwksMock` object creates the mock access_tokens etc. that auth0 does, in order for this to work correctly, a certificate needs to be generated with the correct domain which would be the domain of the `auth0` https service or simulator.

## Approach

The approach in this PR is to use the atom to store the state of any service instances that have been spun up and are running on a specific port.

So this configuration:

```ts
      let { port } = yield spawnSimulationServer(world, atom, {
        simulators: {
          echo({ http }) {
            return http(app => app.get('/', echo));
          },
          secureEcho({ https }) {
            return https(app => app.get('/', echo));
          }
        }
      });
```

Would result in this state getting added:

```js
  serviceInstances: {
    'afec01e1-45c7-4bb8-914b-b97784051f90': {
      id: 'afec01e1-45c7-4bb8-914b-b97784051f90',
      port: 50648,
      name: 'echo',
      url: 'http://localhost:50648'
    },
    '03ef6472-08a6-41ab-b5d7-53e450691e16': {
      id: '03ef6472-08a6-41ab-b5d7-53e450691e16',
      port: 50649,
      name: 'secureEcho',
      url: 'https://localhost:50649'
    }
},
```
With this in place we should be able to use `once` 

```
simulator.slice.once((sim => sim.url)
```

### Alternate Designs

You `wait` for the http/https `listening` event to be raised

```
yield once(sim, 'listening');
```
