### PR TITLE
Debounce watch script

### DIFF
--- a/packages/server/watch.ts
+++ b/packages/server/watch.ts
@@ -13,7 +13,7 @@ main(function* (scope: Task) {
       process = scope.spawn(function*() {
         yield sleep(10);
         console.log('rebuilding.....');
-        process = scope.spawn(buildAndRun);
+        yield buildAndRun;
       });
     });
   } finally {

--- a/packages/server/watch.ts
+++ b/packages/server/watch.ts
@@ -1,19 +1,20 @@
-import { Operation, Stream, Task } from 'effection';
+import { Operation, Stream, Task, on, sleep } from 'effection';
 import type { Process } from '@effection/node';
 import { main, exec, daemon, StdIO } from '@effection/node';
-import { sleep } from 'effection';
-import { on } from 'effection';
 import { watch } from 'chokidar';
 
 main(function* (scope: Task) {
   let watcher = watch('./src/**/*.ts', { ignoreInitial: true, ignored: 'dist' });
   try {
-    let process: Task = scope.spawn(buildAndRun(500));
+    let process: Task = scope.spawn(buildAndRun);
 
-    yield on(watcher, 'all').forEach(function () {
-      console.log('building.....');
+    yield on(watcher, 'all').forEach(() => {
       process.halt();
-      process = scope.spawn(buildAndRun(500));
+      process = scope.spawn(function*() {
+        yield sleep(10);
+        console.log('rebuilding.....');
+        process = scope.spawn(buildAndRun);
+      });
     });
   } finally {
     watcher.close();
@@ -43,20 +44,17 @@ function executeAndOut(command: string): Operation<void> {
   };
 }
 
-function buildAndRun(delay: number):Operation<void> {
-  return function*(scope) {
-    try {
-      yield executeAndOut('clean');
-      yield executeAndOut('build');
-      yield sleep(delay);
+function* buildAndRun(scope: Task) {
+  try {
+    yield executeAndOut('clean');
+    yield executeAndOut('prepack');
 
-      let server: StdIO = daemon('node dist/start.js').run(scope);
-      scope.spawn(writeOut(server.stdout, process.stdout));
-      scope.spawn(writeOut(server.stderr, process.stderr));
-    } catch (err) {
-      console.error(err);
-    }
+    let server: StdIO = daemon('node dist/start.js').run(scope);
+    scope.spawn(writeOut(server.stdout, process.stdout));
+    scope.spawn(writeOut(server.stderr, process.stderr));
+  } catch (err) {
+    console.error(err);
+  }
 
-    yield;
-  };
+  yield;
 }


### PR DESCRIPTION
Motivation
-----------
When I was reviewing the watch script it occured to me that the debounce logic wasn't right. 

The delay needs to go at the beginning of the process, otherwise, we just launching into the middle of the process and not debouncing anything.

## Approach

This optimizes the watch script by having the restart process `sleep(10)` as the very first thing. That way if any file events come in during that time, they'll just cancel the current sleep and sleep again. Once an event has not happened for 10ms, then the process can continue.