### PR TITLE
Check that index.html was found, not just the directory.

### DIFF
--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -6,7 +6,7 @@ const { strict: assert } = require('assert');
 
 module.exports = {
   appDir() {
-    let path = join(__dirname, 'dist');
+    let path = join(__dirname, 'dist', 'index.html');
     assert(existsSync(path), "the @simulation/ui app has gone missing! Either the package is malformed, or you're in development mode and haven't built it yet.");
     return path;
   }


### PR DESCRIPTION
## Motivation

We have a sanity check in place, but with very little effort, it could be enhanced to be more sane.

Approach
----------
Instead of checking that the `dist` directory exists, this checks that the actual `dist/index.html` itself exists. It's possible to have cleaned out the build directory, but left it in place.

