### PR TITLE
Add option to make predictable simulation sequence

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,8 @@
     "cross-fetch": "^3.1.0",
     "effection": "=2.0.0-preview.5",
     "express": "^4.17.1",
+    "faker": "cowboyd/faker.js#one-random-number-generator-per-faker",
+    "@types/faker": "^5.1.7",
     "get-port": "^5.1.1",
     "graphql": "^15.5.0",
     "nexus": "^1.0.0",

--- a/packages/server/src/faker.ts
+++ b/packages/server/src/faker.ts
@@ -1,8 +1,10 @@
 // @ts-ignore
 import Faker from 'faker/lib';
+// @ts-ignore
+import locales from 'faker/lib/locales';
 
 export function createFaker(seed: number): any {
-  let faker = new Faker({ locales: require('faker/lib/locales') });
+  let faker = new Faker({ locales });
   faker.seed(seed);
   return faker;
 }

--- a/packages/server/src/faker.ts
+++ b/packages/server/src/faker.ts
@@ -1,0 +1,14 @@
+// @ts-ignore
+import Faker from 'faker/lib';
+
+export function createFaker(seed: number): any {
+  let faker = new Faker({ locales: require('faker/lib/locales') });
+  faker.seed(seed);
+  return faker;
+}
+
+
+export function stableIds(seed: number): () => string {
+  let faker = createFaker(seed);
+  return () => faker.datatype.uuid();
+}

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -16,6 +16,7 @@ export interface Simulator {
 export interface ServerOptions {
   simulators: Record<string, Simulator>;
   port?: number;
+  seed?: number;
 }
 
 export interface Service {

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,16 +1,15 @@
 import { Slice } from '@effection/atom';
 import { Task } from 'effection';
-import { v4 } from 'uuid';
 import { SimulationState } from '../interfaces';
 
 export class SimulationContext {
-  constructor(private scope: Task, private simulations: Slice<Record<string, SimulationState>>) {}
+  constructor(private scope: Task, private simulations: Slice<Record<string, SimulationState>>, private newid: () => string) {}
 
-  async createSimulation(using: string | string[], uuid?: string): Promise<SimulationState> {
+  async createSimulation(using: string | string[]): Promise<SimulationState> {
     let simulators = ([] as string[]).concat(using);
-    let { scope, simulations } = this;
+    let { scope, simulations, newid } = this;
 
-    let id = uuid || v4();
+    let id = newid();
     let simulation = simulations.slice(id);
     simulation.set({ id, status: 'new', simulators });
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,7 @@
 import { createAtom } from '@effection/atom';
 import express from 'express';
 import { graphqlHTTP } from 'express-graphql';
+import { v4 } from 'uuid';
 import { schema } from './schema/schema';
 import { ServerOptions, ServerState } from './interfaces';
 import { Server, createServer } from './http';
@@ -11,16 +12,19 @@ export type { AddressInfo } from './http';
 import type { Runnable } from './interfaces';
 
 import { createEffects } from './effects';
+import { stableIds } from './faker';
 
 export function createSimulationServer(options: ServerOptions = { simulators: {} }): Runnable<Server> {
   let { port } = options;
   return {
     run(scope) {
+      let newid = options.seed ? stableIds(options.seed) : v4;
+
       let atom = createAtom<ServerState>({
         simulations: {}
       });
 
-      let context = new SimulationContext(scope, atom.slice('simulations'));
+      let context = new SimulationContext(scope, atom.slice('simulations'), newid);
 
       createEffects(atom, options.simulators).run(scope);
 

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -1,14 +1,17 @@
-import { createSimulationServer, Server, AddressInfo } from './server';
 import { main } from '@effection/node';
+
 import { echo } from './echo';
+import { createSimulationServer, Server, AddressInfo } from './server';
 import { createHttpApp } from './http';
 
 const serverPort = !!process.env.PORT ? Number(process.env.PORT) : undefined;
+
 
 main(function* (scope) {
 
   let server: Server = createSimulationServer({
     port: serverPort,
+    seed: 1,
     simulators: {
       echo: () => ({
         services: {

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -1,0 +1,21 @@
+import { Operation } from 'effection';
+import { GraphQLClient } from 'graphql-request';
+import { ServerOptions, Runnable } from '../src/interfaces';
+import { createSimulationServer } from '../src/server';
+
+export function createTestServer(options: ServerOptions): Runnable<{ client(): Operation<GraphQLClient>}> {
+  return {
+    run(scope) {
+      let server = createSimulationServer(options).run(scope);
+
+      return {
+        client: () => function*() {
+          let { port } = yield server.address();
+          return new GraphQLClient(`http://localhost:${port}/graphql`, {
+            headers: {}
+          });
+        }
+      };
+    }
+  };
+}


### PR DESCRIPTION
Motivation
-----------

In order to make testing and development easier, we wanted the ability to pass in a uuid to make sure that the created simulation id was stable so that queries we had sitting around would continue to work and sequences of snippets used for testing would not be one-use and obsolete.

Approach
----------

We can accomplish the same goal by just using a predictable sequence of UUIDs. That way, when we run a server, and start a simulation, it always gets the same UUID.

Currently, faker does not support independent instances that each have their own pseudo random number generators so this change in its current form depends on an open PR I have on the faker.js repo making multiple faker instances safe.

We'll need this very soon since each simulation will have its own random seed and its own faker instance.