### PR TITLE
add atom dependency to auth0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -451,6 +451,48 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "node_modules/@effection/atom": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/atom/-/atom-2.0.0-beta.3.tgz",
+      "integrity": "sha512-mrwyskp1XQe3ggs2rJaV21URluQkew0UcqY3ErOWAiVeeVBJtQkvNTFgrXv3av61AEr3M4SopQFfMPW8vo6Xwg==",
+      "dependencies": {
+        "@effection/channel": "2.0.0-beta.3",
+        "@effection/core": "2.0.0-beta.3",
+        "@effection/subscription": "2.0.0-beta.3",
+        "assert-ts": "^0.2.2",
+        "fp-ts": "^2.8.2",
+        "monocle-ts": "^2.3.3"
+      }
+    },
+    "node_modules/@effection/atom/node_modules/assert-ts": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.2.2.tgz",
+      "integrity": "sha512-aoktTqvPejI9G0+wNOomh44acAJ/KMp4YAw5yW3tM1MESxEBuAlWdBG3Q9QGV6YMv7pEfzor8822B5WinXcmPg=="
+    },
+    "node_modules/@effection/channel": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
+      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
+      "dependencies": {
+        "@effection/core": "2.0.0-beta.3",
+        "@effection/events": "2.0.0-beta.3",
+        "@effection/subscription": "2.0.0-beta.3"
+      }
+    },
+    "node_modules/@effection/core": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
+      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
+    },
+    "node_modules/@effection/events": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
+      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
+      "dependencies": {
+        "@effection/core": "2.0.0-beta.3",
+        "@effection/subscription": "2.0.0-beta.3"
+      }
+    },
     "node_modules/@effection/main": {
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.3.tgz",
@@ -460,11 +502,6 @@
         "chalk": "^4.1.1",
         "stacktrace-parser": "^0.1.10"
       }
-    },
-    "node_modules/@effection/main/node_modules/@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
     },
     "node_modules/@effection/process": {
       "version": "2.0.0-beta.3",
@@ -478,38 +515,6 @@
         "cross-spawn": "^7.0.3",
         "ctrlc-windows": "^2.0.0",
         "shellwords": "^0.1.1"
-      }
-    },
-    "node_modules/@effection/process/node_modules/@effection/channel": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
-      "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
-      }
-    },
-    "node_modules/@effection/process/node_modules/@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
-    },
-    "node_modules/@effection/process/node_modules/@effection/events": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
-      "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
-      }
-    },
-    "node_modules/@effection/process/node_modules/@effection/subscription": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
-      "dependencies": {
-        "@effection/core": "2.0.0-beta.3"
       }
     },
     "node_modules/@effection/process/node_modules/ctrlc-windows": {
@@ -547,6 +552,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@effection/subscription": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
+      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
+      "dependencies": {
+        "@effection/core": "2.0.0-beta.3"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -5492,38 +5505,6 @@
         "@effection/events": "2.0.0-beta.3",
         "@effection/main": "2.0.0-beta.3",
         "@effection/subscription": "2.0.0-beta.3"
-      }
-    },
-    "node_modules/effection/node_modules/@effection/channel": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
-      "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
-      }
-    },
-    "node_modules/effection/node_modules/@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
-    },
-    "node_modules/effection/node_modules/@effection/events": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
-      "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
-      }
-    },
-    "node_modules/effection/node_modules/@effection/subscription": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
-      "dependencies": {
-        "@effection/core": "2.0.0-beta.3"
       }
     },
     "node_modules/ejs": {
@@ -17044,6 +17025,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@effection/atom": "^2.0.0-beta.3",
         "@effection/process": "^2.0.0-beta.3",
         "@simulacrum/server": "0.2.0",
         "@types/faker": "^5.1.7",
@@ -17631,6 +17613,50 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@effection/atom": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/atom/-/atom-2.0.0-beta.3.tgz",
+      "integrity": "sha512-mrwyskp1XQe3ggs2rJaV21URluQkew0UcqY3ErOWAiVeeVBJtQkvNTFgrXv3av61AEr3M4SopQFfMPW8vo6Xwg==",
+      "requires": {
+        "@effection/channel": "2.0.0-beta.3",
+        "@effection/core": "2.0.0-beta.3",
+        "@effection/subscription": "2.0.0-beta.3",
+        "assert-ts": "^0.2.2",
+        "fp-ts": "^2.8.2",
+        "monocle-ts": "^2.3.3"
+      },
+      "dependencies": {
+        "assert-ts": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.2.2.tgz",
+          "integrity": "sha512-aoktTqvPejI9G0+wNOomh44acAJ/KMp4YAw5yW3tM1MESxEBuAlWdBG3Q9QGV6YMv7pEfzor8822B5WinXcmPg=="
+        }
+      }
+    },
+    "@effection/channel": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
+      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
+      "requires": {
+        "@effection/core": "2.0.0-beta.3",
+        "@effection/events": "2.0.0-beta.3",
+        "@effection/subscription": "2.0.0-beta.3"
+      }
+    },
+    "@effection/core": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
+      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
+    },
+    "@effection/events": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
+      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
+      "requires": {
+        "@effection/core": "2.0.0-beta.3",
+        "@effection/subscription": "2.0.0-beta.3"
+      }
+    },
     "@effection/main": {
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.3.tgz",
@@ -17639,13 +17665,6 @@
         "@effection/core": "2.0.0-beta.3",
         "chalk": "^4.1.1",
         "stacktrace-parser": "^0.1.10"
-      },
-      "dependencies": {
-        "@effection/core": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-          "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
-        }
       }
     },
     "@effection/process": {
@@ -17662,38 +17681,6 @@
         "shellwords": "^0.1.1"
       },
       "dependencies": {
-        "@effection/channel": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-          "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
-          "requires": {
-            "@effection/core": "2.0.0-beta.3",
-            "@effection/events": "2.0.0-beta.3",
-            "@effection/subscription": "2.0.0-beta.3"
-          }
-        },
-        "@effection/core": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-          "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
-        },
-        "@effection/events": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-          "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
-          "requires": {
-            "@effection/core": "2.0.0-beta.3",
-            "@effection/subscription": "2.0.0-beta.3"
-          }
-        },
-        "@effection/subscription": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-          "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
-          "requires": {
-            "@effection/core": "2.0.0-beta.3"
-          }
-        },
         "ctrlc-windows": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ctrlc-windows/-/ctrlc-windows-2.0.0.tgz",
@@ -17724,6 +17711,14 @@
             "validate-npm-package-name": "^3.0.0"
           }
         }
+      }
+    },
+    "@effection/subscription": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
+      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
+      "requires": {
+        "@effection/core": "2.0.0-beta.3"
       }
     },
     "@eslint/eslintrc": {
@@ -18833,6 +18828,7 @@
     "@simulacrum/auth0": {
       "version": "file:packages/auth0",
       "requires": {
+        "@effection/atom": "^2.0.0-beta.3",
         "@effection/mocha": "^2.0.0-beta.3",
         "@effection/process": "^2.0.0-beta.3",
         "@frontside/eslint-config": "^2.0.0",
@@ -21730,40 +21726,6 @@
         "@effection/events": "2.0.0-beta.3",
         "@effection/main": "2.0.0-beta.3",
         "@effection/subscription": "2.0.0-beta.3"
-      },
-      "dependencies": {
-        "@effection/channel": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-          "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
-          "requires": {
-            "@effection/core": "2.0.0-beta.3",
-            "@effection/events": "2.0.0-beta.3",
-            "@effection/subscription": "2.0.0-beta.3"
-          }
-        },
-        "@effection/core": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-          "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
-        },
-        "@effection/events": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-          "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
-          "requires": {
-            "@effection/core": "2.0.0-beta.3",
-            "@effection/subscription": "2.0.0-beta.3"
-          }
-        },
-        "@effection/subscription": {
-          "version": "2.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-          "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
-          "requires": {
-            "@effection/core": "2.0.0-beta.3"
-          }
-        }
       }
     },
     "ejs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -455,6 +455,7 @@
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@effection/atom/-/atom-2.0.0-beta.3.tgz",
       "integrity": "sha512-mrwyskp1XQe3ggs2rJaV21URluQkew0UcqY3ErOWAiVeeVBJtQkvNTFgrXv3av61AEr3M4SopQFfMPW8vo6Xwg==",
+      "dev": true,
       "dependencies": {
         "@effection/channel": "2.0.0-beta.3",
         "@effection/core": "2.0.0-beta.3",
@@ -467,7 +468,8 @@
     "node_modules/@effection/atom/node_modules/assert-ts": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.2.2.tgz",
-      "integrity": "sha512-aoktTqvPejI9G0+wNOomh44acAJ/KMp4YAw5yW3tM1MESxEBuAlWdBG3Q9QGV6YMv7pEfzor8822B5WinXcmPg=="
+      "integrity": "sha512-aoktTqvPejI9G0+wNOomh44acAJ/KMp4YAw5yW3tM1MESxEBuAlWdBG3Q9QGV6YMv7pEfzor8822B5WinXcmPg==",
+      "dev": true
     },
     "node_modules/@effection/channel": {
       "version": "2.0.0-beta.3",
@@ -17025,7 +17027,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@effection/atom": "^2.0.0-beta.3",
         "@effection/process": "^2.0.0-beta.3",
         "@simulacrum/server": "0.2.0",
         "@types/faker": "^5.1.7",
@@ -17038,6 +17039,7 @@
         "jsonwebtoken": "^8.5.1"
       },
       "devDependencies": {
+        "@effection/atom": "^2.0.0-beta.3",
         "@effection/mocha": "^2.0.0-beta.3",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
@@ -17617,6 +17619,7 @@
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@effection/atom/-/atom-2.0.0-beta.3.tgz",
       "integrity": "sha512-mrwyskp1XQe3ggs2rJaV21URluQkew0UcqY3ErOWAiVeeVBJtQkvNTFgrXv3av61AEr3M4SopQFfMPW8vo6Xwg==",
+      "dev": true,
       "requires": {
         "@effection/channel": "2.0.0-beta.3",
         "@effection/core": "2.0.0-beta.3",
@@ -17629,7 +17632,8 @@
         "assert-ts": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.2.2.tgz",
-          "integrity": "sha512-aoktTqvPejI9G0+wNOomh44acAJ/KMp4YAw5yW3tM1MESxEBuAlWdBG3Q9QGV6YMv7pEfzor8822B5WinXcmPg=="
+          "integrity": "sha512-aoktTqvPejI9G0+wNOomh44acAJ/KMp4YAw5yW3tM1MESxEBuAlWdBG3Q9QGV6YMv7pEfzor8822B5WinXcmPg==",
+          "dev": true
         }
       }
     },

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
+    "@effection/atom": "^2.0.0-beta.3",
     "@effection/process": "^2.0.0-beta.3",
     "@simulacrum/server": "0.2.0",
     "@types/faker": "^5.1.7",

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
-    "@effection/atom": "^2.0.0-beta.3",
     "@effection/process": "^2.0.0-beta.3",
     "@simulacrum/server": "0.2.0",
     "@types/faker": "^5.1.7",
@@ -42,6 +41,7 @@
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
+    "@effection/atom": "^2.0.0-beta.3",
     "@effection/mocha": "^2.0.0-beta.3",
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/auth0/src/types.ts
+++ b/packages/auth0/src/types.ts
@@ -1,5 +1,5 @@
-import { SimulationState, Store } from '@simulacrum/server';
-import { Slice } from '@effection/atom';
+import type { SimulationState, Store } from '@simulacrum/server';
+import type { Slice } from '@effection/atom';
 
 export interface Options {
   scope: string;

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,5 +1,5 @@
-import { Operation } from 'effection';
-import { Slice } from '@effection/atom';
+import type { Operation } from 'effection';
+import type { Slice } from '@effection/atom';
 import type { HttpApp } from './http';
 import type { Faker } from './faker';
 


### PR DESCRIPTION
## Motivation

Building `v0` locally is failing due to the missing `@effection/atom` dependency in `@simulacrum/auth0`.

## Approach

Add the dependency to `@simulacrum/auth0`.
