### PR TITLE
remove unnecessary local export

### DIFF
--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -3,7 +3,6 @@ import { Request, Response, Application } from 'express';
 
 import type { Server as HTTPServer } from 'http';
 import type { AddressInfo } from 'net';
-export type { AddressInfo } from 'net';
 
 export interface Server {
   http: HTTPServer;
@@ -39,7 +38,7 @@ export function createServer(app: Application, options: ServerOptions = {}): Res
 
       return {
         http: server,
-        address: server.address() as unknown as AddressInfo
+        address: server.address() as AddressInfo
       };
     }
   };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -10,7 +10,6 @@ import { Server, createServer } from './http';
 import { OperationContext } from './schema/context';
 
 export { Server, createServer } from './http';
-export type { AddressInfo } from './http';
 
 import { createEffects } from './effects';
 import { stableIds } from './faker';

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -2,7 +2,7 @@ import assert from 'assert-ts';
 import { Effect, map } from './effect';
 import express, { raw } from 'express';
 import { SimulationState, Simulator } from './interfaces';
-import { AddressInfo, createServer, Server } from './http';
+import { createServer, Server } from './http';
 import { createFaker } from './faker';
 
 export function simulation(simulators: Record<string, Simulator>): Effect<SimulationState> {
@@ -45,7 +45,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       let services: {name: string; url: string; }[] = [];
       for (let { name, protocol, create } of servers) {
         let server: Server = yield create;
-        let address: AddressInfo = server.address;
+        let address = server.address;
         services.push({ name, url: `${protocol}://localhost:${address.port}` });
       }
 


### PR DESCRIPTION
## Motivation

`http.ts` and `server.ts` had the following unnecessary export

```ts
export type { AddressInfo } from 'net';
```

Other parts of the application were then importing `Address` info from `http` and not from 'net`

e.g. `simulation.ts`

```ts
export type { AddressInfo } from './http';
```

## Approach

Remove the export

### Alternate Designs

If this was intended behaviour then we can close the PR.
