### PR TITLE
✨destroy simulations

### DIFF
--- a/.changes/destroy-simulation.md
+++ b/.changes/destroy-simulation.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": minor
+"@simulacrum/client": minor
+---
+Add destroySimulation()

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from 'graphql';
 
 export interface Client {
   createSimulation(simulators?: string | string[]): Promise<Simulation>;
+  destroySimulation(simulation: Simulation): Promise<boolean>;
   given(simulation: Simulation, scenario: string): Promise<Scenario>;
   state<T>(): AsyncIterable<T> & AsyncIterator<T>;
   dispose(): Promise<void>;
@@ -115,6 +116,13 @@ mutation Given($simulation: String!, $scenario: String) {
 }
 `,
       variables: { scenario, simulation: simulation.id }
+    }),
+    destroySimulation: ({ id }: Simulation) => query<boolean>("destroySimulation", {
+      query: `
+mutation DestroySimulation($id: String!) {
+  destroySimulation(id: $id)
+}`,
+      variables: { id }
     }),
     state<T = unknown>() {
       let child = scope.spawn();

--- a/packages/server/src/effect.ts
+++ b/packages/server/src/effect.ts
@@ -12,11 +12,20 @@ export function map<A>(slice: Slice<Record<string, A>>, effect: Effect<A>): Oper
     function synchronize(record: Record<string, A>) {
       let keep = new Set<string>();
 
-      for (let key of Object.keys(record)) {
-        if (!effects.has(key)) {
-          effects.set(key, scope.spawn(effect(slice.slice(key))));
+      // the checks for non-null `record` and `value`
+      // should not be necessary, except for some weirdness
+      // when removing values from our Atom means that sometimes
+      // the are.
+      if (record) {
+        for (let [key, value] of Object.entries(record)) {
+          // see comment above
+          if (value) {
+            if (!effects.has(key)) {
+              effects.set(key, scope.spawn(effect(slice.slice(key))));
+            }
+            keep.add(key);
+          }
         }
-        keep.add(key);
       }
 
       for (let [key, effect] of effects.entries()) {

--- a/packages/server/src/schema/operations.ts
+++ b/packages/server/src/schema/operations.ts
@@ -2,6 +2,7 @@ import { Resolver, Subscriber } from './resolvers';
 import * as resolvers from './resolvers';
 
 export const createSimulation = uncover(resolvers.createSimulation);
+export const destroySimulation = uncover(resolvers.destroySimulation);
 export const given = uncover(resolvers.given);
 export const state = uncover(resolvers.state);
 

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -30,6 +30,18 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
   }
 };
 
+export const destroySimulation: Resolver<{ id: string; }, boolean> = {
+  async resolve({ id }, { atom }) {
+    let simulation = atom.slice("simulations").slice(id);
+    if (simulation.get()) {
+      simulation.remove();
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
 export interface GivenParameters {
   a: string;
   simulation: string;

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -1,6 +1,6 @@
 import { objectType, mutationType, scalarType, nonNull, list, stringArg, intArg, subscriptionType } from 'nexus';
 
-import { createSimulation, given, state } from './operations';
+import { createSimulation, destroySimulation, given, state } from './operations';
 
 export const types = [
   scalarType({
@@ -35,6 +35,13 @@ export const types = [
           ),
         },
         ...createSimulation
+      });
+      t.field('destroySimulation', {
+        type: 'Boolean',
+        args: {
+          id: nonNull(stringArg())
+        },
+        ...destroySimulation
       });
       t.field('given', {
         type: 'JSON',

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from '@effection/mocha';
+import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import { Client, Simulation } from '@simulacrum/client';
 import fetch from 'cross-fetch';
 import expect from 'expect';
@@ -66,6 +66,24 @@ describe('@simulacrum/server', () => {
         expect(body).toEqual("hello world");
       });
     });
+
+    describe('destroySimulation()', () => {
+      let destroyed: boolean;
+      beforeEach(function*() {
+        destroyed = yield client.destroySimulation(simulation);
+      })
+
+      it('indicates in the response that this operation tore down the simulation', function*() {
+        expect(destroyed).toEqual(true);
+      });
+
+      it('tears down any running services', function*() {
+        let [{ url }] = simulation.services;
+        let response = fetch(url.toString(), { method: 'POST', body: "hello world" });
+        expect(yield captureError(response)).toMatchObject({ name: 'FetchError' })
+      });
+    });
+
   });
 
   describe('creating two servers with the same seed', () => {


### PR DESCRIPTION
Motivation
----------

Simulations are big stateful things, and especially when they are part of the testcases we need to be able to create and destroy them instantaneously. Whenever a simulation is destroyed, any effectsassociated with it should be torn down.

Approach
----------
This implements the GraphQL client to remove the slice associated with the simulation, and since all the effects are derived off of that slice, they are immediately shut down.

```graphql
mutation {
  destroySimulation(id: "the-id-of-the-simulation")
}
```

Note: because of some weirdness with our atom implementation, the removal is somewhat weird in that it results in the effect hook getting fired with the state being `undefined`, and also with an undefined value. While this should technically never happen, it does. and so we have to work around it until a more permanent solution can be found.