### PR TITLE
fix ./well-known/openid-configuration typo

### DIFF
--- a/.changes/openid.md
+++ b/.changes/openid.md
@@ -2,4 +2,4 @@
 "@simulacrum/auth0": minor
 ---
 
-Add openid endpoints `/.well-known/jwks.json` and `/.well-known/openid-cofiguration`.
+Add openid endpoints `/.well-known/jwks.json` and `/.well-known/openid-configuration`.

--- a/packages/auth0/README.md
+++ b/packages/auth0/README.md
@@ -210,4 +210,4 @@ The following endpoints have been assigned handlers:
 - `/oauth/token`
 - `/v2/logout`
 - `/.well-known/jwks.json`
-- `/.well-known/openid-cofiguration`
+- `/.well-known/openid-configuration`

--- a/packages/auth0/src/handlers/openid-handlers.ts
+++ b/packages/auth0/src/handlers/openid-handlers.ts
@@ -5,7 +5,7 @@ import { getServiceUrl } from './get-service-url';
 
 type Routes =
   | '/jwks.json'
-  | '/openid-cofiguration'
+  | '/openid-configuration'
 
 export type OpenIdRoutes = `${`/.well-known`}${Routes}`
 
@@ -15,7 +15,7 @@ export const createOpenIdHandlers = (options: Options): Record<OpenIdRoutes, Htt
       res.json(JWKS);
     },
 
-    ['/.well-known/openid-cofiguration']: function* (_, res) {
+    ['/.well-known/openid-configuration']: function* (_, res) {
       let url = getServiceUrl(options).toString().replace(/\/$/, '');
 
       res.json({

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -39,7 +39,7 @@ const createAuth0Service = (handlers: ReturnType<typeof createAuth0Handlers> & R
           .post('/oauth/token', handlers['/oauth/token'])
           .get('/v2/logout', handlers['/v2/logout'])
           .get('/.well-known/jwks.json', handlers['/.well-known/jwks.json'])
-          .get('/.well-known/openid-cofiguration', handlers['/.well-known/openid-cofiguration'])
+          .get('/.well-known/openid-configuration', handlers['/.well-known/openid-configuration'])
 
   } as const;
 };

--- a/packages/auth0/test/openid-handlers.test.ts
+++ b/packages/auth0/test/openid-handlers.test.ts
@@ -35,7 +35,7 @@ describe('openid routes', () => {
     });
 
     it('returns the openid configuration', function * () {
-      let res: Response = yield fetch(`${auth0Url}/.well-known/openid-cofiguration`);
+      let res: Response = yield fetch(`${auth0Url}/.well-known/openid-configuration`);
 
       let json: { token_endpoint: string } = yield res.json();
 


### PR DESCRIPTION
## Motivation

I had a typo in `/.well-known/openid-configuration` that I must have copied and pasted across the codebase.

## Approach

fix it.
