### PR TITLE
Get rid of `webSocketImpl` argument in `createClient`

### DIFF
--- a/.changes/cross-platform-client.md
+++ b/.changes/cross-platform-client.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/client": minor
+---
+Automatically detect platform (nodejs, browser) and use appropriate
+WebSocket library

--- a/package-lock.json
+++ b/package-lock.json
@@ -8077,6 +8077,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -16777,7 +16785,8 @@
       "license": "MIT",
       "dependencies": {
         "effection": "2.0.0-preview.14",
-        "graphql-ws": "^4.2.3"
+        "graphql-ws": "^4.2.3",
+        "isomorphic-ws": "^4.0.1"
       },
       "devDependencies": {
         "@frontside/eslint-config": "^2.0.0",
@@ -18420,6 +18429,7 @@
         "@frontside/typescript": "^1.1.1",
         "effection": "2.0.0-preview.14",
         "graphql-ws": "^4.2.3",
+        "isomorphic-ws": "^4.0.1",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.3"
       }
@@ -23165,6 +23175,12 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "effection": "2.0.0-preview.14",
-    "graphql-ws": "^4.2.3"
+    "graphql-ws": "^4.2.3",
+    "isomorphic-ws": "^4.0.1"
   },
   "devDependencies": {
     "@frontside/eslint-config": "^2.0.0",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 import { Deferred, Task, createChannel, run, sleep, Subscription } from 'effection';
 import { createClient as createWSClient, SubscribePayload } from 'graphql-ws';
+import webSocketImpl from 'isomorphic-ws';
 import { GraphQLError } from 'graphql';
 
 export interface Client {
@@ -41,7 +42,7 @@ interface Result<T> {
   errors?: GraphQLError[];
 }
 
-export function createClient(serverURL: string, webSocketImpl?: WebSocketImpl): Client {
+export function createClient(serverURL: string): Client {
   let wsurl = new URL(serverURL);
   wsurl.protocol = 'ws';
   let url = wsurl.toString();

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -2,14 +2,13 @@ import { createClient, Client } from '@simulacrum/client';
 import { Resource, spawn } from 'effection';
 import { ServerOptions } from '../src/interfaces';
 import { createSimulationServer, Server } from '../src/server';
-import WS from 'ws';
 
 export function createTestServer(options: ServerOptions): Resource<Client> {
   return {
     *init() {
       let server: Server = yield createSimulationServer(options);
       let { port } = server.address;
-      let client = createClient(`http://localhost:${port}`, WS);
+      let client = createClient(`http://localhost:${port}`);
       yield spawn(function*() {
         try {
           yield;


### PR DESCRIPTION
## Motivation
It's annoying and confusing that on NodeJs you have to explicitly pass in your WebSocket constructor to the `createClient` method. We want to have the same signature of `createClient(url: string)` instead of forcing the user to have to choose a websocket implementation.

## Approach 
In this case, we just always explicitly pass the websocket constructor to the underlying `graphql-ws` instance using `isomorphic-ws` since it is created for exactly this situation. 
