### PR TITLE
Autofix lint and install dependencies with Volta in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run linters
+        uses: wearerequired/lint-action@v1
         with:
-          node-version: 14
-      - run: npm install --global npm@7.10.0
-      - run: npm ci
-      - run: npm run lint
+          eslint: true
+          auto_fix: true


### PR DESCRIPTION
## Motivation

When PRs like #54 fail because of a missing semi, every moment spent fixing the semi is a waste of time.
Let computers do stupid work like write semicolons.

## Approach

Try [wearerequired/lint-action](https://github.com/wearerequired/lint-action) which has an `auto_fix` action that fixes lint errors that eslint can fix.

Also: using `volta-cli` to install project dependencies on Lint action. 

