### PR TITLE
Https

### DIFF
--- a/.changes/https.md
+++ b/.changes/https.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/server": minor
+---
+Add the ability to create https services

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     docker:
       - image: cimg/node:15.14.0
     steps:
+      - checkout
       - run: wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64 
       - run: mv mkcert-v1.4.3-linux-amd64 mkcert
       - run: export CWD=$(pwd)
@@ -13,10 +14,9 @@ jobs:
       - run: sudo cp mkcert /usr/local/bin/
       - run: sudo mkcert -install
       - run: mkdir -p ~/.simulacrum/certs
-      - run: cd ~/.simulacrum/certs
-      - run: cd $CWD
-      - run: mkcert localhost
-      - checkout
+      - run:
+          command: mkcert localhost
+          working_directory: ~/.simulacrum/certs
       - node/install-packages
       - run: npm run build
       - run: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,14 @@ jobs:
     docker:
       - image: cimg/node:15.14.0
     steps:
+      - run: wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64 
+      - run: mv mkcert-v1.4.3-linux-amd64 mkcert
+      - run: chmod +x mkcert
+      - run: sudo cp mkcert /usr/local/bin/
+      - run: sudo mkcert -install
+      - run: mkdir -p ~/.simulacrum/certs
+      - run: cd ~/.simulacrum/certs
+      - run: mkcert localhost
       - checkout
       - node/install-packages
       - run: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ jobs:
       - run: export CWD=$(pwd)
       - run: chmod +x mkcert
       - run: sudo cp mkcert /usr/local/bin/
-      - run: sudo mkcert -install
       - run: mkdir -p ~/.simulacrum/certs
+      - run: export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
       - run:
-          command: mkcert localhost
+          command: sudo mkcert -install && mkcert localhost
           working_directory: ~/.simulacrum/certs
       - node/install-packages
       - run: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,13 @@ jobs:
     steps:
       - run: wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64 
       - run: mv mkcert-v1.4.3-linux-amd64 mkcert
+      - run: export CWD=$(pwd)
       - run: chmod +x mkcert
       - run: sudo cp mkcert /usr/local/bin/
       - run: sudo mkcert -install
       - run: mkdir -p ~/.simulacrum/certs
       - run: cd ~/.simulacrum/certs
+      - run: cd $CWD
       - run: mkcert localhost
       - checkout
       - node/install-packages

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "clean": "rimraf *.tsbuildinfo dist",
-    "test": "mocha -r ts-node/register --timeout 10000 test/**/*.test.ts",
+    "test": "NODE_EXTRA_CA_CERTS=\"$(mkcert -CAROOT)/rootCA.pem\" mocha -r ts-node/register --timeout 10000 test/**/*.test.ts",
     "prepack": "tsc --build tsconfig.dist.json",
     "build": "npm run prepack",
     "lint": "eslint src test watch.ts",

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -6,8 +6,6 @@ const certificatesDir = path.join(rootDir, "certs");
 const pemFile = path.join(certificatesDir, "localhost.pem");
 const keyFile = path.join(certificatesDir, "localhost-key.pem");
 
-// TODO: need to check certificates exist and if not dispaly meaningful error
-
 export const paths = {
   rootDir,
   certificatesDir,

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -1,0 +1,18 @@
+import { homedir } from "os";
+import path from "path";
+
+const rootDir = path.join(homedir(), ".simulacrum");
+const certificatesDir = path.join(rootDir, "certs");
+const pemFile = path.join(certificatesDir, "localhost.pem");
+const keyFile = path.join(certificatesDir, "localhost-key.pem");
+
+// TODO: need to check certificates exist and if not dispaly meaningful error
+
+export const paths = {
+  rootDir,
+  certificatesDir,
+  ssl: {
+    pemFile,
+    keyFile
+  }
+} as const;

--- a/packages/server/src/errors/ssl/ssl-error.ts
+++ b/packages/server/src/errors/ssl/ssl-error.ts
@@ -1,17 +1,18 @@
 import { paths } from '../../config/paths';
 
-export const mkcertText = `A certificate has not 
+export const mkcertText = `
+In order to run an https service from localhost you need locally-trusted development certificates.
 
-  mkcert (https://github.com/FiloSottile/mkcert) makes this pretty easy:
+mkcert (https://github.com/FiloSottile/mkcert) makes this pretty easy:
 
-  brew install mkcert
-  brew install nss  # for firefox
+brew install mkcert
+brew install nss  # for firefox
 
-  mkdir -p ${paths.certificatesDir}
-  cd ${paths.certificatesDir}
+mkdir -p ${paths.certificatesDir}
+cd ${paths.certificatesDir}
 
-  mkcert -install   # Created a new local CA at the location returned from mkcert -CAROOT
-  mkcert localhost  # Using the local CA at CAROOT, create a new certificate valid for the following names
+mkcert -install   # Created a new local CA at the location returned from mkcert -CAROOT
+mkcert localhost  # Using the local CA at CAROOT, create a new certificate valid for the following names
       `;
 
 export class NoSSLError extends Error {

--- a/packages/server/src/errors/ssl/ssl-error.ts
+++ b/packages/server/src/errors/ssl/ssl-error.ts
@@ -1,0 +1,23 @@
+import { paths } from '../../config/paths';
+
+export const mkcertText = `A certificate has not 
+
+  mkcert (https://github.com/FiloSottile/mkcert) makes this pretty easy:
+
+  brew install mkcert
+  brew install nss  # for firefox
+
+  mkdir -p ${paths.certificatesDir}
+  cd ${paths.certificatesDir}
+
+  mkcert -install   # Created a new local CA at the location returned from mkcert -CAROOT
+  mkcert localhost  # Using the local CA at CAROOT, create a new certificate valid for the following names
+      `;
+
+export class NoSSLError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -19,7 +19,6 @@ export interface ServerOptions {
   protocol: Service['protocol'];
 }
 
-
 const createAppServer = (app: Application, options: ServerOptions) => {
   switch(options.protocol) {
     case 'http':
@@ -91,7 +90,6 @@ export interface HttpApp {
   put(path: string, handler: HttpHandler): HttpApp;
   post(path: string, handler: HttpHandler): HttpApp;
 }
-
 
 export function createHttpApp(handlers: RouteHandler[] = []): HttpApp {
   function append(handler: RouteHandler) {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -30,6 +30,10 @@ const createAppServer = (app: Application, options: ServerOptions) => {
         throw new NoSSLError('no self signed certificate.');
       }
 
+      // mkcert does not generate a fullchain certificate
+      // https://github.com/FiloSottile/mkcert/issues/76
+      // one solution is to monkey patch secureContext
+      // https://medium.com/trabe/monkey-patching-tls-in-node-js-to-support-self-signed-certificates-with-custom-root-cas-25c7396dfd2a
       let ssl: SSLOptions = {
         key: fs.readFileSync(
           paths.ssl.keyFile

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -1,8 +1,13 @@
+import type { ServerOptions as SSLOptions } from 'https';
+import type { AddressInfo } from 'net';
+import type { Service } from './interfaces';
 import { Operation, once, Resource, spawn } from 'effection';
 import { Request, Response, Application } from 'express';
-
-import type { Server as HTTPServer } from 'http';
-import type { AddressInfo } from 'net';
+import { createServer as createHttpsServer } from 'https';
+import { Server as HTTPServer, createServer as createHttpServer } from 'http';
+import { paths } from './config/paths';
+import fs from 'fs';
+import { mkcertText, NoSSLError } from './errors/ssl/ssl-error';
 
 export interface Server {
   http: HTTPServer;
@@ -10,19 +15,45 @@ export interface Server {
 }
 
 export interface ServerOptions {
-  port?: number
+  port?: number;
+  protocol: Service['protocol'];
 }
 
-export function createServer(app: Application, options: ServerOptions = {}): Resource<Server> {
+
+const createAppServer = (app: Application, options: ServerOptions) => {
+  switch(options.protocol) {
+    case 'http':
+      return createHttpServer(app);
+    case 'https':
+      if([paths.ssl.keyFile, paths.ssl.pemFile].some(f => !fs.existsSync(f))){
+        console.warn(mkcertText);
+
+        throw new NoSSLError('no self signed certificate.');
+      }
+
+      let ssl: SSLOptions = {
+        key: fs.readFileSync(
+          paths.ssl.keyFile
+        ),
+        cert: fs.readFileSync(paths.ssl.pemFile),
+      } as const;
+
+      return createHttpsServer(ssl, app);
+  }
+};
+
+export function createServer(app: Application, options: ServerOptions): Resource<Server> {
   return {
     *init() {
 
-      let server = app.listen(options.port);
+      let server = createAppServer(app, options);
 
       yield spawn(function*() {
         let error: Error = yield once(server, 'error');
         throw error;
       });
+
+      server.listen(options.port);
 
       yield spawn(function*() {
         try {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -34,7 +34,7 @@ export function createSimulationServer(options: ServerOptions = { simulators: {}
         .use(express.static(appDir()))
         .use('/', graphqlHTTP({ schema, context }));
 
-      let server = yield createServer(app, { port });
+      let server = yield createServer(app, { protocol: 'http', port });
 
       yield createWebSocketTransport(context, server.http);
 

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -37,10 +37,12 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
           });
         }
 
+        let { protocol } = service;
+
         return {
           name,
-          protocol: service.protocol,
-          create: createServer(app)
+          protocol,
+          create: createServer(app, { protocol })
         };
       });
 

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -10,6 +10,12 @@ import { ServerOptions } from '../src/interfaces';
 
 import { createTestServer } from './helpers';
 
+// mkcert does not generate a fullchain certificate
+// https://github.com/FiloSottile/mkcert/issues/76
+// There are a number of ways around this that we should probably handle when scripting the ssl setup
+// NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem" works also
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 describe('@simulacrum/server', () => {
   let simulation: Simulation;
   let client: Client;
@@ -28,9 +34,9 @@ describe('@simulacrum/server', () => {
                 protocol: 'http',
                 app: app(times)
               },
-              ["echo.too"]: {
-                protocol: 'http',
-                app:  app(times)
+              ["echo.secure"]: {
+                protocol: 'https',
+                app: app(times)
               },
 
             },
@@ -53,15 +59,31 @@ describe('@simulacrum/server', () => {
     it('has the echo service', function* () {
       expect(simulation.services).toEqual([
         { name: 'echo', url: expect.stringMatching('http://localhost') },
-        { name: 'echo.too', url: expect.stringMatching('http://localhost') }
+        { name: 'echo.secure', url: expect.stringMatching('https://localhost') }
       ]);
     });
 
-    describe('posting to the echo service', () => {
+    describe('posting to the http echo service', () => {
       let body: string;
 
       beforeEach(function*() {
         let [{ url }] = simulation.services;
+
+        let response = yield fetch(url.toString(), { method: 'POST', body: "hello world" });
+        expect(response.ok).toEqual(true);
+        body = yield response.text();
+      });
+
+      it('gives you back what you gave it', function*() {
+        expect(body).toEqual("hello world");
+      });
+    });
+
+    describe('posting to the https echo service', () => {
+      let body: string;
+
+      beforeEach(function*() {
+        let [, { url }] = simulation.services;
 
         let response = yield fetch(url.toString(), { method: 'POST', body: "hello world" });
         expect(response.ok).toEqual(true);

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -10,12 +10,6 @@ import { ServerOptions } from '../src/interfaces';
 
 import { createTestServer } from './helpers';
 
-// mkcert does not generate a fullchain certificate
-// https://github.com/FiloSottile/mkcert/issues/76
-// There are a number of ways around this that we should probably handle when scripting the ssl setup
-// NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem" works also
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 describe('@simulacrum/server', () => {
   let simulation: Simulation;
   let client: Client;

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -25,3 +25,30 @@ Server running at http://localhost:1234
 You can now connect to the server with the following url:
 
 http://localhost:1234?server=http://localhost:5000
+
+### running https services from localhost
+
+In order to run an https service from localhost you need locally-trusted development certificates.
+
+[mkcert](https://github.com/FiloSottile/mkcert) makes this pretty easy:
+
+```bash
+brew install mkcert
+brew install nss  # for firefox
+
+mkdir -p ~/.simulacrum/certificates
+cd ~/.simulacrum/certificates
+
+mkcert -install   # Created a new local CA at the location returned from mkcert -CAROOT
+mkcert localhost  # Using the local CA at CAROOT, create a new certificate valid for the following names
+```
+
+To uninstall the certificates
+
+```bash
+cd ~/.simulacrum/certs
+mkcert -uninstall localhost
+mkcert -uninstall 
+rm -rf "$(mkcert -CAROOT)/*"
+mkcert localhost
+```


### PR DESCRIPTION
## Motivation

Another chunk of the auth0 branch that provides a means to create HTTPS services.

## Approach

In order for localhost to run under https, there needs to be locally trusted development certificates.

I've made heavy use of [mkcert ](https://github.com/FiloSottile/mkcert) as it is very easy to use.

The code is expecting the certificates to be in a specified location (`~/.simulacrum/certs').

We definitely want to script this if possible although it does require sudo privileges but I think that deserves a PR all on its own.

### Alternate Designs

We want to allow the certificates location to be configurable and I had an interactive `init` command on the other simulator where users could specify a different configuration or accept the defaults and a config file was written.

### Possible Drawbacks or Risks

What do we think is the the best way of running this in CI?  Should we install mkcert as part of the github action?