### PR TITLE
Break apart graphql context

### DIFF
--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,36 +1,9 @@
 import { Slice } from '@effection/atom';
-import assert from 'assert-ts';
 import { Task } from 'effection';
-import { v4 } from 'uuid';
-import { SimulationState, ScenarioState } from '../interfaces';
+import { ServerState } from '../interfaces';
 
-export class SimulationContext {
-  constructor(private scope: Task, private simulations: Slice<Record<string, SimulationState>>, private newid: () => string) {}
-
-  async createSimulation(using: string | string[]): Promise<SimulationState> {
-    let simulators = ([] as string[]).concat(using);
-    let { scope, simulations, newid } = this;
-
-    let id = newid();
-    let simulation = simulations.slice(id);
-    simulation.set({ id, status: 'new', simulators, scenarios: {}, store: {} });
-
-    return scope.spawn(simulation.filter(settled).expect());
-  }
-
-  async given(simulationId: string, scenarioName: string): Promise<ScenarioState> {
-    let { scope, simulations } = this;
-    let simulation = simulations.slice(simulationId);
-    assert(simulation.get() != null, `no simulation found with id: ${simulationId}`);
-
-    let id = v4();
-    let scenario = simulation.slice('scenarios').slice(id);
-    scenario.set({ id, status: 'new', name: scenarioName });
-
-    return scope.spawn(scenario.filter(settled).expect());
-  }
-}
-
-function settled<T extends { status: 'new' | 'running' | 'failed' }>(value: T): boolean {
-  return value.status !== 'new';
+export interface OperationContext {
+  scope: Task;
+  atom: Slice<ServerState>;
+  newid(): string;
 }

--- a/packages/server/src/schema/operations.ts
+++ b/packages/server/src/schema/operations.ts
@@ -1,0 +1,14 @@
+import { Resolver } from './resolvers';
+import * as resolvers from './resolvers';
+
+export const createSimulation = createResolve(resolvers.createSimulation);
+
+export const given = createResolve(resolvers.given);
+
+function createResolve(resolver: Resolver<unknown, unknown>) {
+  return {
+    resolve(_: any, args: any, context: any): Promise<any> {
+      return resolver.resolve(args, context);
+    }
+  };
+}

--- a/packages/server/src/schema/operations.ts
+++ b/packages/server/src/schema/operations.ts
@@ -1,11 +1,17 @@
 import { Resolver } from './resolvers';
 import * as resolvers from './resolvers';
 
-export const createSimulation = createResolve(resolvers.createSimulation);
+export const createSimulation = uncover(resolvers.createSimulation);
+export const given = uncover(resolvers.given);
 
-export const given = createResolve(resolvers.given);
-
-function createResolve(resolver: Resolver<unknown, unknown>) {
+/**
+ * Nexus types are currently a mess. This lets us take a soundly
+ * typed resolver and replace all the safe types removed
+ * so that the schema can compile. Maybe it doesn't have to be
+ * this way, but that can be sorted out later. This is a compromise
+ * that lets us move forward while maintaining type safety.
+ */
+function uncover(resolver: Resolver<unknown, unknown>) {
   return {
     resolve(_: any, args: any, context: any): Promise<any> {
       return resolver.resolve(args, context);

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -20,7 +20,7 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
     let simulation = atom.slice("simulations").slice(id);
     simulation.set({ id, status: 'new', simulators, scenarios: {}, store: {} });
 
-    return scope.spawn(simulation.filter(settled).expect());
+    return scope.spawn(simulation.filter(({ status }) => status !== 'new').expect());
   }
 };
 
@@ -39,10 +39,6 @@ export const given: Resolver<GivenParameters, ScenarioState> = {
     let scenario = simulation.slice('scenarios').slice(id);
     scenario.set({ id, status: 'new', name: scenarioName });
 
-    return scope.spawn(scenario.filter(settled).expect());
+    return scope.spawn(scenario.filter(({ status }) => status !== 'new').expect());
   }
 };
-
-function settled<T extends { status: 'new' | 'running' | 'failed' }>(value: T): boolean {
-  return value.status !== 'new';
-}

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -1,0 +1,48 @@
+import { SimulationState, ScenarioState } from "../interfaces";
+import { OperationContext } from "./context";
+import { v4 } from 'uuid';
+
+import { assert } from 'assert-ts';
+
+export interface Resolver<Args, Result> {
+  resolve(args: Args, context: OperationContext): Promise<Result>;
+}
+
+export interface CreateSimulationParameters {
+  simulators: string[];
+}
+
+export const createSimulation: Resolver<CreateSimulationParameters, SimulationState> = {
+  resolve({ simulators }, ctx) {
+    let { atom, scope, newid } = ctx;
+
+    let id = newid();
+    let simulation = atom.slice("simulations").slice(id);
+    simulation.set({ id, status: 'new', simulators, scenarios: {}, store: {} });
+
+    return scope.spawn(simulation.filter(settled).expect());
+  }
+};
+
+export interface GivenParameters {
+  a: string;
+  simulation: string;
+}
+
+export const given: Resolver<GivenParameters, ScenarioState> = {
+  resolve({ simulation: simulationId, a: scenarioName }, context) {
+    let { scope, atom } = context;
+    let simulation = atom.slice("simulations").slice(simulationId);
+    assert(simulation.get() != null, `no simulation found with id: ${simulationId}`);
+
+    let id = v4();
+    let scenario = simulation.slice('scenarios').slice(id);
+    scenario.set({ id, status: 'new', name: scenarioName });
+
+    return scope.spawn(scenario.filter(settled).expect());
+  }
+};
+
+function settled<T extends { status: 'new' | 'running' | 'failed' }>(value: T): boolean {
+  return value.status !== 'new';
+}

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -1,5 +1,7 @@
 import { objectType, mutationType, scalarType, nonNull, list, stringArg, intArg } from 'nexus';
 
+import { createSimulation, given } from './operations';
+
 export const types = [
   scalarType({
     name: "JSON",
@@ -32,9 +34,7 @@ export const types = [
             list(nonNull(stringArg())),
           ),
         },
-        resolve(_, { simulators }, ctx) {
-          return ctx.createSimulation(simulators);
-        }
+        ...createSimulation
       });
       t.field('given', {
         type: 'JSON',
@@ -42,9 +42,7 @@ export const types = [
           simulation: nonNull(stringArg()),
           a: nonNull(stringArg())
         },
-        resolve: async (_, { simulation, a: scenarioName }, ctx) => {
-          return ctx.given(simulation, scenarioName);
-        }
+        ...given
       });
     }
   })

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -7,7 +7,7 @@ import { v4 } from 'uuid';
 import { schema } from './schema/schema';
 import { ServerOptions, ServerState } from './interfaces';
 import { Server, createServer } from './http';
-import { SimulationContext } from './schema/context';
+import { OperationContext } from './schema/context';
 
 export { Server, createServer } from './http';
 export type { AddressInfo } from './http';
@@ -26,7 +26,7 @@ export function createSimulationServer(options: ServerOptions = { simulators: {}
         simulations: {}
       });
 
-      let context = new SimulationContext(scope, atom.slice('simulations'), newid);
+      let context: OperationContext = { atom, scope, newid };
 
       createEffects(atom, options.simulators).run(scope);
 


### PR DESCRIPTION
## Motivation
\Integrating websockets requires some pretty big changes to the way we execute graphql queries. Specifically, the Effection scope will be different when we do queries over http than when we do queries over websockets. The scope of the http requests will be shared for all requests, but for the subscription we'll want a scope that is per-websocket. Because of this, we won't be able to use a one size fits all graphql context.

## Approach

This breaks apart the context, which was more of a "resolver holder" into a bunch of free standing functions that take the bare minimum of things which they need to run: an effection context, an atom, and an id sequence.

The schema can now just include these free standing functions by passing through the context. It is up to the http and wss layer to choose the appropriate effection scope.