### PR TITLE
Fix global clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,18 @@
   "version": "0.0.0",
   "description": "Composable simulations for testing, development, and application previews",
   "scripts": {
-    "build": "tsc -b ./tsconfig.packages.json && cd packages/ui && npm run build",
-    "clean": "find . \\( -name node_modules -o -name dir2 -o -path name \\) -prune -false -o -name dist | xargs rm -rf",
-    "watch": "npm run build && \"$(npm bin)/tsc\" -b ./tsconfig.packages.json --watch"
+    "clean": "npm run clean -ws",
+    "test": "npm run test -ws",
+    "build": "npm run build -ws",
+    "build:tsc": "tsc -b ./tsconfig.packages.json",
+    "watch:tsc": "npm run build && \"$(npm bin)/tsc\" -b ./tsconfig.packages.json --watch"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thefrontside/simulacrum.git"
   },
   "workspaces": [
-    "./packages/*"
+    "packages/*"
   ],
   "keywords": [
     "simulation",
@@ -23,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/thefrontside/simulacrum/issues"
   },
-  "homepage": "https://github.com/thefrontside/simulacrum#readme"
+  "homepage": "https://github.com/thefrontside/simulacrum#readme",
+  "engines": {
+    "npm": ">=7.7.0"
+  }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,9 @@
   "description": "connect to simulacrum servers and manipulate them via the control API",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "clean": "echo nothing to do",
+    "build": "echo nothing to do",
+    "test": "echo nothing to do"
   },
   "devDependencies": {
     "@frontside/eslint-config": "^2.0.0",


### PR DESCRIPTION
## Motivation

`npm run clean` from the project root will not actually clean everything up. Also, running a build is awkward since we have to `cd` into each package and invoke the build script.

## Approach
Luckily, with npm 7.7.0, we have the capability to fan out a command over all the workspaces by passing the `-ws` flag. This updates the `clean`, `build` and `test` commands to use this functionality so that each project can decide for itself what it means to do these things.

## Learning
- https://github.com/npm/cli/releases/tag/v7.7.0
- https://docs.npmjs.com/cli/v7/using-npm/workspaces#running-commands-in-the-context-of-workspaces
