### PR TITLE
add console.error in catch handlers

### DIFF
--- a/.changes/error.md
+++ b/.changes/error.md
@@ -1,3 +1,5 @@
 ---
 "@simulacrum/auth0-simulator": patch
 ---
+Add a `debug` option to server that will log errors when
+createSimulation() fails

--- a/.changes/error.md
+++ b/.changes/error.md
@@ -1,0 +1,3 @@
+---
+"@simulacrum/auth0": patch
+---

--- a/.changes/error.md
+++ b/.changes/error.md
@@ -1,3 +1,3 @@
 ---
-"@simulacrum/auth0": patch
+"@simulacrum/auth0-simulator": patch
 ---

--- a/packages/auth0/src/start.ts
+++ b/packages/auth0/src/start.ts
@@ -6,6 +6,7 @@ const port = process.env.PORT ? parseInt(process.env.PORT) : undefined;
 
 main(function*() {
   let server: Server = yield createSimulationServer({
+    debug: true,
     seed: 1,
     port,
     simulators: { auth0 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,7 +4,6 @@ import webSocketImpl from 'isomorphic-ws';
 import { GraphQLError } from 'graphql';
 
 export interface SimulationOptions {
-  debug?: boolean
   options?: Record<string, unknown>;
   services?: Record<string,{
     port?: number
@@ -21,7 +20,6 @@ export interface Client {
 
 export interface Simulation {
   id: string;
-  debug: boolean;
   status: 'new' | 'running' | 'failed',
   services: Service[];
 }
@@ -108,7 +106,6 @@ export function createClient(serverURL: string): Client {
 mutation CreateSimulation($simulator: String, $options: JSON) {
   createSimulation(simulator: $simulator, options: $options) {
     id
-    debug
     simulators
     status
     services {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -108,6 +108,7 @@ export function createClient(serverURL: string): Client {
 mutation CreateSimulation($simulator: String, $options: JSON) {
   createSimulation(simulator: $simulator, options: $options) {
     id
+    debug
     simulators
     status
     services {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,6 +4,7 @@ import webSocketImpl from 'isomorphic-ws';
 import { GraphQLError } from 'graphql';
 
 export interface SimulationOptions {
+  debug?: boolean
   options?: Record<string, unknown>;
   services?: Record<string,{
     port?: number

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -21,6 +21,7 @@ export interface Client {
 
 export interface Simulation {
   id: string;
+  debug: boolean;
   status: 'new' | 'running' | 'failed',
   services: Service[];
 }
@@ -67,7 +68,6 @@ export function createClient(serverURL: string): Client {
       }
     }
   });
-
 
   function subscribe<T>(payload: SubscribePayload): Runnable<Subscription<Result<T>>> {
     return {

--- a/packages/server/src/effects.ts
+++ b/packages/server/src/effects.ts
@@ -3,13 +3,14 @@ import { Resource, spawn } from "effection";
 import { ServerState, Simulator } from "./interfaces";
 import { map } from './effect';
 import { simulation } from './simulation';
-import { loggingEffect } from './effects/logging';
+import { createLogger } from './effects/logging';
 
 export function createEffects(atom: Slice<ServerState>, available: Record<string, Simulator>): Resource<void> {
   return {
+    name: 'server effects',
     *init() {
       yield spawn(map(atom.slice('simulations'), simulation(available)));
-      yield spawn(map(atom.slice('simulations'), loggingEffect()));
+      yield createLogger(atom);
     }
   };
 }

--- a/packages/server/src/effects.ts
+++ b/packages/server/src/effects.ts
@@ -3,11 +3,13 @@ import { Resource, spawn } from "effection";
 import { ServerState, Simulator } from "./interfaces";
 import { map } from './effect';
 import { simulation } from './simulation';
+import { loggingEffect } from './effects/logging';
 
 export function createEffects(atom: Slice<ServerState>, available: Record<string, Simulator>): Resource<void> {
   return {
     *init() {
       yield spawn(map(atom.slice('simulations'), simulation(available)));
+      yield spawn(map(atom.slice('simulations'), loggingEffect()));
     }
   };
 }

--- a/packages/server/src/effects/logging.ts
+++ b/packages/server/src/effects/logging.ts
@@ -1,0 +1,20 @@
+import type { SimulationState } from 'src/interfaces';
+import { Effect } from '../effect';
+import { assert } from 'assert-ts';
+
+export const loggingEffect = (): Effect<SimulationState> => slice => function*(scope) {
+  let simulation = slice.get();
+  let { debug = false } = simulation.options;
+
+  if (debug) {
+    scope.spawn(function* () {
+      yield slice.filter(({ status }) => status === 'failed').forEach(function *(state) {
+        assert(state.status === 'failed');
+
+        console.error(state.error);
+      });
+    });
+  } else {
+    scope.halt();
+  }
+};

--- a/packages/server/src/effects/logging.ts
+++ b/packages/server/src/effects/logging.ts
@@ -7,8 +7,8 @@ export const loggingEffect = (): Effect<SimulationState> => slice => function*(s
   let task: Task = yield spawn();
 
   yield slice.slice('debug').forEach(function*(shouldLogErrors) {
+    yield task.halt();
     if (shouldLogErrors) {
-      yield task.halt();
       task = yield spawn(function* () {
         yield slice.filter(({ status }) => status === 'failed').forEach(function *(state) {
           assert(state.status === 'failed');

--- a/packages/server/src/effects/logging.ts
+++ b/packages/server/src/effects/logging.ts
@@ -16,8 +16,6 @@ export const loggingEffect = (): Effect<SimulationState> => slice => function*(s
           console.error(state.error);
         });
       }).within(scope);
-    } else if (!shouldLogErrors) {
-      task.halt();
     }
   });
 };

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -54,8 +54,9 @@ export interface SimulationOptions {
 export type SimulationState =
   {
     id: string;
-    status: 'new',
-    simulator: string,
+    status: 'new';
+    debug: boolean;
+    simulator: string;
     options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
     services: [];
@@ -63,8 +64,9 @@ export type SimulationState =
   } |
   {
     id: string,
-    status: 'running',
-    simulator: string,
+    status: 'running';
+    debug: boolean;
+    simulator: string;
     options: SimulationOptions;
     services: {
       name: string;
@@ -75,8 +77,9 @@ export type SimulationState =
   } |
   {
     id: string,
-    status: 'failed',
-    simulator: string,
+    status: 'failed';
+    debug: boolean;
+    simulator: string;
     options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
     services: [];

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -46,7 +46,8 @@ export interface ServerState {
 export interface SimulationOptions {
   options?: Record<string, unknown>;
   services?: Record<string, {
-    port?: number
+    port?: number;
+    debug?: boolean;
   }>
 }
 

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -44,10 +44,10 @@ export interface ServerState {
 }
 
 export interface SimulationOptions {
+  debug?: boolean;
   options?: Record<string, unknown>;
   services?: Record<string, {
     port?: number;
-    debug?: boolean;
   }>
 }
 

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -26,6 +26,7 @@ export interface ServerOptions {
   simulators: Record<string, Simulator<any>>;
   port?: number;
   seed?: number;
+  debug?: boolean;
 }
 
 export interface Service {
@@ -40,11 +41,11 @@ export type StoreState = Record<string, Record<string, Record<string, any>>>;
 export type Store = Slice<StoreState>;
 
 export interface ServerState {
+  debug: boolean;
   simulations: Record<string, SimulationState>;
 }
 
 export interface SimulationOptions {
-  debug?: boolean;
   options?: Record<string, unknown>;
   services?: Record<string, {
     port?: number;
@@ -55,7 +56,6 @@ export type SimulationState =
   {
     id: string;
     status: 'new';
-    debug: boolean;
     simulator: string;
     options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
@@ -65,7 +65,6 @@ export type SimulationState =
   {
     id: string,
     status: 'running';
-    debug: boolean;
     simulator: string;
     options: SimulationOptions;
     services: {
@@ -78,7 +77,6 @@ export type SimulationState =
   {
     id: string,
     status: 'failed';
-    debug: boolean;
     simulator: string;
     options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -24,7 +24,7 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
     let { atom, scope, newid } = ctx;
 
     let id = newid();
-    let simulation = atom.slice("simulations").slice(id);
+    let simulation = atom.slice("simulations", id);
     simulation.set({ id, status: 'new', simulator, options, services: [], scenarios: {}, store: {} });
 
     return scope.spawn(simulation.filter(({ status }) => status !== 'new').expect());
@@ -33,7 +33,7 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
 
 export const destroySimulation: Resolver<{ id: string; }, boolean> = {
   async resolve({ id }, { atom }) {
-    let simulation = atom.slice("simulations").slice(id);
+    let simulation = atom.slice("simulations", id);
     if (simulation.get()) {
       simulation.remove();
       return true;

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -34,7 +34,6 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
       services: [],
       scenarios: {},
       store: {},
-      debug: !!options.debug
     });
 
     return scope.spawn(simulation.filter(({ status }) => status !== 'new').expect());

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -25,7 +25,17 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
 
     let id = newid();
     let simulation = atom.slice("simulations", id);
-    simulation.set({ id, status: 'new', simulator, options, services: [], scenarios: {}, store: {} });
+
+    simulation.set({
+      id,
+      status: 'new',
+      simulator,
+      options,
+      services: [],
+      scenarios: {},
+      store: {},
+      debug: !!options.debug
+    });
 
     return scope.spawn(simulation.filter(({ status }) => status !== 'new').expect());
   }

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -21,6 +21,7 @@ export const types = [
     definition(t) {
       t.id('id');
       t.nonNull.string('status');
+      t.boolean('debug');
       t.nonNull.list.field('services', {
         type: 'Service'
       });

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -21,7 +21,6 @@ export const types = [
     definition(t) {
       t.id('id');
       t.nonNull.string('status');
-      t.boolean('debug');
       t.nonNull.list.field('services', {
         type: 'Service'
       });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -16,13 +16,20 @@ import { stableIds } from './faker';
 import { createWebSocketTransport } from './websocket-transport';
 import { Resource } from 'effection';
 
-export function createSimulationServer(options: ServerOptions = { simulators: {} }): Resource<Server> {
-  let { port } = options;
+const defaults = {
+  simulators: {},
+  debug: false
+};
+
+export function createSimulationServer(options: ServerOptions = defaults): Resource<Server> {
+  let { simulators, debug, port, seed } = { ...defaults, ...options };
+
   return {
     *init(scope) {
-      let newid = options.seed ? stableIds(options.seed) : v4;
+      let newid = seed ? stableIds(seed) : v4;
 
       let atom = createAtom<ServerState>({
+        debug: !!debug,
         simulations: {}
       });
 
@@ -38,7 +45,7 @@ export function createSimulationServer(options: ServerOptions = { simulators: {}
 
       yield createWebSocketTransport(context, server.http);
 
-      yield createEffects(atom, options.simulators);
+      yield createEffects(atom, simulators);
 
       return server;
     }

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -56,22 +56,11 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
         }
 
         let { protocol } = service;
-        let { port, debug } = serviceOptions[name] ?? {};
-
-        if (debug) {
-          scope.spawn(function* () {
-            yield slice.filter(s => s.status === 'failed').forEach(function *(state) {
-              assert(state.status === 'failed');
-
-              console.error(state.error);
-            });
-          });
-        }
 
         return {
           name,
           protocol,
-          create: createServer(app, { protocol, port })
+          create: createServer(app, { protocol, port: serviceOptions[name]?.port })
         };
       });
 
@@ -122,7 +111,6 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       // all spun up, we can just wait.
       yield;
     } catch (error) {
-      console.error(error);
       slice.update((state) => ({
         ...state,
         status: "failed",

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -91,6 +91,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
             data
           }));
         } catch (error) {
+          console.error(error);
           slice.update(state => ({
             ...state,
             status: 'failed',
@@ -112,6 +113,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       // all spun up, we can just wait.
       yield;
     } catch (error) {
+      console.error(error);
       slice.update((state) => ({
         ...state,
         status: "failed",

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -13,6 +13,7 @@ main(function* () {
   });
 
   let server: Server = yield createSimulationServer({
+    debug: true,
     port,
     seed: 1,
     simulators: {

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -128,6 +128,18 @@ describe('@simulacrum/server', () => {
     });
   });
 
+  describe('debug', () => {
+    beforeEach(function*() {
+      simulation = yield client.createSimulation("echo", {
+        debug: true
+      });
+    });
+
+    it('sets the debug flag', function * () {
+      expect(simulation.debug).toBe(true);
+    });
+  });
+
   describe('createSimulation() with parameters', () => {
     let response: Response;
     let body: string;

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -128,18 +128,6 @@ describe('@simulacrum/server', () => {
     });
   });
 
-  describe('debug', () => {
-    beforeEach(function*() {
-      simulation = yield client.createSimulation("echo", {
-        debug: true
-      });
-    });
-
-    it('sets the debug flag', function * () {
-      expect(simulation.debug).toBe(true);
-    });
-  });
-
   describe('createSimulation() with parameters', () => {
     let response: Response;
     let body: string;
@@ -229,6 +217,3 @@ hello world`);
     });
   });
 });
-
-
-

--- a/packages/server/test/websocket.test.ts
+++ b/packages/server/test/websocket.test.ts
@@ -27,6 +27,7 @@ describe('webocket transport', () => {
     expect(first).toEqual({
       done: false,
       value: {
+        debug: false,
         simulations: {}
       }
     });


### PR DESCRIPTION
## Motivation

Catch handlers in `simulation.ts`  were not getting logged to the console.

## Approach

add `console.error` to catch handlers.
