### PR TITLE
pass store to simulator

### DIFF
--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -15,7 +15,7 @@ export interface Scenario<T = any> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Simulator<Options = any> {
-  (options: Options): Behaviors;
+  (store: Store, options: Options): Behaviors;
 }
 
 export interface ServerOptions {

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -11,9 +11,10 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       let simulatorName = slice.get().simulator;
       let simulator = simulators[simulatorName];
       assert(simulator, `unknown simulator ${simulatorName}`);
+      let store = slice.slice("store");
       let options = slice.get().options;
 
-      let behaviors = simulator(options);
+      let behaviors = simulator(store, options);
 
       let servers = Object.entries(behaviors.services).map(([name, service]) => {
         let app = express();
@@ -49,7 +50,6 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
         services.push({ name, url: `${protocol}://localhost:${address.port}` });
       }
 
-      let store = slice.slice("store");
       let { scenarios } = behaviors;
 
       // we can support passing a seed to a scenario later, but let's

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, captureError } from '@effection/mocha';
 import { Client, Simulation } from '@simulacrum/client';
+import { assert } from 'assert-ts';
 import fetch from 'cross-fetch';
 import expect from 'expect';
 
@@ -18,19 +19,24 @@ describe('@simulacrum/server', () => {
   beforeEach(function * (world) {
     client = yield world.spawn(createTestServer({
       simulators: {
-        echo: (({ times = 1 }) => ({
-          services: {
-            echo: {
-              protocol: 'http',
-              app: app(times)
+        echo: ((store, { times }) => {
+          assert(typeof store !== 'undefined', 'store not getting passed to simulator');
+
+          return {
+            services: {
+              echo: {
+                protocol: 'http',
+                app: app(times)
+              },
+              ["echo.too"]: {
+                protocol: 'http',
+                app:  app(times)
+              },
+
             },
-            ["echo.too"]: {
-              protocol: 'http',
-              app:  app(times)
-            }
-          },
-          scenarios: {}
-        }))
+            scenarios: {}
+          };
+        }),
       }
     }));
   });


### PR DESCRIPTION
## Motivation

Pass the store `Slice` to each simulator so they can have access to the global state.

## Approach

```ts
export interface Simulator<Options = any> {
  (soptions: Options): Behaviors;
}
```

Becomes

```ts
export interface Simulator<Options = any> {
  (store: Store, options: Options): Behaviors;
}
```
