### PR TITLE
✨ Make a proper release

### DIFF
--- a/.changes/proper-npm-packages.md
+++ b/.changes/proper-npm-packages.md
@@ -1,0 +1,6 @@
+---
+"@simulacrum/server": patch
+"@simulacrum/client": patch
+"@simulacrum/ui": patch
+---
+create proper npm packages that actually work

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "clean": "npm run clean -ws",
     "test": "npm run test -ws",
-    "build": "npm run build -ws",
+    "build": "npm run prepack -ws",
+    "prepack": "npm run prepack -ws",
     "build:tsc": "tsc -b ./tsconfig.packages.json",
     "watch:tsc": "npm run build && \"$(npm bin)/tsc\" -b ./tsconfig.packages.json --watch"
   },

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,7 @@
+# @simulacrum/client
+
+A JavaScript client to control a `@simulacrum/server` over HTTP from
+inside your testcases, preview applications, and local development
+environment.
+
+https://github.com/thefrontside/simulacrum

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "description": "connect to simulacrum servers and manipulate them via the control API",
   "main": "dist/index.js",
+  "files": ["dist"],
   "scripts": {
     "clean": "echo nothing to do",
-    "build": "tsc --build",
+    "prepack": "tsc --build",
+    "build": "npm run prepack",
     "test": "echo client is used to test server"
   },
   "dependencies": {
@@ -27,7 +29,7 @@
     "simulation",
     "emulation"
   ],
-  "author": "Charles Lowell <cowboyd@frontside.io>",
+  "author": "Frontside Engineering <cowboyd@frontside.io>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/thefrontside/simulacrum/issues"

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,6 @@
+# @simulacrum/server
+
+Server capable of running multiple concurrent simulations that can be
+controlled by test cases, preview apps, and local developer environments.
+
+https://github.com/thefrontside/simulacrum

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,10 +3,12 @@
   "version": "0.0.2",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
+  "files": ["dist"],
   "scripts": {
-    "clean": "rimraf *.tsbuildinfo __generated__ dist",
+    "clean": "rimraf *.tsbuildinfo dist",
     "test": "mocha -r ts-node/register --timeout 10000 test/**/*.test.ts",
-    "build": "tsc --build tsconfig.dist.json && ts-node src/schema/schema.ts",
+    "prepack": "tsc --build tsconfig.dist.json",
+    "build": "npm run prepack",
     "start": "node dist/start.js",
     "watch": "PORT=3000 NODE_ENV=development ts-node -P ./watch-tsconfig.json ./watch.ts"
   },
@@ -18,7 +20,7 @@
     "simulation",
     "emulation"
   ],
-  "author": "Charles Lowell <cowboyd@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/thefrontside/simulacrum/issues"

--- a/packages/server/src/schema/schema.ts
+++ b/packages/server/src/schema/schema.ts
@@ -2,15 +2,9 @@ import { makeSchema } from 'nexus';
 import path from 'path';
 import { types } from './types';
 
-const parent = path.basename(path.join(__dirname, '..'));
-
 export const schema = makeSchema({
-  shouldGenerateArtifacts: parent !== 'dist',
+  shouldGenerateArtifacts: false,
   types,
-  outputs: {
-    schema: path.join(__dirname, '../__generated__/schema.graphql'),
-    typegen: path.join(__dirname, '../__generated__/schema.types.d.ts'),
-  },
   sourceTypes: {
     modules: [
       {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,11 +4,13 @@
   "description": "A web UI to work with a Simulacrum Server",
   "browser": "dist/index.html",
   "main": "index.js",
+  "files": ["dist"],
   "scripts": {
     "test": "echo skip",
+    "prepack": "parcel build app/index.html --target browser",
     "start": "parcel serve app/index.html --target browser",
-    "build": "parcel build app/index.html --target browser",
     "watch": "parcel watch app/index.html --target browser",
+    "build": "npm run prepack",
     "clean": "rm -rf dist"
   },
   "repository": {
@@ -18,7 +20,7 @@
   "keywords": [
     "simulation"
   ],
-  "author": "Charles Lowell <cowboyd@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/thefrontside/simulacrum/issues"


### PR DESCRIPTION
Motivation
---------
Right now, we're just bundling up the source of Simulacrum and making it downloadable on NPM, but as an executable program, it is a full-featured system written in TypeScript, JavaScript, HTML and CSS. As such, we need to make sure and build all of our sources into their target executables.

Approach
----------
This adds a prepack script to each package that builds its local sources and makes it ready to distribute to npmjs.com. Among other things we:

1. build typescript into javascript
2. add at least a minimal README to every package
3. Fix the author field to not be just cowboyd personally, but all of
FS engineering
4. Only distribute built files, not sources

Finally, I removed the `.graphql` schema generation since we weren't using it anywhere, and all it did was slow down and murk up the build. basically, that stuff is if you want to consume a schema from another package, but all our things consume the schema over HTTP.

> Note:  I left in the aliases to `npm run build` as just doing a prepack. This is because `build` is a little more common nomenclature. However, we can remove these at some point.