### PR TITLE
fix(covector): remove nicknames and pin all deps

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -8,19 +8,19 @@
     }
   },
   "packages": {
-    "client": {
+    "@simulacrum/client": {
       "path": "./packages/client",
       "manager": "javascript"
     },
-    "server": {
+    "@simulacrum/server": {
       "path": "./packages/server",
       "manager": "javascript",
-      "dependencies": ["ui", "client"]
+      "dependencies": ["@simulacrum/ui", "@simulacrum/client"]
     },
-    "ui": {
+    "@simulacrum/ui": {
       "path": "./packages/ui",
       "manager": "javascript",
-      "dependencies": ["client"]
+      "dependencies": ["@simulacrum/client"]
     }
   }
 }

--- a/.changes/simulacrum-client.md
+++ b/.changes/simulacrum-client.md
@@ -1,5 +1,6 @@
 ---
-client: minor
+"@simulacrum/client": minor
 ---
+
 Provide a decent implementation of createClient() that can create
 simulations and scenarios

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@effection/atom": "=2.0.0-preview.8",
     "@effection/node": "=2.0.0-preview.10",
-    "@simulacrum/ui": "^0",
+    "@simulacrum/ui": "0.0.1",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "cors": "^2.8.5",
@@ -47,7 +47,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
-    "@simulacrum/client": "^0",
+    "@simulacrum/client": "0.0.1",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/mocha": "^8.2.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,7 +28,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
-    "@simulacrum/client": "^0.0.0",
+    "@simulacrum/client": "0.0.1",
     "graphiql": "^1.4.0",
     "parcel": "next",
     "react": "^16.8.0",


### PR DESCRIPTION
## Motivation

This change allows covector in it's current state to handle the dep/devDep bumps. We may decide to undo this in the future once that has been addressed.

### Alternate Designs

Nicknames are nice especially with `@simulacrum` prepended to all of the packages, but there are some bugs in `dep` and `devDep` bumps that need to be resolved in covector before we use them here.

