### PR TITLE
Pass data generation API to scenarios

### DIFF
--- a/packages/server/src/faker.ts
+++ b/packages/server/src/faker.ts
@@ -1,10 +1,18 @@
 // @ts-ignore
-import Faker from 'faker/lib';
+import FakerInstance from 'faker/lib';
 // @ts-ignore
 import locales from 'faker/lib/locales';
 
-export function createFaker(seed: number): any {
-  let faker = new Faker({ locales });
+// the @types/faker don't account for
+// constructing individual instances of faker so we
+// import the default faker export and use that type
+// as the type of all fakers. A nice side-quest would be
+// to add types.d.ts directly to the faker project.
+import faker from 'faker';
+export type Faker = typeof faker;
+
+export function createFaker(seed: number): Faker {
+  let faker = new FakerInstance({ locales });
   faker.seed(seed);
   return faker;
 }

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,6 +1,7 @@
 import { Operation, Task } from 'effection';
 import { Slice } from '@effection/atom';
 import type { HttpApp } from './http';
+import type { Faker } from './faker';
 
 export interface Runnable<T> {
   run(scope: Task): T;
@@ -12,7 +13,7 @@ export interface Behaviors {
 }
 
 export interface Scenario<T = any> {
-  (store: Store): Operation<T>;
+  (store: Store, faker: Faker): Operation<T>;
 }
 
 export interface Simulator {

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -3,6 +3,7 @@ import { Effect, map } from './effect';
 import express, { raw } from 'express';
 import { Behaviors, SimulationState, Simulator } from './interfaces';
 import { AddressInfo, createServer } from './http';
+import { createFaker } from './faker';
 
 export function simulation(definitions: Record<string, Simulator>): Effect<SimulationState> {
   return slice => function*(scope) {
@@ -46,13 +47,17 @@ export function simulation(definitions: Record<string, Simulator>): Effect<Simul
       let store = slice.slice("store");
       let { scenarios } = behaviors;
 
+      // we can support passing a seed to a scenario later, but let's
+      // just hard-code it for now.
+      let faker = createFaker(2);
+
       scope.spawn(map(slice.slice("scenarios"), slice => function*() {
         try {
           let { name } = slice.get();
           let fn = scenarios[name];
           assert(fn, `unknown scenario ${name}`);
 
-          let data = yield fn(store);
+          let data = yield fn(store, faker);
           slice.update(state => ({
             ...state,
             status: 'running',

--- a/packages/server/src/simulators/person.ts
+++ b/packages/server/src/simulators/person.ts
@@ -1,6 +1,7 @@
 import { Slice } from '@effection/atom';
 import { Operation } from 'effection';
 import { v4 } from 'uuid';
+import { Faker } from '../faker';
 import { Behaviors, Store } from "../interfaces";
 
 export default function(): Behaviors {
@@ -14,13 +15,13 @@ export interface Person {
   name: string;
 }
 
-export function person(store: Store): Operation<Person> {
+export function person(store: Store, faker: Faker): Operation<Person> {
   return function*() {
     let id = v4();
     let slice = records(store).slice(id);
 
     // this is the lamest data generation ever :)
-    let attrs = { id, name: "Bob Dobalina" };
+    let attrs = { id, name: faker.name.findName() };
 
     slice.set(attrs);
     return attrs;

--- a/packages/server/test/person.test.ts
+++ b/packages/server/test/person.test.ts
@@ -47,7 +47,7 @@ mutation {
         });
 
       it('creates a person', function*() {
-        expect(person.data).toMatchObject({ name: "Bob Dobalina" });
+        expect(person.data).toMatchObject({ name: "Paul Waters" });
       });
     });
   });


### PR DESCRIPTION
Motivation
-----------
Right now, we don't provide any support to our scenarios for generating data. That means that each individual scenario that need to generate data is left completely to its own devices. But given that this is going to be very common, this is something that the simulation server should provide out of the box.

Approach
----------
This creates a single instance of faker per simulation, and passes it into each scenario so that the scenario can use it to generate high-fidelity simulation data.

As a bonus, I was able to actually get rudimentary typing on the `Faker` interface. However, the `@types/faker` module is quite behind the actual faker and so there are a lot of methods on the faker instance that aren't represented in the typings. Given that caveat, it seems to me better than just having it typed as `any`.