### PR TITLE
✨ refresh package-lock.json as part of the release PR

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -37,6 +37,13 @@ jobs:
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           command: "version-or-publish"
           createRelease: true
+
+      # We need to run npm again so that `package-lock.json`
+      # is updated if it needs to be before the PR is created
+      # and submitted. We can remove this if this gets baked into
+      # covector
+      - run: npm install
+
       - name: Create Pull Request With Versions Bumped
         id: cpr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Motivation
-----------
We keep `package-lock.json` under version control so that we can not only have a consistent environment across development machines, but also so that we can speed up CI by having the set of dev dependencies pre-computed.

In Yarn, intra-monorepo dependency version are _not_ tracked in the `yarn.lock` file, just the fact that there is a dependency. However, NPM _does_ track the information for all dependencies. That means that when we create new versions of our packages, the package-lock.json will also update the next time that we run an `npm install` to point to the new versions.

So, in order to deliver a clean development environment to folks after a release, we have to update the package-lock.json as _part_ of that transaction.

Approach
----------
This just runs another `npm install` after creating the versions, but before creating the PR. That way, if `package-lock.json` needs to be updated it will. If there is no change to package-lock.json, then this is a very fast no-op.