### PR TITLE
fix: adjust package name check in covector publish

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -3,7 +3,7 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "npm view ${ pkg.pkg } version",
+      "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
       "publish": "npm publish --access public"
     }
   },


### PR DESCRIPTION
## Motivation

This fixes the skipped publish on client. When doing the configuration, I had used the nicknames instead of `@simulacrum/` to save some typing. Unfortunately, the `init` has a poor default that uses that nickname as the check to see if the package has been published. Funny enough, `client@0.0.1` actually does exist so it didn't attempt to publish that package.

This adjusts to use the name directly from the package.json (and will be the best default moving forward, will update the `covector init` with this). If you merge this without a change file, @cowboyd, it will immediately attempt to publish again and should pick up the `client` to publish it.


