### PR TITLE
♻️ Only one top-level simulator in a simulation

### DIFF
--- a/.changes/root-simulator.md
+++ b/.changes/root-simulator.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": minor
+"@simulacrum/client": minor
+---
+require a single root simulator for each simulation

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,7 +3,7 @@ import { createClient as createWSClient, SubscribePayload } from 'graphql-ws';
 import { GraphQLError } from 'graphql';
 
 export interface Client {
-  createSimulation(simulator?: string): Promise<Simulation>;
+  createSimulation(simulator: string): Promise<Simulation>;
   destroySimulation(simulation: Simulation): Promise<boolean>;
   given(simulation: Simulation, scenario: string): Promise<Scenario>;
   state<T>(): AsyncIterable<T> & AsyncIterator<T>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,7 +3,7 @@ import { createClient as createWSClient, SubscribePayload } from 'graphql-ws';
 import { GraphQLError } from 'graphql';
 
 export interface Client {
-  createSimulation(simulators?: string | string[]): Promise<Simulation>;
+  createSimulation(simulator?: string): Promise<Simulation>;
   destroySimulation(simulation: Simulation): Promise<boolean>;
   given(simulation: Simulation, scenario: string): Promise<Scenario>;
   state<T>(): AsyncIterable<T> & AsyncIterator<T>;
@@ -92,11 +92,11 @@ export function createClient(serverURL: string, webSocketImpl?: WebSocketImpl): 
   }
 
   return {
-    createSimulation: (simulators?: string | string[]) => {
+    createSimulation: (simulator?: string) => {
       return query<Simulation>("createSimulation", {
         query: `
-mutation CreateSimulation($simulators: [String!]!) {
-  createSimulation(simulators: $simulators) {
+mutation CreateSimulation($simulator: String) {
+  createSimulation(simulator: $simulator) {
     id
     simulators
     services {
@@ -106,7 +106,7 @@ mutation CreateSimulation($simulators: [String!]!) {
   }
 }`,
         operationName: 'CreateSimulation',
-        variables: { simulators: ([] as string[]).concat(simulators || []) }
+        variables: { simulator }
       });
     },
     given: (simulation: Simulation, scenario: string) => query<Scenario>("given", {

--- a/packages/server/src/effects.ts
+++ b/packages/server/src/effects.ts
@@ -7,7 +7,10 @@ import { simulation } from './simulation';
 export function createEffects(atom: Slice<ServerState>, available: Record<string, Simulator>): Runnable<void> {
   return {
     run(scope: Task) {
-      scope.spawn(map(atom.slice('simulations'), simulation(available)));
+      scope.spawn(map(atom.slice('simulations'), simulation({
+        nothing: () => ({ scenarios: {}, services: {} }),
+        ...available
+      })));
     }
   };
 }

--- a/packages/server/src/effects.ts
+++ b/packages/server/src/effects.ts
@@ -7,10 +7,7 @@ import { simulation } from './simulation';
 export function createEffects(atom: Slice<ServerState>, available: Record<string, Simulator>): Runnable<void> {
   return {
     run(scope: Task) {
-      scope.spawn(map(atom.slice('simulations'), simulation({
-        nothing: () => ({ scenarios: {}, services: {} }),
-        ...available
-      })));
+      scope.spawn(map(atom.slice('simulations'), simulation(available)));
     }
   };
 }

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -43,14 +43,14 @@ export type SimulationState =
   {
     id: string;
     status: 'new',
-    simulators: string[],
+    simulator: string,
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
   } |
   {
     id: string,
     status: 'running',
-    simulators: string[],
+    simulator: string,
     services: {
       name: string;
       url: string;
@@ -61,7 +61,7 @@ export type SimulationState =
   {
     id: string,
     status: 'failed',
-    simulators: string[],
+    simulator: string,
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
     error: Error

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -15,11 +15,11 @@ export interface Subscriber<Args, TEach, Result = TEach> {
 }
 
 export interface CreateSimulationParameters {
-  simulator?: string;
+  simulator: string;
 }
 
 export const createSimulation: Resolver<CreateSimulationParameters, SimulationState> = {
-  resolve({ simulator = "nothing" }, ctx) {
+  resolve({ simulator }, ctx) {
     let { atom, scope, newid } = ctx;
 
     let id = newid();

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -15,16 +15,16 @@ export interface Subscriber<Args, TEach, Result = TEach> {
 }
 
 export interface CreateSimulationParameters {
-  simulators: string[];
+  simulator?: string;
 }
 
 export const createSimulation: Resolver<CreateSimulationParameters, SimulationState> = {
-  resolve({ simulators }, ctx) {
+  resolve({ simulator = "nothing" }, ctx) {
     let { atom, scope, newid } = ctx;
 
     let id = newid();
     let simulation = atom.slice("simulations").slice(id);
-    simulation.set({ id, status: 'new', simulators, scenarios: {}, store: {} });
+    simulation.set({ id, status: 'new', simulator, scenarios: {}, store: {} });
 
     return scope.spawn(simulation.filter(({ status }) => status !== 'new').expect());
   }

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -1,4 +1,4 @@
-import { objectType, mutationType, scalarType, nonNull, list, stringArg, intArg, subscriptionType } from 'nexus';
+import { objectType, mutationType, scalarType, nonNull, stringArg, intArg, subscriptionType } from 'nexus';
 
 import { createSimulation, destroySimulation, given, state } from './operations';
 
@@ -30,9 +30,7 @@ export const types = [
         type: 'Simulation',
         args: {
           seed: intArg(),
-          simulators: nonNull(
-            list(nonNull(stringArg())),
-          ),
+          simulator: stringArg(),
         },
         ...createSimulation
       });

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -30,7 +30,7 @@ export const types = [
         type: 'Simulation',
         args: {
           seed: intArg(),
-          simulator: stringArg(),
+          simulator: nonNull(stringArg()),
         },
         ...createSimulation
       });

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -5,6 +5,7 @@ import expect from 'expect';
 
 import { echo } from '../src/echo';
 import { createHttpApp } from '../src/http';
+import { ServerOptions } from '../src/interfaces';
 
 import { createTestServer } from './helpers';
 
@@ -89,23 +90,21 @@ describe('@simulacrum/server', () => {
   describe('creating two servers with the same seed', () => {
     let one: Client;
     let two: Client;
+    let options: ServerOptions = {
+      seed: 5,
+      simulators: {
+        empty: () => ({ services: {}, scenarios: {} })
+      }
+    };
 
     beforeEach(function*(world) {
-      one = yield createTestServer({
-        seed: 5,
-        simulators: {}
-      }).run(world).client();
-
-      two = yield createTestServer({
-        seed: 5,
-        simulators: {}
-      }).run(world).client();
-
+      one = yield createTestServer(options).run(world).client();
+      two = yield createTestServer(options).run(world).client();
     });
 
     it('creates simulations with the same uuid', function*() {
-      let first = yield one.createSimulation();
-      let second = yield two.createSimulation();
+      let first = yield one.createSimulation("empty");
+      let second = yield two.createSimulation("empty");
 
       expect(first).toBeDefined();
       expect(second).toBeDefined();


### PR DESCRIPTION
Motivation
----------
We want to add the concept of simulation parameters. For example, if I have multiple versions of an API, then I might want to have a "stage" parameter that I pass to `createSimulation()`.

```js
createSimulation(["gateway"], {
  stage: "production"
});
```

This begs the question, which simulator would receive this if I was creating the simulation with multiple simulators?

```js
createSimulation(["auth0", "gateway"], {
  stage: "production"
})
```

It seems very unclear when it shouldn't be. There's a need to pass the properties to both and then let them just do what they want. but that seems very odd indeed.

Approach
----------
We can avoid this situation entirely by saying that you must have a single simulator sitting at the root of your tree, similar to the way that you have to have a single React component that you render in the DOM. In the same way that the React component can be comprised of several different child compoents, so we could also have a root simulator that was comprised of multiple different simulator "children".

This takes a first step in that direction by restricting createSimulation to a single simulator. That way, if you want to compose `auth0` and `backend`, you would need to create a root simulator that would compose them explicitly rather than implicitly:

```
-> backend
   -> auth0
   -> gateway
```

and you would instantiate it like so:

```js
createSimulatation("backend", {
  stage: "production"
})
```

Where the backend simulation would start _both_ `auth0` _and_ `gateway` and explicitly delegate the `stage` parameter to gateway.

The APIs for composing simulators are yet to be settled, but the core concept, that you have a  "component-like" tree that rolls up into a single simulator is still the basic idea.

This makes the implementation quite a bit simpler, where instead of having to merge and combine scenarios and services from the different simulators, the composition happens at the simulator level.

~~For completeness, an "empty" simulation is still possible by creating it without a simulator, but it won't do anything. Mainly this is easier to model internally and also via the client.~~