### PR TITLE
Add tests from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+workflows:
+  tests:
+    jobs:
+      - node/test


### PR DESCRIPTION
## Motivation

Have a reliable pipeline.

## Approach

Install CircleCI. For tests we've been running on Circle since we need to validate both Windows and Mac and the experience there is still way ahead of github actions.
