### PR TITLE
add a static port to simulator options

### DIFF
--- a/.changes/port.md
+++ b/.changes/port.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": minor
+---
+
+Allow an optional port field in the options argument of createSimulation.

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -41,12 +41,14 @@ export interface ServerState {
   simulations: Record<string, SimulationState>;
 }
 
+export type SimulationOptions = { port?: number } & Omit<Record<string, unknown>, 'port'>;
+
 export type SimulationState =
   {
     id: string;
     status: 'new',
     simulator: string,
-    options: Record<string, unknown>;
+    options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
   } |
@@ -54,7 +56,7 @@ export type SimulationState =
     id: string,
     status: 'running',
     simulator: string,
-    options: Record<string, unknown>;
+    options: SimulationOptions;
     services: {
       name: string;
       url: string;
@@ -66,7 +68,7 @@ export type SimulationState =
     id: string,
     status: 'failed',
     simulator: string,
-    options: Record<string, unknown>;
+    options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
     error: Error

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { SimulationState, ScenarioState, ServerState } from "../interfaces";
+import { SimulationState, ScenarioState, ServerState, SimulationOptions } from "../interfaces";
 import { OperationContext } from "./context";
 import { createQueue } from '../queue';
 
@@ -16,7 +16,7 @@ export interface Subscriber<Args, TEach, Result = TEach> {
 
 export interface CreateSimulationParameters {
   simulator: string;
-  options?: Record<string, unknown>;
+  options?: SimulationOptions;
 }
 
 export const createSimulation: Resolver<CreateSimulationParameters, SimulationState> = {

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -61,7 +61,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
         return {
           name,
           protocol,
-          create: createServer(app, { protocol })
+          create: createServer(app, { protocol, port: options.port })
         };
       });
 

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -148,6 +148,33 @@ hello world`);
     });
   });
 
+  describe('creating a simulator with static port', () => {
+    let client: Client;
+    let simulation: Simulation;
+    let options: ServerOptions = {
+      simulators: {
+        static: () => ({ services: {
+          static: {
+            protocol: 'http',
+            app: createHttpApp()
+          }
+        }, scenarios: {} })
+      }
+    };
+
+    beforeEach(function*() {
+      client = yield createTestServer(options);
+
+      simulation = yield client.createSimulation("static", { port: 3300 });
+    });
+
+    it('creates simulations with the same uuid', function*() {
+      let [{ url }] = simulation.services;
+
+      expect(url).toBe('http://localhost:3300');
+    });
+  });
+
   describe('creating two servers with the same seed', () => {
     let one: Client;
     let two: Client;
@@ -174,3 +201,6 @@ hello world`);
     });
   });
 });
+
+
+


### PR DESCRIPTION
## Motivation

At the moment, simulator http servers get a random port each time they are created which makes development painful.

## Approach

The `options` parameter of `createSimulation` is a pretty loose type to keep it generic.

This PR allows an optional `port` property to be added to the options hash.  If no port field exists then a random port is assigned.

```ts
export type SimulationOptions = { port?: number } & Omit<Record<string, unknown>, 'port'>;

export interface CreateSimulationParameters {
  simulator: string;
  options?: SimulationOptions;
}

simulation = yield client.createSimulation("static", { port: 3300 });
```
