### PR TITLE
allow normal express middleware to be added as well as operations

### DIFF
--- a/packages/server/src/guards/guards.ts
+++ b/packages/server/src/guards/guards.ts
@@ -1,0 +1,14 @@
+import { RequestHandler } from 'express';
+import type { Middleware } from '../http';
+
+export function isGeneratorFunction(value: unknown): value is GeneratorFunction {
+  return /\[object Generator|GeneratorFunction\]/.test(Object.prototype.toString.call(value));
+}
+
+export function middlewareHandlerIsOperation(value: unknown): value is Middleware {
+  return isGeneratorFunction(value);
+}
+
+export function isRequestHandler(value: unknown): value is RequestHandler {
+  return isGeneratorFunction(value) === false && typeof value === 'function';
+}

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -2,7 +2,7 @@ import type { ServerOptions as SSLOptions } from 'https';
 import type { AddressInfo } from 'net';
 import type { Service } from './interfaces';
 import { Operation, once, Resource, spawn } from 'effection';
-import { Request, Response, Application } from 'express';
+import { Request, Response, Application, RequestHandler } from 'express';
 import { createServer as createHttpsServer } from 'https';
 import { Server as HTTPServer, createServer as createHttpServer } from 'http';
 import { paths } from './config/paths';
@@ -93,19 +93,19 @@ export interface Middleware {
 
 export interface HttpApp {
   handlers: RouteHandler[];
-  middleware: Middleware[];
+  middleware: (Middleware | RequestHandler)[];
   get(path: string, handler: HttpHandler): HttpApp;
   put(path: string, handler: HttpHandler): HttpApp;
   post(path: string, handler: HttpHandler): HttpApp;
-  use(middleware: Middleware): HttpApp;
+  use(middleware: Middleware | RequestHandler): HttpApp;
 }
 
-export function createHttpApp(handlers: RouteHandler[] = [], middleware: Middleware[] = []): HttpApp {
+export function createHttpApp(handlers: RouteHandler[] = [], middleware: (Middleware | RequestHandler)[] = []): HttpApp {
   function appendHandler(routeHandler: RouteHandler) {
     return createHttpApp(handlers.concat(routeHandler), middleware);
   }
 
-  function appendMiddleware(middlewareHandler: Middleware) {
+  function appendMiddleware(middlewareHandler: Middleware | RequestHandler) {
     return createHttpApp(handlers, middleware.concat(middlewareHandler));
   }
 

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -20,7 +20,15 @@ describe('@simulacrum/server', () => {
       calls.push('one');
     }).use(function* () {
       calls.push('two');
-    }).post('/', echo(times));
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .use(function(_, __, next) {
+      calls.push('three');
+
+      next();
+    })
+    .post('/', echo(times));
+
 
   beforeEach(function* () {
     client = yield createTestServer({
@@ -81,7 +89,7 @@ describe('@simulacrum/server', () => {
 
     describe('middleware', () => {
       it('should add middleware handlers', function* () {
-        expect(calls).toEqual(['one', 'two']);
+        expect(calls).toEqual(['one', 'two', 'three']);
       });
     });
 


### PR DESCRIPTION
## Motivation

The last middleware PR added a means to add middleware functions that were operations:

```ts
reateHttpApp()
    .use(function* () {
      // etc
    })
```    

This makes adding regular 3rd party middleware like [cors](https://github.com/expressjs/cors) difficult.

## Approach

middleware that is either a regular express `RequestHandler` function or an operation can now be added:

```ts
createHttpApp()
    .use(function* () {
      // operation
    })
    .use(function(req, res, next) {
      // regular function
    })
```