### PR TITLE
drive entire simulation as an effect mapped off simulation state

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
+    "@effection/atom": "^2.0.0-preview.3",
     "@effection/node": "=2.0.0-preview.5",
-    "@simulacrum/client": "^0.0.0",
     "assert-ts": "^0.3.2",
     "cross-fetch": "^3.1.0",
     "effection": "=2.0.0-preview.5",
@@ -41,6 +41,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
+    "@simulacrum/client": "^0.0.0",
     "@types/express": "^4.17.11",
     "@types/mocha": "^8.2.1",
     "@types/uuid": "^8.3.0",

--- a/packages/server/src/behaviors.ts
+++ b/packages/server/src/behaviors.ts
@@ -5,7 +5,7 @@ export interface Services {
   services: Service[];
 }
 
-export function applyBehaviors(simulators: Record<string, Simulator>, selected: string[]): Services {
+export function selectBehaviors(simulators: Record<string, Simulator>, selected: string[]): Services {
   return selected.reduce((behaviors, selection) => {
     assert(simulators[selection] != null, `unknown simulator ${selection}`);
     return collectSimulatorBehaviors(selection, simulators[selection], behaviors);

--- a/packages/server/src/behaviors.ts
+++ b/packages/server/src/behaviors.ts
@@ -1,0 +1,68 @@
+import assert from 'assert-ts';
+import { Behaviors, HttpApp, Protocols, Service, Methods, HttpMethods, HttpHandler, Simulator } from './interfaces';
+
+export interface Services {
+  services: Service[];
+}
+
+export function applyBehaviors(simulators: Record<string, Simulator>, selected: string[]): Services {
+  return selected.reduce((behaviors, selection) => {
+    assert(simulators[selection] != null, `unknown simulator ${selection}`);
+    return collectSimulatorBehaviors(selection, simulators[selection], behaviors);
+  }, { services: [] as Service [] });
+
+}
+
+export function collectSimulatorBehaviors(simulatorName: string, simulator: Simulator, accumulated: Services): Services {
+  let collector = createBehaviorsCollector(simulatorName, accumulated.services);
+  let collected = simulator(collector);
+  if (isServices(collected)) {
+    return { services: accumulated.services.concat(collected.services) };
+  } else {
+    return accumulated;
+  }
+}
+
+function createBehaviorsCollector(simulatorName: string, services: Service[]): Behaviors & Services {
+  function append(serviceName: string, protocol: Protocols, app: HttpApp) {
+    let name = serviceName !== simulatorName ? `${simulatorName}.${serviceName}` : serviceName;
+    return createBehaviorsCollector(
+      simulatorName,
+      services.concat({ name, protocol, app })
+    );
+  }
+  return {
+    services,
+    http(handler, name = simulatorName) {
+      let app = handler(createHttpApp());
+      return append(name, 'http', app);
+    },
+    https(handler, name = simulatorName) {
+      let app = handler(createHttpApp());
+      return append(name, 'https', app);
+    }
+  };
+}
+
+export function isServices(value: unknown): value is Services {
+  return typeof value === 'object'
+    && Array.isArray((value as Services).services);
+}
+
+const createAppHandler = (app: HttpApp) => (method: Methods) => (path: string, handler: HttpHandler): HttpApp => {
+  return { ...app, handlers: app.handlers.concat({ method, path, handler }) };
+};
+
+const createHttpApp = () => {
+  let app = {
+    handlers: []
+  } as unknown as HttpApp;
+
+  let appHandler = createAppHandler(app);
+
+  for(let method of HttpMethods) {
+    app[method] = appHandler(method);
+  }
+
+  return app;
+};

--- a/packages/server/src/effect.ts
+++ b/packages/server/src/effect.ts
@@ -1,0 +1,33 @@
+import { Slice } from "@effection/atom";
+import { Operation, Task } from "effection";
+
+export interface Effect<A> {
+  (slice: Slice<A>): Operation<void>;
+}
+
+export function map<A>(slice: Slice<Record<string, A>>, effect: Effect<A>): Operation<void> {
+  return function*(scope) {
+    let effects = new Map<string,Task>();
+
+    function synchronize(record: Record<string, A>) {
+      let keep = new Set<string>();
+
+      for (let key of Object.keys(record)) {
+        if (!effects.has(key)) {
+          effects.set(key, scope.spawn(effect(slice.slice(key))));
+        }
+        keep.add(key);
+      }
+
+      for (let [key, context] of effects.entries()) {
+        if (!keep.has(key)) {
+          context.halt();
+        }
+      }
+    }
+
+    synchronize(slice.get());
+
+    yield slice.forEach(synchronize);
+  };
+}

--- a/packages/server/src/effect.ts
+++ b/packages/server/src/effect.ts
@@ -19,9 +19,9 @@ export function map<A>(slice: Slice<Record<string, A>>, effect: Effect<A>): Oper
         keep.add(key);
       }
 
-      for (let [key, context] of effects.entries()) {
+      for (let [key, effect] of effects.entries()) {
         if (!keep.has(key)) {
-          context.halt();
+          effect.halt();
         }
       }
     }

--- a/packages/server/src/effects.ts
+++ b/packages/server/src/effects.ts
@@ -1,0 +1,13 @@
+import { Slice } from "@effection/atom";
+import { Task } from "effection";
+import { Runnable, ServerState, Simulator } from "./interfaces";
+import { map } from './effect';
+import { simulation } from './simulation';
+
+export function createEffects(atom: Slice<ServerState>, available: Record<string, Simulator>): Runnable<void> {
+  return {
+    run(scope: Task) {
+      scope.spawn(map(atom.slice('simulations'), simulation(available)));
+    }
+  };
+}

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -6,9 +6,8 @@ export interface Runnable<T> {
 }
 
 export interface Behaviors {
-  https: (handler: (app: HttpApp) => HttpApp) => Behaviors;
-  http: (handler: (app: HttpApp) => HttpApp) => Behaviors;
-  services: Service[];
+  https(handler: (app: HttpApp) => HttpApp, name?: string): Behaviors;
+  http(handler: (app: HttpApp) => HttpApp, name?: string): Behaviors;
 }
 
 export interface Simulator {

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -28,13 +28,30 @@ export interface Service {
   app: HttpApp
 }
 
-export interface Simulation {
-  id: string;
-  simulators: Record<string, Simulator>;
-  services: Service[];
-  addSimulator(name: string, simulator: Simulator): Simulation;
-  scope: Task;
+export interface ServerState {
+  simulations: Record<string, SimulationState>;
 }
+
+export type SimulationState =
+  {
+    id: string;
+    status: 'new',
+    simulators: string[]
+  } |
+  {
+    id: string,
+    status: 'running',
+    simulators: string[],
+    services: {
+      name: string;
+      url: string;
+    }[] }|
+  {
+    id: string,
+    status: 'failed',
+    simulators: string[],
+    error: Error
+  }
 
 export interface Server {
   port: number;

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -10,12 +10,12 @@ export class SimulationContext {
     let simulators = ([] as string[]).concat(using);
     let { scope, simulations } = this;
 
-    return await scope.spawn(function*() {
-      let id = uuid || v4();
-      let simulation = simulations.slice(id);
-      simulation.set({ id, status: 'new', simulators });
-      yield simulation.filter(({ status }) => status === 'running' || status === 'failed').first();
-      return simulation.get();
-    });
+    let id = uuid || v4();
+    let simulation = simulations.slice(id);
+    simulation.set({ id, status: 'new', simulators });
+
+    return scope.spawn(
+      simulation.once(({ status }) => status === 'running' || status === 'failed')
+    );
   }
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,9 +1,8 @@
-import { Task } from 'effection';
+import { createAtom } from '@effection/atom';
 import express from 'express';
 import { graphqlHTTP } from 'express-graphql';
 import { schema } from './schema/schema';
-import { v4 } from 'uuid';
-import { ServerOptions, Simulation, HttpApp, Methods, HttpHandler, HttpMethods, Simulator, Behaviors } from './interfaces';
+import { ServerOptions, ServerState } from './interfaces';
 import { Server, createServer } from './http';
 import { SimulationContext } from './schema/context';
 
@@ -11,60 +10,19 @@ export { Server, createServer } from './http';
 export type { AddressInfo } from './http';
 import type { Runnable } from './interfaces';
 
-const createAppHandler = (app: HttpApp) => (method: Methods) => (path: string, handler: HttpHandler): HttpApp => {
-  return { ...app, handlers: app.handlers.concat({ method, path, handler }) };
-};
-
-const createHttpApp = () => {
-  let app = {
-    handlers: []
-  } as unknown as HttpApp;
-
-  let appHandler = createAppHandler(app);
-
-  for(let method of HttpMethods) {
-    app[method] = appHandler(method);
-  }
-
-  return app;
-};
-
-export function createSimulation(scope: Task, id?: string): Simulation {
-  // TODO: if id exists, and existing simulation exists then return existing
-  let simulation: Simulation = {
-    id: id ?? v4(),
-    scope,
-    simulators: {},
-    services: [],
-    addSimulator(name: string, simulator: Simulator): Simulation {
-      let behavior: Behaviors = {
-        services: [],
-        https(handler) {
-          let app = handler(createHttpApp());
-
-          return { ...behavior, services: behavior.services.concat({ name, protocol: 'https', app }) };
-        },
-        http(handler) {
-          let app = handler(createHttpApp());
-
-          return { ...behavior, services: behavior.services.concat({ name, protocol: 'http', app }) };
-        }
-      };
-
-      let behaviors = simulator(behavior);
-
-      return { ...simulation, services: simulation.services.concat(behaviors.services) };
-    }
-  };
-
-  return simulation;
-}
+import { createEffects } from './effects';
 
 export function createSimulationServer(options: ServerOptions = { simulators: {} }): Runnable<Server> {
   let { port } = options;
   return {
     run(scope) {
-      let context = new SimulationContext(scope, options.simulators);
+      let atom = createAtom<ServerState>({
+        simulations: {}
+      });
+
+      let context = new SimulationContext(scope, atom.slice('simulations'));
+
+      createEffects(atom, options.simulators).run(scope);
 
       let app = express()
         .disable('x-powered-by')

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -1,0 +1,97 @@
+import { Effect } from './effect';
+import express, { raw } from 'express';
+import { Behaviors, HttpApp, HttpHandler, HttpMethods, Methods, Protocols, Service, SimulationState, Simulator } from './interfaces';
+import { AddressInfo, createServer } from './http';
+
+
+export function simulation(definitions: Record<string, Simulator>): Effect<SimulationState> {
+  return slice => function*(scope) {
+    try {
+      let behaviors = Object.entries(definitions).reduce(({ services }, [name, simulator]) => {
+        return simulator(createBehaviors(services, name));
+      }, createBehaviors());
+
+      let servers = behaviors.services.map((service) => {
+        let app = express();
+        app.use(raw({ type: "*/*" }));
+        for (let handler of service.app.handlers) {
+          app[handler.method](handler.path, (request, response) => {
+            scope.spawn(function*() {
+              try {
+                yield handler.handler(request, response);
+              } catch(err) {
+                console.error(err);
+
+                response.status(500);
+                response.write('server error');
+              } finally {
+                response.end();
+              }
+            });
+          });
+        }
+
+        return {
+          name: service.name,
+          protocol: service.protocol,
+          server: createServer(app).run(scope)
+        };
+      });
+
+      let services: {name: string; url: string; }[] = [];
+      for (let { name, server, protocol } of servers) {
+        let address: AddressInfo = yield server.address();
+        services.push({ name, url: `${protocol}://localhost:${address.port}`});
+      }
+
+      slice.update(state => ({
+        ...state,
+        status: 'running',
+        services
+      }));
+
+      // all spun up, we can just wait.
+      yield;
+    } catch (error) {
+      slice.update((state) => ({
+        ...state,
+        status: "failed",
+        error
+      }));
+    }
+  };
+}
+
+function createBehaviors(services: Service[] = [], name = ''): Behaviors {
+  return {
+    services,
+    http(handler) {
+      let protocol: Protocols = 'http';
+      let app = handler(createHttpApp());
+      return createBehaviors(services.concat({ name, protocol, app }), name);
+    },
+    https(handler) {
+      let protocol: Protocols = 'https';
+      let app = handler(createHttpApp());
+      return createBehaviors(services.concat({ name, protocol, app }), name)
+    }
+  };
+}
+
+const createAppHandler = (app: HttpApp) => (method: Methods) => (path: string, handler: HttpHandler): HttpApp => {
+  return { ...app, handlers: app.handlers.concat({ method, path, handler }) };
+};
+
+const createHttpApp = () => {
+  let app = {
+    handlers: []
+  } as unknown as HttpApp;
+
+  let appHandler = createAppHandler(app);
+
+  for(let method of HttpMethods) {
+    app[method] = appHandler(method);
+  }
+
+  return app;
+};

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -3,13 +3,13 @@ import express, { raw } from 'express';
 import { SimulationState, Simulator } from './interfaces';
 import { AddressInfo, createServer } from './http';
 
-import { applyBehaviors } from './behaviors';
+import { selectBehaviors } from './behaviors';
 
 export function simulation(definitions: Record<string, Simulator>): Effect<SimulationState> {
   return slice => function*(scope) {
     try {
       let selected = slice.get().simulators;
-      let behaviors = applyBehaviors(definitions, selected);
+      let behaviors = selectBehaviors(definitions, selected);
 
       let servers = behaviors.services.map((service) => {
         let app = express();

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -56,7 +56,8 @@ export function simulation(definitions: Record<string, Simulator>): Effect<Simul
       slice.update((state) => ({
         ...state,
         status: "failed",
-        error
+        error,
+        services: []
       }));
     }
   };

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -12,7 +12,10 @@ describe('@simulacrum/server', () => {
     let { port } = yield createSimulationServer({
       simulators: {
         echo(behaviors) {
-          return behaviors.http(app => app.post('/', echo));
+          return behaviors
+            .http(app => app.post('/', echo))
+            .http(app => app.post('/', echo), 'too')
+
         }
       }
     }).run(world).address();
@@ -48,7 +51,8 @@ mutation CreateSimulation {
 
     it('has the echo service', function* () {
       expect(simulation.services).toEqual([
-        { name: 'echo', url: expect.stringMatching('http://localhost') }
+        { name: 'echo', url: expect.stringMatching('http://localhost') },
+        { name: 'echo.too', url: expect.stringMatching('http://localhost') }
       ]);
     });
 


### PR DESCRIPTION
Motivation
-----------
Since we're about the business of adding the atom to track simulation with https://github.com/thefrontside/simulacrum/pull/6 we have an opportunity to completely re-think how this will work and organize accordingly.

Approach
----------
The strategy is that the entire simulation is tracked in the atom from the moment it is created until the moment it is destroyed. Instead of doing everything in the graphql context, the context just inserts the initial simulation record into the atom and the `map()` effect which maps each record to an operation takes it away from there.
