### PR TITLE
🐛Fix typo that caused dist directory not to be ignored

### DIFF
--- a/packages/server/watch.ts
+++ b/packages/server/watch.ts
@@ -6,7 +6,7 @@ import { on } from 'effection';
 import { watch } from 'chokidar';
 
 main(function* (scope: Task) {
-  let watcher = watch('./src/**/*.ts', { ignoreInitial: true, ignored: 'distå' });
+  let watcher = watch('./src/**/*.ts', { ignoreInitial: true, ignored: 'dist' });
   try {
     let process: Task = scope.spawn(buildAndRun(500));
 


### PR DESCRIPTION
## Motivation

The `dist/` directory was not actually being ignored which was causing spurious restarts.

## Approach
fix the typo.
