### PR TITLE
Add openid endpoints `/.well-known/jwks.json` and `/.well-known/openid-cofiguration`.

### DIFF
--- a/.changes/openid.md
+++ b/.changes/openid.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/auth0": minor
+---
+
+Add openid endpoints `/.well-known/jwks.json` and `/.well-known/openid-cofiguration`.

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -9,6 +9,7 @@ import { decode, encode } from "base64-url";
 import { userNamePasswordForm } from '../views/username-password';
 import { expiresAt } from '../auth/date';
 import { createAuthJWT, createJsonWebToken } from '../auth/jwt';
+import { getSericeUrl } from './get-service-url';
 
 export type Routes =
   | '/heartbeat'
@@ -18,7 +19,7 @@ export type Routes =
   | '/login/callback'
   | '/oauth/token'
 
-  type Predicate<T> = (this: void, value: [string, T], index: number, obj: [string, T][]) => boolean;
+type Predicate<T> = (this: void, value: [string, T], index: number, obj: [string, T][]) => boolean;
 
 const getServiceUrlFromOptions = (options: Options) => {
   let service = options.services.get().find(({ name }) => name === 'auth0' );
@@ -70,10 +71,7 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
     ['/login']: function* (req, res) {
       let { redirect_uri } = req.query as QueryParams;
 
-      let service = options.services.get().find(({ name }) => name === 'auth0' );
-      assert(!!service, `did not find auth0 service in set of running services`);
-
-      let url = new URL(service.url);
+      let url = getSericeUrl(options);
 
       assert(!!clientId, `no clientId assigned`);
 

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -9,7 +9,7 @@ import { decode, encode } from "base64-url";
 import { userNamePasswordForm } from '../views/username-password';
 import { expiresAt } from '../auth/date';
 import { createAuthJWT, createJsonWebToken } from '../auth/jwt';
-import { getSericeUrl } from './get-service-url';
+import { getServiceUrl } from './get-service-url';
 
 export type Routes =
   | '/heartbeat'
@@ -71,7 +71,7 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
     ['/login']: function* (req, res) {
       let { redirect_uri } = req.query as QueryParams;
 
-      let url = getSericeUrl(options);
+      let url = getServiceUrl(options);
 
       assert(!!clientId, `no clientId assigned`);
 

--- a/packages/auth0/src/handlers/get-service-url.ts
+++ b/packages/auth0/src/handlers/get-service-url.ts
@@ -1,7 +1,7 @@
 import { Options } from '../types';
 import { assert } from 'assert-ts';
 
-export const getSericeUrl = (options: Options): URL => {
+export const getServiceUrl = (options: Options): URL => {
   let service = options.services.get().find(({ name }) => name === 'auth0' );
 
   assert(!!service, `did not find auth0 service in set of running services`);

--- a/packages/auth0/src/handlers/get-service-url.ts
+++ b/packages/auth0/src/handlers/get-service-url.ts
@@ -1,0 +1,10 @@
+import { Options } from '../types';
+import { assert } from 'assert-ts';
+
+export const getSericeUrl = (options: Options): URL => {
+  let service = options.services.get().find(({ name }) => name === 'auth0' );
+
+  assert(!!service, `did not find auth0 service in set of running services`);
+
+  return new URL(service.url);
+};

--- a/packages/auth0/src/handlers/openid-handlers.ts
+++ b/packages/auth0/src/handlers/openid-handlers.ts
@@ -1,0 +1,30 @@
+import type { HttpHandler } from '@simulacrum/server';
+import { Options } from 'src/types';
+import { JWKS } from '../auth/constants';
+import { getSericeUrl } from './get-service-url';
+
+type Routes =
+  | '/jwks.json'
+  | '/openid-cofiguration'
+
+export type OpenIdRoutes = `${`/.well-known`}${Routes}`
+
+export const createOpenIdHandlers = (options: Options): Record<OpenIdRoutes, HttpHandler> => {
+  return {
+    ['/.well-known/jwks.json']: function* (_, res) {
+      res.json(JWKS);
+    },
+
+    ['/.well-known/openid-cofiguration']: function* (_, res) {
+      let url = getSericeUrl(options).toString().replace(/\/$/, '');
+
+      res.json({
+        issuer: url,
+        authorization_endpoint: [url, "authorize"].join('/'),
+        token_endpoint: [url, "oauth", "token"].join('/'),
+        userinfo_endpoint: [url, "userinfo"].join('/'),
+        jwks_uri: [url, ".well-known", "jwks.json"].join('/'),
+      });
+    }
+  };
+};

--- a/packages/auth0/src/handlers/openid-handlers.ts
+++ b/packages/auth0/src/handlers/openid-handlers.ts
@@ -1,7 +1,7 @@
 import type { HttpHandler } from '@simulacrum/server';
 import { Options } from 'src/types';
 import { JWKS } from '../auth/constants';
-import { getSericeUrl } from './get-service-url';
+import { getServiceUrl } from './get-service-url';
 
 type Routes =
   | '/jwks.json'
@@ -16,7 +16,7 @@ export const createOpenIdHandlers = (options: Options): Record<OpenIdRoutes, Htt
     },
 
     ['/.well-known/openid-cofiguration']: function* (_, res) {
-      let url = getSericeUrl(options).toString().replace(/\/$/, '');
+      let url = getServiceUrl(options).toString().replace(/\/$/, '');
 
       res.json({
         issuer: url,

--- a/packages/auth0/test/openid-handlers.test.ts
+++ b/packages/auth0/test/openid-handlers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, beforeEach } from '@effection/mocha';
+import expect from 'expect';
+import { createTestServer, Client, Simulation } from './helpers';
+import { auth0 } from '../src';
+import fetch from 'cross-fetch';
+import { JWKS } from '../src/auth/constants';
+
+describe('openid routes', () => {
+  let client: Client;
+  let auth0Url: string;
+
+  beforeEach(function*() {
+    client = yield createTestServer({
+      simulators: {
+        auth0
+      }
+    });
+  });
+
+  describe('/.well-known/*', () => {
+    beforeEach(function*() {
+      let simulation: Simulation = yield client.createSimulation("auth0");
+
+      auth0Url = simulation.services[0].url;
+    });
+
+    it('returns the JWKS keys', function *() {
+      let res: Response = yield fetch(`${auth0Url}/.well-known/jwks.json`);
+
+      let json: typeof JWKS = yield res.json();
+
+      expect(res.ok).toBe(true);
+
+      expect(json).toEqual(JWKS);
+    });
+
+    it('returns the openid configuration', function * () {
+      let res: Response = yield fetch(`${auth0Url}/.well-known/openid-cofiguration`);
+
+      let json: { token_endpoint: string } = yield res.json();
+
+      expect(res.ok).toBe(true);
+
+      expect(json.token_endpoint).toContain('/oauth/token');
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

This PR adds handlers for
 - `/.well-known/jwks.json`  This endpoint will contain the JWK used to sign all Auth0-issued JWTs for this tenant.
 - `/.well-known/openid-cofiguration` Returns the OpenID Connect configuration values from the provider's Well-Known Configuration Endpoint, per the [specification](http://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest).

## Approach

A constants file with a fake generated JWKS key is returned from the `jwks.json` handler.

For `/.well-known/openid-cofiguration` the service URL is appended to the relevant JSON object fields as per openid spec:

```ts
let url = getSericeUrl(options).toString().replace(/\/$/, '');

res.json({
  issuer: url,
  authorization_endpoint: [url, "authorize"].join('/'),
  token_endpoint: [url, "oauth", "token"].join('/'),
  userinfo_endpoint: [url, "userinfo"].join('/'),
  jwks_uri: [url, ".well-known", "jwks.json"].join('/'),
});
```
