### PR TITLE
Middleware

### DIFF
--- a/.changes/middleware.md
+++ b/.changes/middleware.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": minor
+---
+
+Add a `use` function to `createHttpApp` that adds express middleware that are operations.

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -8,7 +8,6 @@ import { Server as HTTPServer, createServer as createHttpServer } from 'http';
 import { paths } from './config/paths';
 import fs from 'fs';
 import { mkcertText, NoSSLError } from './errors/ssl/ssl-error';
-
 export interface Server {
   http: HTTPServer;
   address: AddressInfo;
@@ -88,21 +87,32 @@ export type RouteHandler = {
   handler: HttpHandler;
 }
 
+export type Middleware = (req: Request, res: Response) => void;
+
 export interface HttpApp {
   handlers: RouteHandler[];
+  middleware: Middleware[];
   get(path: string, handler: HttpHandler): HttpApp;
   put(path: string, handler: HttpHandler): HttpApp;
   post(path: string, handler: HttpHandler): HttpApp;
+  use(middleware: Middleware): HttpApp;
 }
 
-export function createHttpApp(handlers: RouteHandler[] = []): HttpApp {
-  function append(handler: RouteHandler) {
-    return createHttpApp(handlers.concat(handler));
+export function createHttpApp(handlers: RouteHandler[] = [], middleware: Middleware[] = []): HttpApp {
+  function appendHandler(routeHandler: RouteHandler) {
+    return createHttpApp(handlers.concat(routeHandler), middleware);
   }
+
+  function appendMiddleware(middlewareHandler: Middleware) {
+    return createHttpApp(handlers, middleware.concat(middlewareHandler));
+  }
+
   return {
     handlers,
-    get: (path, handler) => append({ path, handler, method: 'get' }),
-    post: (path, handler) => append({ path, handler, method: 'post' }),
-    put: (path, handler) => append({ path, handler, method: 'put' })
+    middleware: middleware,
+    get: (path, handler) => appendHandler({ path, handler, method: 'get' }),
+    post: (path, handler) => appendHandler({ path, handler, method: 'post' }),
+    put: (path, handler) => appendHandler({ path, handler, method: 'put' }),
+    use: (middlewareHandler) => appendMiddleware(middlewareHandler),
   };
 }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -87,7 +87,9 @@ export type RouteHandler = {
   handler: HttpHandler;
 }
 
-export type Middleware = (req: Request, res: Response) => void;
+export interface Middleware {
+  (req: Request, res: Response): Operation<void>
+}
 
 export interface HttpApp {
   handlers: RouteHandler[];

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -20,11 +20,11 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       let servers = Object.entries(behaviors.services).map(([name, service]) => {
         let app = express();
 
-        for(let middleware of service.app.middleware) {
-          app.use(function(...args) {
-            scope.spawn(function* () {
-              yield middleware(...args);
-            });
+        for(let handler of service.app.middleware) {
+          app.use(function(req, res, next) {
+            scope.spawn(handler(req, res))
+            .then(next)
+            .catch(next);
           });
         }
 

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -20,6 +20,15 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       let servers = Object.entries(behaviors.services).map(([name, service]) => {
         let app = express();
         app.use(raw({ type: "*/*" }));
+
+        for(let middleware of service.app.middleware) {
+          app.use(function(...args) {
+            scope.spawn(function* () {
+              yield middleware(...args);
+            });
+          });
+        }
+
         for (let handler of service.app.handlers) {
           app[handler.method](handler.path, (request, response) => {
             scope.spawn(function*() {

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -19,7 +19,6 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
 
       let servers = Object.entries(behaviors.services).map(([name, service]) => {
         let app = express();
-        app.use(raw({ type: "*/*" }));
 
         for(let middleware of service.app.middleware) {
           app.use(function(...args) {
@@ -28,6 +27,8 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
             });
           });
         }
+
+        app.use(raw({ type: "*/*" }));
 
         for (let handler of service.app.handlers) {
           app[handler.method](handler.path, (request, response) => {

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -96,7 +96,7 @@ describe('@simulacrum/server', () => {
     });
 
     describe('middleware', () => {
-      it('should add middleware handler', function* () {
+      it('should add middleware handlers', function* () {
         expect(calls).toEqual(['one', 'two']);
       });
     });

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -79,6 +79,12 @@ describe('@simulacrum/server', () => {
       });
     });
 
+    describe('middleware', () => {
+      it('should add middleware handlers', function* () {
+        expect(calls).toEqual(['one', 'two']);
+      });
+    });
+
     describe('posting to the https echo service', () => {
       let body: string;
 
@@ -92,12 +98,6 @@ describe('@simulacrum/server', () => {
 
       it('gives you back what you gave it', function*() {
         expect(body).toEqual("hello world");
-      });
-    });
-
-    describe('middleware', () => {
-      it('should add middleware handlers', function* () {
-        expect(calls).toEqual(['one', 'two']);
       });
     });
 

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -13,8 +13,14 @@ import { createTestServer } from './helpers';
 describe('@simulacrum/server', () => {
   let simulation: Simulation;
   let client: Client;
+  let calls: string[] = [];
 
-  let app = (times: number) => createHttpApp().post('/', echo(times));
+  let app = (times: number) => createHttpApp()
+    .use(function* () {
+      calls.push('one');
+    }).use(function* () {
+      calls.push('two');
+    }).post('/', echo(times));
 
   beforeEach(function* () {
     client = yield createTestServer({
@@ -86,6 +92,12 @@ describe('@simulacrum/server', () => {
 
       it('gives you back what you gave it', function*() {
         expect(body).toEqual("hello world");
+      });
+    });
+
+    describe('middleware', () => {
+      it('should add middleware handler', function* () {
+        expect(calls).toEqual(['one', 'two']);
       });
     });
 


### PR DESCRIPTION
## Motivation

I am using this as a first PR to break up the auth0 branch into smaller chunks.

This PR adds a `use` function to `createHttpApp` that adds express middleware that are operations

## Approach

A `use` function is added to the builder function

```ts
let app = (times: number) => createHttpApp()
  .use(function* (req, res, next) {
    // do stuff


  next();
})
```

An operation is spawned for each middleware element

```ts
for(let middleware of service.app.middleware) {
  app.use(function(...args) {
    scope.spawn(function* () {
      yield middleware(...args);
    });
  });
}
```

### Alternate Designs

You could just use straight up express middleware functions.