### PR TITLE
Fix circleci by using npm 7.11.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,16 @@
 version: 2.1
 orbs:
-  node: circleci/node@4.2.1
+  node: circleci/node@4.3.0
 jobs:
   test:
     docker:
       - image: cimg/node:15.14.0
     steps:
       - node/install:
-          npm-version: 7.7.6
+          npm-version: 7.11.2
       - checkout
       - node/install-packages
-      - run: npm run build        
+      - run: npm run build
       - run: npm run test
 
 workflows:


### PR DESCRIPTION
## Motivation

The @circleci build started breaking on the `npm install` step, blocking any PR from passing https://app.circleci.com/pipelines/github/thefrontside/simulacrum/83/workflows/3117c138-1a48-469c-9929-1c06788dab5b/jobs/76/parallel-runs/0/steps/0-102

## Approach

Upgrade the node orb to latest, and use the npm 7.11.2 (7.12.0 is still failing)