### PR TITLE
add rimraf to ui for cross OS cleaning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16840,6 +16840,7 @@
         "parcel": "next",
         "react": "^16.8.0",
         "react-dom": "^16.8.0",
+        "rimraf": "^3.0.2",
         "typescript": "^4.2.3"
       }
     }
@@ -18471,6 +18472,7 @@
         "parcel": "next",
         "react": "^16.8.0",
         "react-dom": "^16.8.0",
+        "rimraf": "^3.0.2",
         "typescript": "^4.2.3"
       }
     },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,7 @@
     "watch": "parcel watch app/index.html --target browser",
     "build": "npm run prepack",
     "lint": "eslint app index.js",
-    "clean": "rm -rf dist"
+    "clean": "rimraf dist"
   },
   "repository": {
     "type": "git",
@@ -37,6 +37,7 @@
     "parcel": "next",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.2.3"
   },
   "volta": {


### PR DESCRIPTION
## Motivation

`npm run clean` in `ui` fails with `rm`. Switch to `rimraf` that works cross platform.

## Additional Thoughts

I didn't include a change file since it doesn't affect the publish artifacts in any way.
