### PR TITLE
Pass options to simulation when creating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,18 +1795,6 @@
         "effection": "^1.0.0"
       }
     },
-    "node_modules/@effection/mocha": {
-      "version": "2.0.0-preview.2-f9e72f1",
-      "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-preview.2-f9e72f1.tgz",
-      "integrity": "sha512-NAlhyY0OngUHx69iM6GHg3ahz7QJW9IoO+cBIJsyx5rgZn/VCJXMOVm48X86LTfjvEHL3N7GNGVyI6/MZ2o+wg==",
-      "dev": true,
-      "dependencies": {
-        "@effection/core": "^2.0.0-preview.2"
-      },
-      "peerDependencies": {
-        "mocha": "^8.0.0"
-      }
-    },
     "node_modules/@effection/node": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@effection/node/-/node-1.0.1.tgz",
@@ -19265,7 +19253,7 @@
         "ws": "^7.4.4"
       },
       "devDependencies": {
-        "@effection/mocha": "^2.0.0-preview.9",
+        "@effection/mocha": "2.0.0-preview.11",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
@@ -19293,6 +19281,18 @@
         "@effection/subscription": "2.0.0-preview.10"
       }
     },
+    "packages/server/node_modules/@effection/channel/node_modules/@effection/core": {
+      "version": "2.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+      "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+    },
+    "packages/server/node_modules/@effection/core": {
+      "version": "2.0.0-preview.10",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.10.tgz",
+      "integrity": "sha512-f7iBwXGhL/DcLB8qd8m9un5NGWEjw8xJycIMVLMjClez0+6+78kZchZH8RsdTUBQIjQFRQ8idmIdQu2dQ0akyw==",
+      "dev": true,
+      "peer": true
+    },
     "packages/server/node_modules/@effection/events": {
       "version": "2.0.0-preview.9",
       "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-preview.9.tgz",
@@ -19300,6 +19300,21 @@
       "dependencies": {
         "@effection/core": "2.0.0-preview.9",
         "@effection/subscription": "2.0.0-preview.10"
+      }
+    },
+    "packages/server/node_modules/@effection/events/node_modules/@effection/core": {
+      "version": "2.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+      "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+    },
+    "packages/server/node_modules/@effection/mocha": {
+      "version": "2.0.0-preview.11",
+      "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-preview.11.tgz",
+      "integrity": "sha512-fe0i7o4+oBvEqdTYfQ0U7aB0qrVOyqLw3D2prFPCCnHWeeMFUBrFJQIaiErW55G/pb1Uy+Td9HauegkQuRp0mw==",
+      "dev": true,
+      "peerDependencies": {
+        "@effection/core": "2.0.0-preview.10",
+        "mocha": "^8.0.0"
       }
     },
     "packages/server/node_modules/@effection/node": {
@@ -19316,6 +19331,11 @@
         "shellwords": "^0.1.1"
       }
     },
+    "packages/server/node_modules/@effection/node/node_modules/@effection/core": {
+      "version": "2.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+      "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+    },
     "packages/server/node_modules/@effection/subscription": {
       "version": "2.0.0-preview.10",
       "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-preview.10.tgz",
@@ -19323,6 +19343,11 @@
       "dependencies": {
         "@effection/core": "2.0.0-preview.9"
       }
+    },
+    "packages/server/node_modules/@effection/subscription/node_modules/@effection/core": {
+      "version": "2.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+      "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
     },
     "packages/server/node_modules/effection": {
       "version": "2.0.0-preview.12",
@@ -19334,6 +19359,11 @@
         "@effection/events": "2.0.0-preview.9",
         "@effection/subscription": "2.0.0-preview.10"
       }
+    },
+    "packages/server/node_modules/effection/node_modules/@effection/core": {
+      "version": "2.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+      "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
     },
     "packages/ui": {
       "name": "@simulacrum/ui",
@@ -20853,15 +20883,6 @@
         "effection": "^1.0.0"
       }
     },
-    "@effection/mocha": {
-      "version": "2.0.0-preview.2-f9e72f1",
-      "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-preview.2-f9e72f1.tgz",
-      "integrity": "sha512-NAlhyY0OngUHx69iM6GHg3ahz7QJW9IoO+cBIJsyx5rgZn/VCJXMOVm48X86LTfjvEHL3N7GNGVyI6/MZ2o+wg==",
-      "dev": true,
-      "requires": {
-        "@effection/core": "^2.0.0-preview.2"
-      }
-    },
     "@effection/node": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@effection/node/-/node-1.0.1.tgz",
@@ -22230,7 +22251,7 @@
       "version": "file:packages/server",
       "requires": {
         "@effection/atom": "=2.0.0-preview.10",
-        "@effection/mocha": "^2.0.0-preview.9",
+        "@effection/mocha": "2.0.0-preview.11",
         "@effection/node": "=2.0.0-preview.12",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
@@ -22271,7 +22292,21 @@
             "@effection/core": "2.0.0-preview.9",
             "@effection/events": "2.0.0-preview.9",
             "@effection/subscription": "2.0.0-preview.10"
+          },
+          "dependencies": {
+            "@effection/core": {
+              "version": "2.0.0-preview.9",
+              "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+              "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+            }
           }
+        },
+        "@effection/core": {
+          "version": "2.0.0-preview.10",
+          "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.10.tgz",
+          "integrity": "sha512-f7iBwXGhL/DcLB8qd8m9un5NGWEjw8xJycIMVLMjClez0+6+78kZchZH8RsdTUBQIjQFRQ8idmIdQu2dQ0akyw==",
+          "dev": true,
+          "peer": true
         },
         "@effection/events": {
           "version": "2.0.0-preview.9",
@@ -22280,7 +22315,21 @@
           "requires": {
             "@effection/core": "2.0.0-preview.9",
             "@effection/subscription": "2.0.0-preview.10"
+          },
+          "dependencies": {
+            "@effection/core": {
+              "version": "2.0.0-preview.9",
+              "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+              "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+            }
           }
+        },
+        "@effection/mocha": {
+          "version": "2.0.0-preview.11",
+          "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-preview.11.tgz",
+          "integrity": "sha512-fe0i7o4+oBvEqdTYfQ0U7aB0qrVOyqLw3D2prFPCCnHWeeMFUBrFJQIaiErW55G/pb1Uy+Td9HauegkQuRp0mw==",
+          "dev": true,
+          "requires": {}
         },
         "@effection/node": {
           "version": "2.0.0-preview.12",
@@ -22294,6 +22343,13 @@
             "cross-spawn": "^7.0.3",
             "ctrlc-windows": "^1.0.3",
             "shellwords": "^0.1.1"
+          },
+          "dependencies": {
+            "@effection/core": {
+              "version": "2.0.0-preview.9",
+              "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+              "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+            }
           }
         },
         "@effection/subscription": {
@@ -22302,6 +22358,13 @@
           "integrity": "sha512-TJL6m3GK6L+MfbsWzOeSfgfW7syiD/ZbxY3rwaolyE7It9j/W+7zgmdOiXnlw8XWPC03zoMT3m9sqBqKF2AgKQ==",
           "requires": {
             "@effection/core": "2.0.0-preview.9"
+          },
+          "dependencies": {
+            "@effection/core": {
+              "version": "2.0.0-preview.9",
+              "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+              "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+            }
           }
         },
         "effection": {
@@ -22313,6 +22376,13 @@
             "@effection/core": "2.0.0-preview.9",
             "@effection/events": "2.0.0-preview.9",
             "@effection/subscription": "2.0.0-preview.10"
+          },
+          "dependencies": {
+            "@effection/core": {
+              "version": "2.0.0-preview.9",
+              "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-preview.9.tgz",
+              "integrity": "sha512-iXDvUaTSmfnZcywiIzvbpkgknx6CxYksl+CtA9sktKEnmsjgbAlSa/+braaJPM21KpTCukEzBR1p3x5HgHdbkA=="
+            }
           }
         }
       }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,7 +3,7 @@ import { createClient as createWSClient, SubscribePayload } from 'graphql-ws';
 import { GraphQLError } from 'graphql';
 
 export interface Client {
-  createSimulation(simulator: string): Promise<Simulation>;
+  createSimulation(simulator: string, options?: Record<string, unknown>): Promise<Simulation>;
   destroySimulation(simulation: Simulation): Promise<boolean>;
   given(simulation: Simulation, scenario: string): Promise<Scenario>;
   state<T>(): AsyncIterable<T> & AsyncIterator<T>;
@@ -92,11 +92,11 @@ export function createClient(serverURL: string, webSocketImpl?: WebSocketImpl): 
   }
 
   return {
-    createSimulation: (simulator?: string) => {
+    createSimulation: (simulator: string, options?: Record<string, unknown>) => {
       return query<Simulation>("createSimulation", {
         query: `
-mutation CreateSimulation($simulator: String) {
-  createSimulation(simulator: $simulator) {
+mutation CreateSimulation($simulator: String, $options: JSON) {
+  createSimulation(simulator: $simulator, options: $options) {
     id
     simulators
     services {
@@ -106,7 +106,7 @@ mutation CreateSimulation($simulator: String) {
   }
 }`,
         operationName: 'CreateSimulation',
-        variables: { simulator }
+        variables: { simulator, options }
       });
     },
     given: (simulation: Simulation, scenario: string) => query<Scenario>("given", {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,7 +48,7 @@
     "ws": "^7.4.4"
   },
   "devDependencies": {
-    "@effection/mocha": "^2.0.0-preview.9",
+    "@effection/mocha": "2.0.0-preview.11",
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",

--- a/packages/server/src/echo.ts
+++ b/packages/server/src/echo.ts
@@ -1,6 +1,6 @@
 import { HttpHandler } from './http';
 
-export const echo = (times: number) => function echo(request, response) {
+export const echo: (times: number) => HttpHandler = (times: number) => function echo(request, response) {
   return function * () {
     response.contentType(request.headers['content-type'] ?? "application/octet-stream");
     let body = Array(times).fill(request.body ?? "echo").join("\n");

--- a/packages/server/src/echo.ts
+++ b/packages/server/src/echo.ts
@@ -1,9 +1,9 @@
 import { HttpHandler } from './http';
 
-export const echo: HttpHandler = function echo(request, response) {
+export const echo = (times: number) => function echo(request, response) {
   return function * () {
     response.contentType(request.headers['content-type'] ?? "application/octet-stream");
-
-    response.status(200).write(request.body ?? "echo");
+    let body = Array(times).fill(request.body ?? "echo").join("\n");
+    response.status(200).write(body);
   };
-};
+} as HttpHandler;

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -13,12 +13,12 @@ export interface Scenario<T = any> {
   (store: Store, faker: Faker): Operation<T>;
 }
 
-export interface Simulator {
-  (): Behaviors;
+export interface Simulator<Options = any> {
+  (options: Options): Behaviors;
 }
 
 export interface ServerOptions {
-  simulators: Record<string, Simulator>;
+  simulators: Record<string, Simulator<any>>;
   port?: number;
   seed?: number;
 }
@@ -40,6 +40,7 @@ export type SimulationState =
     id: string;
     status: 'new',
     simulator: string,
+    options: Record<string, unknown>;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
   } |
@@ -47,6 +48,7 @@ export type SimulationState =
     id: string,
     status: 'running',
     simulator: string,
+    options: Record<string, unknown>;
     services: {
       name: string;
       url: string;
@@ -58,6 +60,7 @@ export type SimulationState =
     id: string,
     status: 'failed',
     simulator: string,
+    options: Record<string, unknown>;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
     error: Error

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -13,11 +13,13 @@ export interface Scenario<T = any> {
   (store: Store, faker: Faker): Operation<T>;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Simulator<Options = any> {
   (options: Options): Behaviors;
 }
 
 export interface ServerOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   simulators: Record<string, Simulator<any>>;
   port?: number;
   seed?: number;

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -16,15 +16,16 @@ export interface Subscriber<Args, TEach, Result = TEach> {
 
 export interface CreateSimulationParameters {
   simulator: string;
+  options?: Record<string, unknown>;
 }
 
 export const createSimulation: Resolver<CreateSimulationParameters, SimulationState> = {
-  resolve({ simulator }, ctx) {
+  resolve({ simulator, options = {} }, ctx) {
     let { atom, scope, newid } = ctx;
 
     let id = newid();
     let simulation = atom.slice("simulations").slice(id);
-    simulation.set({ id, status: 'new', simulator, scenarios: {}, store: {} });
+    simulation.set({ id, status: 'new', simulator, options, scenarios: {}, store: {} });
 
     return scope.spawn(simulation.filter(({ status }) => status !== 'new').expect());
   }

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -1,4 +1,4 @@
-import { objectType, mutationType, scalarType, nonNull, stringArg, intArg, subscriptionType } from 'nexus';
+import { objectType, mutationType, scalarType, nonNull, arg, stringArg, intArg, subscriptionType } from 'nexus';
 
 import { createSimulation, destroySimulation, given, state } from './operations';
 
@@ -6,7 +6,8 @@ export const types = [
   scalarType({
     name: "JSON",
     description: "JSON value",
-    serialize: value => value
+    serialize: value => value,
+    parseValue: value => value
   }),
   objectType({
     name: 'Service',
@@ -31,6 +32,11 @@ export const types = [
         args: {
           seed: intArg(),
           simulator: nonNull(stringArg()),
+          options: arg({
+            type: 'JSON',
+            description: "options to pass to the simulation",
+
+          })
         },
         ...createSimulation
       });

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -9,7 +9,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
   return slice => function*(scope) {
     try {
       let simulatorName = slice.get().simulator;
-      let simulator = simulators[simulatorName]
+      let simulator = simulators[simulatorName];
       assert(simulator, `unknown simulator ${simulatorName}`);
       let options = slice.get().options;
 

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -9,8 +9,11 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
   return slice => function*(scope) {
     try {
       let simulatorName = slice.get().simulator;
-      assert(!!simulators[simulatorName], `unknown simulator ${simulatorName}`);
-      let behaviors = simulators[simulatorName]();
+      let simulator = simulators[simulatorName]
+      assert(simulator, `unknown simulator ${simulatorName}`);
+      let options = slice.get().options;
+
+      let behaviors = simulator(options);
 
       let servers = Object.entries(behaviors.services).map(([name, service]) => {
         let app = express();

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -21,7 +21,7 @@ main(function* () {
         services: {
           echo: {
             protocol: 'http',
-            app: createHttpApp().post('/', echo)
+            app: createHttpApp().post('/', echo(1))
           }
         },
         scenarios: {}

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -10,33 +10,32 @@ import { ServerOptions } from '../src/interfaces';
 import { createTestServer } from './helpers';
 
 describe('@simulacrum/server', () => {
+  let simulation: Simulation;
   let client: Client;
 
-  let app = createHttpApp().post('/', echo);
+  let app = (times: number) => createHttpApp().post('/', echo(times));
 
   beforeEach(function * (world) {
     client = yield world.spawn(createTestServer({
       simulators: {
-        echo: () => ({
+        echo: (({ times = 1 }) => ({
           services: {
             echo: {
               protocol: 'http',
-              app
+              app: app(times)
             },
             ["echo.too"]: {
               protocol: 'http',
-              app
+              app:  app(times)
             }
           },
           scenarios: {}
-        })
+        }))
       }
     }));
   });
 
   describe('createSimulation()', () => {
-    let simulation: Simulation;
-
     beforeEach(function*() {
       simulation = yield client.createSimulation("echo");
     });
@@ -84,8 +83,28 @@ describe('@simulacrum/server', () => {
         expect(yield captureError(response)).toMatchObject({ name: 'FetchError' });
       });
     });
-
   });
+
+  describe('createSimulation() with parameters', () => {
+    let response: Response;
+    let body: string;
+    beforeEach(function*() {
+      simulation = yield client.createSimulation("echo", {
+        times: 3
+      });
+      let [{ url }] = simulation.services;
+      response = yield fetch(url.toString(), { method: 'POST', body: "hello world" });
+      expect(response.ok).toBe(true);
+      body = yield response.text();
+    });
+
+    it('can use those parameters to alter the behavor of its services', function*() {
+      expect(body).toEqual(
+        `hello world
+hello world
+hello world`);
+    });
+  })
 
   describe('creating two servers with the same seed', () => {
     let one: Client;

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -104,7 +104,7 @@ describe('@simulacrum/server', () => {
 hello world
 hello world`);
     });
-  })
+  });
 
   describe('creating two servers with the same seed', () => {
     let one: Client;


### PR DESCRIPTION
Motivation
----------

Sometimes you want to determine ahead of time aspects of how a simulation will behave. For example, what if you want a stable port number for your service? This is handy for development if you always want your server to be at the same place. You can make your similulator hard-code a port, or even use an environment variable, but that doesn't scale across running tests in parallel. In that case, what we'd really like to do is pass the port number from _outside_, when we're creating the simulation, by saying "this is the port number to use".

In other words,

```graphql
createSimulation("my-backend", {
  port: 4400
})
```

Approach
----------
This allows for the passage of an arbitrary JSON blob to the simulator that is controlling the simulation. Where as before, a simulator was a no-arg function `() => Behaviors`, it now takes options to become `(options) => Behaviors`. That way, the options can inform how the services and scenarios will behave.