### PR TITLE
Add a person simulator

### DIFF
--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,4 +1,5 @@
-import { Task } from 'effection';
+import { Operation, Task } from 'effection';
+import { Slice } from '@effection/atom';
 import type { HttpApp } from './http';
 
 export interface Runnable<T> {
@@ -7,6 +8,11 @@ export interface Runnable<T> {
 
 export interface Behaviors {
   services: Record<string, Service>;
+  scenarios: Record<string, Scenario>;
+}
+
+export interface Scenario<T = any> {
+  (store: Store): Operation<T>;
 }
 
 export interface Simulator {
@@ -24,6 +30,9 @@ export interface Service {
   app: HttpApp
 }
 
+export type StoreState = Record<string, Record<string, Record<string, unknown>>>;
+export type Store = Slice<StoreState>;
+
 export interface ServerState {
   simulations: Record<string, SimulationState>;
 }
@@ -32,7 +41,9 @@ export type SimulationState =
   {
     id: string;
     status: 'new',
-    simulators: string[]
+    simulators: string[],
+    scenarios: Record<string, ScenarioState>;
+    store: StoreState;
   } |
   {
     id: string,
@@ -41,12 +52,35 @@ export type SimulationState =
     services: {
       name: string;
       url: string;
-    }[] }|
+    }[];
+    scenarios: Record<string, ScenarioState>;
+    store: StoreState;
+  } |
   {
     id: string,
     status: 'failed',
     simulators: string[],
+    scenarios: Record<string, ScenarioState>;
+    store: StoreState;
     error: Error
+  }
+
+export type ScenarioState =
+  {
+    id: string;
+    name: string;
+    status: 'new';
+  } |
+  {
+    id: string;
+    name: string;
+    status: 'running';
+  } |
+  {
+    id: string;
+    name: string;
+    status: "failed";
+    error: Error;
   }
 
 export interface Server {

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,6 +1,8 @@
 import { Slice } from '@effection/atom';
+import assert from 'assert-ts';
 import { Task } from 'effection';
-import { SimulationState } from '../interfaces';
+import { v4 } from 'uuid';
+import { SimulationState, ScenarioState } from '../interfaces';
 
 export class SimulationContext {
   constructor(private scope: Task, private simulations: Slice<Record<string, SimulationState>>, private newid: () => string) {}
@@ -11,10 +13,24 @@ export class SimulationContext {
 
     let id = newid();
     let simulation = simulations.slice(id);
-    simulation.set({ id, status: 'new', simulators });
+    simulation.set({ id, status: 'new', simulators, scenarios: {}, store: {} });
 
-    return scope.spawn(
-      simulation.once(({ status }) => status === 'running' || status === 'failed')
-    );
+    return scope.spawn(simulation.once(settled));
   }
+
+  async given(simulationId: string, scenarioName: string): Promise<ScenarioState> {
+    let { scope, simulations } = this;
+    let simulation = simulations.slice(simulationId);
+    assert(simulation.get() != null, `no simulation found with id: ${simulationId}`);
+
+    let id = v4();
+    let scenario = simulation.slice('scenarios').slice(id);
+    scenario.set({ id, status: 'new', name: scenarioName });
+
+    return scope.spawn(scenario.once(settled));
+  }
+}
+
+function settled<T extends { status: 'new' | 'running' | 'failed' }>(value: T): boolean {
+  return value.status !== 'new';
 }

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -1,6 +1,11 @@
-import { objectType, mutationType, nonNull, list, stringArg } from 'nexus';
+import { objectType, mutationType, scalarType, nonNull, list, stringArg, intArg } from 'nexus';
 
 export const types = [
+  scalarType({
+    name: "JSON",
+    description: "JSON value",
+    serialize: value => value
+  }),
   objectType({
     name: 'Service',
     definition(t) {
@@ -19,9 +24,10 @@ export const types = [
   }),
   mutationType({
     definition(t) {
-      t.nonNull.field('createSimulation', {
+      t.field('createSimulation', {
         type: 'Simulation',
         args: {
+          seed: intArg(),
           simulators: nonNull(
             list(nonNull(stringArg())),
           ),
@@ -29,7 +35,17 @@ export const types = [
         resolve(_, { simulators }, ctx) {
           return ctx.createSimulation(simulators);
         }
-      })
+      });
+      t.field('given', {
+        type: 'JSON',
+        args: {
+          simulation: nonNull(stringArg()),
+          a: nonNull(stringArg())
+        },
+        resolve: async (_, { simulation, a: scenarioName }, ctx) => {
+          return ctx.given(simulation, scenarioName);
+        }
+      });
     }
   })
-]
+];

--- a/packages/server/src/simulators/person.ts
+++ b/packages/server/src/simulators/person.ts
@@ -1,0 +1,39 @@
+import { Slice } from '@effection/atom';
+import { Operation } from 'effection';
+import { v4 } from 'uuid';
+import { Behaviors, Store } from "../interfaces";
+
+export default function(): Behaviors {
+  return {
+    services: {},
+    scenarios: { person }
+  };
+}
+
+export interface Person {
+  name: string;
+}
+
+export function person(store: Store): Operation<Person> {
+  return function*() {
+    let id = v4();
+    let slice = records(store).slice(id);
+
+    // this is the lamest data generation ever :)
+    let attrs = { id, name: "Bob Dobalina" };
+
+    slice.set(attrs);
+    return attrs;
+  };
+}
+
+function records(store: Store): Slice<Record<string, Record<string, unknown>>> {
+  let people = store.slice("people");
+
+  // atom doesn't quite work right in the sense that we can't make a
+  // deep slice and have it create parents on demand.
+  if (!people.get()) {
+    people.set({});
+  }
+  return people;
+}

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -3,6 +3,7 @@ import { main } from '@effection/node';
 import { echo } from './echo';
 import { createSimulationServer, Server, AddressInfo } from './server';
 import { createHttpApp } from './http';
+import person from './simulators/person';
 
 const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
 
@@ -13,13 +14,15 @@ main(function* (scope) {
     port: serverPort,
     seed: 1,
     simulators: {
+      person,
       echo: () => ({
         services: {
           echo: {
             protocol: 'http',
             app: createHttpApp().post('/', echo)
           }
-        }
+        },
+        scenarios: {}
       }),
     }
   }).run(scope);

--- a/packages/server/test/person.test.ts
+++ b/packages/server/test/person.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, beforeEach } from '@effection/mocha';
+import expect from 'expect';
+import { createSimulationServer } from '../src/server';
+import person from '../src/simulators/person';
+import { GraphQLClient, gql } from 'graphql-request';
+
+describe('person simulator', () => {
+  let client: GraphQLClient;
+
+  beforeEach(function * (world) {
+    let { port } = yield createSimulationServer({
+      simulators: { person }
+    }).run(world).address();
+
+    let endpoint = `http://localhost:${port}/graphql`;
+    client = new GraphQLClient(endpoint, { headers: {} });
+  });
+
+  describe('createSimulation()', () => {
+    let simulation: Record<string, any>;
+
+    beforeEach(function*() {
+      let createSimulationMutation = gql`
+mutation CreateSimulation {
+  createSimulation(
+    seed: 1
+    simulators: ["person"]
+  ) {
+    id
+  }
+}
+`;
+      let result = yield client.request(createSimulationMutation);
+      simulation = result.createSimulation;
+      expect(simulation.id).toBeDefined();
+    });
+
+    describe('positing a person', () => {
+      let person: Record<string, any>
+        beforeEach(function*() {
+          let { given } = yield client.request(gql`
+mutation {
+  given(a: "person", simulation: ${JSON.stringify(simulation.id)})
+}
+`);
+          person = given;
+        });
+
+      it('creates a person', function*() {
+        expect(person.data).toMatchObject({ name: "Bob Dobalina" });
+      });
+    });
+  });
+});

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -24,7 +24,8 @@ describe('@simulacrum/server', () => {
               protocol: 'http',
               app
             }
-          }
+          },
+          scenarios: {}
         })
       }
     }).run(world).client();


### PR DESCRIPTION
Motivation
-----------
We need to do more than just bind services. We have to be able to declare scenarios that arrange the state of the simulation into a specific order.


Approach
----------
This adds the concept of a "scenario" to the simulation and the given() GraphQL API that can be used to add that it to the current simulation.

As the first implementer of this scenario API is the "person" simulator which currently exports a single scenario called "person" which generates the person and inserts it into the store.

The person generation logic is deliberately hokey and we can upgrade it to use faker / fast-check, or some combination later on.


### TODOs and Open Questions

- Currently there is some duplication of the scenario data because we have to actually return the generated data to the graphql caller. I'm not aware of a better way to do this without some sort of referencing mechanism in the atom

