### PR TITLE
A static port can be assigned to a service from the control API.

### DIFF
--- a/.changes/port.md
+++ b/.changes/port.md
@@ -2,4 +2,4 @@
 "@simulacrum/server": minor
 ---
 
-Allow an optional port field in the options argument of createSimulation.
+a `services` field added to the `createSimulation` options argument where a port can be assigned.

--- a/.changes/port.md
+++ b/.changes/port.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": minor
+---
+
+Allow an optional port field in the options argument of createSimulation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6724,6 +6724,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -16831,6 +16832,7 @@
         "@types/ws": "^7.4.0",
         "cross-fetch": "^3.1.0",
         "expect": "^26.6.2",
+        "get-port": "^5.1.1",
         "mocha": "^8.0.0",
         "rimraf": "^3.0.2",
         "ts-node": "^9.1.1",
@@ -22195,7 +22197,8 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,8 +3,15 @@ import { createClient as createWSClient, SubscribePayload } from 'graphql-ws';
 import webSocketImpl from 'isomorphic-ws';
 import { GraphQLError } from 'graphql';
 
+export interface SimulationOptions {
+  options?: Record<string, unknown>;
+  services?: Record<string,{
+    port?: number
+  }>
+}
+
 export interface Client {
-  createSimulation(simulator: string, options?: Record<string, unknown>): Promise<Simulation>;
+  createSimulation(simulator: string, options?: SimulationOptions): Promise<Simulation>;
   destroySimulation(simulation: Simulation): Promise<boolean>;
   given(simulation: Simulation, scenario: string, params?: Record<string, unknown>): Promise<Scenario>;
   state<T>(): AsyncIterable<T> & AsyncIterator<T>;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -60,6 +60,7 @@
     "@types/ws": "^7.4.0",
     "cross-fetch": "^3.1.0",
     "expect": "^26.6.2",
+    "get-port": "^5.1.1",
     "mocha": "^8.0.0",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -41,7 +41,12 @@ export interface ServerState {
   simulations: Record<string, SimulationState>;
 }
 
-export type SimulationOptions = { port?: number } & Omit<Record<string, unknown>, 'port'>;
+export interface SimulationOptions {
+  options?: Record<string, unknown>;
+  services?: Record<string, {
+    port?: number
+  }>
+}
 
 export type SimulationState =
   {

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -41,12 +41,14 @@ export interface ServerState {
   simulations: Record<string, SimulationState>;
 }
 
+export type SimulationOptions = { port?: number } & Omit<Record<string, unknown>, 'port'>;
+
 export type SimulationState =
   {
     id: string;
     status: 'new',
     simulator: string,
-    options: Record<string, unknown>;
+    options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
   } |
@@ -54,7 +56,7 @@ export type SimulationState =
     id: string,
     status: 'running',
     simulator: string,
-    options: Record<string, unknown>;
+    options: SimulationOptions;
     services: {
       name: string;
       url: string;
@@ -66,7 +68,7 @@ export type SimulationState =
     id: string,
     status: 'failed',
     simulator: string,
-    options: Record<string, unknown>;
+    options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
     error: Error

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { SimulationState, ScenarioState, ServerState } from "../interfaces";
+import { SimulationState, ScenarioState, ServerState, SimulationOptions } from "../interfaces";
 import { OperationContext } from "./context";
 import { createQueue } from '../queue';
 
@@ -16,7 +16,7 @@ export interface Subscriber<Args, TEach, Result = TEach> {
 
 export interface CreateSimulationParameters {
   simulator: string;
-  options?: Record<string, unknown>;
+  options?: SimulationOptions;
 }
 
 export const createSimulation: Resolver<CreateSimulationParameters, SimulationState> = {

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -61,7 +61,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
         return {
           name,
           protocol,
-          create: createServer(app, { protocol })
+          create: createServer(app, { protocol, port: options.port })
         };
       });
 

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -14,7 +14,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       let simulatorName = slice.get().simulator;
       let simulator = simulators[simulatorName];
       assert(simulator, `unknown simulator ${simulatorName}`);
-      let options = slice.get().options;
+      let { options = {}, services: serviceOptions = {} } = slice.get().options;
 
       let behaviors = simulator(slice, options);
 
@@ -61,7 +61,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
         return {
           name,
           protocol,
-          create: createServer(app, { protocol, port: options.port })
+          create: createServer(app, { protocol, port: serviceOptions[name]?.port })
         };
       });
 

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -148,6 +148,33 @@ hello world`);
     });
   });
 
+  describe('creating a simulator with static port', () => {
+    let client: Client;
+    let simulation: Simulation;
+    let options: ServerOptions = {
+      simulators: {
+        static: () => ({ services: {
+          static: {
+            protocol: 'http',
+            app: createHttpApp()
+          }
+        }, scenarios: {} })
+      }
+    };
+
+    beforeEach(function*() {
+      client = yield createTestServer(options);
+
+      simulation = yield client.createSimulation("static", { port: 3300 });
+    });
+
+    it('creates simulations with the same uuid', function*() {
+      let [{ url }] = simulation.services;
+
+      expect(url).toBe('http://localhost:3300');
+    });
+  });
+
   describe('creating two servers with the same seed', () => {
     let one: Client;
     let two: Client;
@@ -174,3 +201,6 @@ hello world`);
     });
   });
 });
+
+
+

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -3,6 +3,7 @@ import { Client, Simulation } from '@simulacrum/client';
 import { assert } from 'assert-ts';
 import fetch from 'cross-fetch';
 import expect from 'expect';
+import getPort from 'get-port';
 
 import { echo } from '../src/echo';
 import { createHttpApp } from '../src/http';
@@ -130,11 +131,22 @@ describe('@simulacrum/server', () => {
   describe('createSimulation() with parameters', () => {
     let response: Response;
     let body: string;
+    let serviceUrl: string;
+    let port: number;
     beforeEach(function*() {
-      simulation = yield client.createSimulation("echo", {
+      port = yield getPort();
+
+      expect(port).toBeDefined();
+
+      simulation = yield client.createSimulation("echo", { options: {
         times: 3
-      });
+      }, services: {
+        echo: {
+          port
+        }
+      } });
       let [{ url }] = simulation.services;
+      serviceUrl = url;
       response = yield fetch(url.toString(), { method: 'POST', body: "hello world" });
       expect(response.ok).toBe(true);
       body = yield response.text();
@@ -145,6 +157,10 @@ describe('@simulacrum/server', () => {
         `hello world
 hello world
 hello world`);
+    });
+
+    it('assigns a static port to the service', function* () {
+      expect(serviceUrl).toBe(`http://localhost:${port}`);
     });
   });
 
@@ -165,7 +181,7 @@ hello world`);
     beforeEach(function*() {
       client = yield createTestServer(options);
 
-      simulation = yield client.createSimulation("static", { port: 3300 });
+      simulation = yield client.createSimulation("static", { services: { static: { port: 3300 } } });
     });
 
     it('creates simulations with the same uuid', function*() {


### PR DESCRIPTION
## Motivation

Following on from #79, this PR tackles the problem of assigning a static port to a service.

## Approach

The `createSimulation` options argument now takes a `services` field , e.g.

```ts
const simulation = yield client.createSimulation("echo", { options: {
  times: 3
}, services: {
  echo: {
    port: 3300
  }
} });
```