### PR TITLE
Add Volta configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,9 @@
   },
   "devDependencies": {
     "covector": "^0.5.3"
+  },
+  "volta": {
+    "node": "14.17.0",
+    "npm": "7.13.0"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,5 +37,8 @@
   "bugs": {
     "url": "https://github.com/thefrontside/simulacrum/issues"
   },
-  "homepage": "https://github.com/thefrontside/simulacrum#readme"
+  "homepage": "https://github.com/thefrontside/simulacrum#readme",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -64,5 +64,8 @@
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,5 +38,8 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "typescript": "^4.2.3"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
## Motivation

We ran into some issues where the correct version of `npm` was not being used and was causing problems, specifically getting stuck on npm@6

Approach
----------
Volta users (which are many) can circumvent this problem entirely if we have a specification of which point release of node and npm we want to use. This creates a volta config at the root, and then every other package inherits that volta config
