### PR TITLE
Decouple the service stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15605,7 +15605,8 @@
         "effection": "^2.0.0-beta.3",
         "html-entities": "^2.3.2",
         "jsesc": "^3.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "jsonwebtoken": "^8.5.1",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@effection/atom": "^2.0.0-beta.3",
@@ -17326,6 +17327,7 @@
         "rimraf": "^3.0.2",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.3",
+        "uuid": "^8.3.2",
         "ws": "^7.4.4"
       },
       "dependencies": {

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -38,7 +38,8 @@
     "effection": "^2.0.0-beta.3",
     "html-entities": "^2.3.2",
     "jsesc": "^3.0.2",
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@effection/atom": "^2.0.0-beta.3",

--- a/packages/auth0/src/effects/user.ts
+++ b/packages/auth0/src/effects/user.ts
@@ -1,12 +1,9 @@
-import { Slice } from '@effection/atom';
-import { onPerson, SimulationState, Faker } from '@simulacrum/server';
+import { onPerson, Faker, Store } from '@simulacrum/server';
 import { Operation } from 'effection';
 
 import { userQuery, user } from '../scenarios/user';
 
-export function *createUserFromPerson(slice: Slice<SimulationState>, faker: Faker): Operation<void> {
-  let store = slice.slice('store');
-
+export function *createUserFromPerson(store: Store, faker: Faker): Operation<void> {
   yield onPerson(store, function *(person) {
     let { id, email, password } = person.get();
     let existingUser = userQuery(store)(user => user.__personId === id);

--- a/packages/auth0/src/effects/user.ts
+++ b/packages/auth0/src/effects/user.ts
@@ -1,0 +1,17 @@
+import { Slice } from '@effection/atom';
+import { onPerson, SimulationState, Faker } from '@simulacrum/server';
+import { Operation } from 'effection';
+
+import { userQuery, user } from '../scenarios/user';
+
+export function *createUserFromPerson(slice: Slice<SimulationState>, faker: Faker): Operation<void> {
+  let store = slice.slice('store');
+
+  yield onPerson(store, function *(person) {
+    let { id, email, password } = person.get();
+    let existingUser = userQuery(store)(user => user.__personId === id);
+    if (!existingUser) {
+      yield user(store, faker, { email, password, __personId: id });
+    }
+  });
+}

--- a/packages/auth0/src/effects/user.ts
+++ b/packages/auth0/src/effects/user.ts
@@ -5,10 +5,10 @@ import { userQuery, user } from '../scenarios/user';
 
 export function *createUserFromPerson(store: Store, faker: Faker): Operation<void> {
   yield onPerson(store, function *(person) {
-    let { id, email, password } = person.get();
-    let existingUser = userQuery(store)(user => user.__personId === id);
+    let { email, password } = person.get();
+    let existingUser = userQuery(store)(user => user.email === email);
     if (!existingUser) {
-      yield user(store, faker, { email, password, __personId: id });
+      yield user(store, faker, { email, password });
     }
   });
 }

--- a/packages/auth0/src/handlers/get-service-url.ts
+++ b/packages/auth0/src/handlers/get-service-url.ts
@@ -2,7 +2,7 @@ import { Options } from '../types';
 import { assert } from 'assert-ts';
 
 export const getServiceUrl = (options: Options): URL => {
-  let service = options.services.get().find(({ name }) => name === 'auth0' );
+  let service = options.services.slice('auth0').get();
 
   assert(!!service, `did not find auth0 service in set of running services`);
 

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -55,8 +55,8 @@ export const auth0: Simulator<Options> = (slice, options) => {
   return {
     services: { auth0: createAuth0Service({ ...auth0Handlers, ...openIdHandlers }) },
     scenarios: { person },
-    *effects(slice, faker) {
-      yield createUserFromPerson(slice, faker);
+    *effects(store, faker) {
+      yield createUserFromPerson(store, faker);
     },
   };
 };

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -1,16 +1,15 @@
 import type { Simulator, Service } from '@simulacrum/server';
-import { createHttpApp } from '@simulacrum/server';
-import { urlencoded, json } from 'express';
-import { createAuth0Handlers } from './handlers/auth0-handlers';
-import { person } from '@simulacrum/server';
-import { createSession } from './middleware/session';
+import { createHttpApp, person } from '@simulacrum/server';
+import express, { urlencoded, json } from 'express';
 import path from 'path';
-import express from 'express';
-import { Options } from './types';
+
+import { createUserFromPerson } from './effects/user';
+import { createAuth0Handlers } from './handlers/auth0-handlers';
 import { createCors } from './middleware/create-cors';
 import { noCache } from './middleware/no-cache';
 import { createOpenIdHandlers } from './handlers/openid-handlers';
-
+import { createSession } from './middleware/session';
+import { Options } from './types';
 
 const publicDir = path.join(process.cwd(), 'src', 'views', 'public');
 
@@ -55,16 +54,9 @@ export const auth0: Simulator<Options> = (slice, options) => {
 
   return {
     services: { auth0: createAuth0Service({ ...auth0Handlers, ...openIdHandlers }) },
-    scenarios: {
-      /**
-       * Here we just wrap the internal `person` scenario to augment
-       * it with a username and password
-       * but what we really need to have some way to _react_ to the person
-       * having been created and augment the record at that point.
-       */
-      *person(store, faker) {
-        return yield person(store, faker);
-      }
-    }
+    scenarios: { person },
+    *effects(slice, faker) {
+      yield createUserFromPerson(slice, faker);
+    },
   };
 };

--- a/packages/auth0/src/scenarios/user.ts
+++ b/packages/auth0/src/scenarios/user.ts
@@ -1,0 +1,62 @@
+import { Slice } from '@effection/atom';
+import { Faker, OptionalParams, Store } from '@simulacrum/server';
+import { Operation } from 'effection';
+import { v4 } from 'uuid';
+
+type Predicate<T> = (this: void, value: T, index: number, obj: T[]) => boolean;
+
+export interface Nonce {
+  nonce: string;
+  username: string;
+}
+
+export interface User {
+  id: string;
+  email?: string;
+  password?: string;
+  __personId?: string;
+}
+
+export interface Auth0State {
+  nonce: Record<string, Nonce>;
+  users: Record<string, User>;
+}
+
+export function *user(store: Store, faker: Faker, params: OptionalParams<User> = {}): Operation<User> {
+  let id = v4();
+  let slice = records(store).slice('users').slice(id);
+
+  let attrs = {
+    id,
+    email: params.email ?? faker.internet.email().toLowerCase(),
+    password: params.password ?? faker.internet.password(),
+    __personId: params.__personId,
+  };
+
+  slice.set(attrs);
+  return attrs;
+}
+
+export const userQuery = (store: Store) => (predicate: Predicate<User>): User | undefined => {
+  let users = records(store).slice('users').get() ?? {};
+  return Object.values(users).find(predicate);
+};
+
+export function records(store: Store): Slice<Auth0State> {
+  let auth0 = store.slice("auth0");
+  if (!auth0.get()) {
+    auth0.set({});
+  }
+
+  let nonce = auth0.slice('nonce');
+  if (!nonce.get()) {
+    nonce.set({});
+  }
+
+  let users = auth0.slice("users");
+  if (!users.get()) {
+    users.set({});
+  }
+
+  return auth0 as unknown as Slice<Auth0State>;
+}

--- a/packages/auth0/src/scenarios/user.ts
+++ b/packages/auth0/src/scenarios/user.ts
@@ -14,7 +14,6 @@ export interface User {
   id: string;
   email?: string;
   password?: string;
-  __personId?: string;
 }
 
 export interface Auth0State {
@@ -30,7 +29,6 @@ export function *user(store: Store, faker: Faker, params: OptionalParams<User> =
     id,
     email: params.email ?? faker.internet.email().toLowerCase(),
     password: params.password ?? faker.internet.password(),
-    __personId: params.__personId,
   };
 
   slice.set(attrs);

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, beforeEach } from '@effection/mocha';
+import { createHttpApp, person, Person } from '@simulacrum/server';
+import fetch from 'cross-fetch';
 import expect from 'expect';
+import { stringify } from 'querystring';
 import { createTestServer, Client, Simulation } from './helpers';
 import { auth0 } from '../src';
-import fetch from 'cross-fetch';
-import { stringify } from 'querystring';
-import { createHttpApp, person, Person } from '@simulacrum/server';
 import { decode, encode } from 'base64-url';
 import jwt from 'jsonwebtoken';
-
 import Keygrip from 'keygrip';
+import { createUserFromPerson } from '../src/effects/user';
 
 const createSessionCookie = <T>(data: T): string => {
   let cookie = Buffer.from(JSON.stringify(data)).toString('base64');
@@ -39,9 +39,11 @@ describe('Auth0 simulator', () => {
                   res.status(200).send('ok');
                 })
               },
-
             },
-            scenarios: { person }
+            scenarios: { person },
+            *effects(slice, faker) {
+              yield createUserFromPerson(slice, faker);
+            },
           };
         }
       }

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -41,9 +41,7 @@ describe('Auth0 simulator', () => {
               },
             },
             scenarios: { person },
-            *effects(slice, faker) {
-              yield createUserFromPerson(slice, faker);
-            },
+            effects: createUserFromPerson,
           };
         }
       }

--- a/packages/graphql-starwars/src/simulation/context.ts
+++ b/packages/graphql-starwars/src/simulation/context.ts
@@ -1,28 +1,10 @@
-import { Slice } from '@effection/atom';
 import { Store } from '@simulacrum/server';
 
-import { Character, Context } from "../schema/types";
-
-// atom doesn't quite work right in the sense that we can't make a
-// deep slice and have it create parents on demand.
-export function records<TRecord = unknown>(store: Store, key: string): Slice<Record<string, TRecord>> {
-  // create and initialize the graphql slice
-  let graphql = store.slice("graphql");
-  if (!graphql.get()) {
-    graphql.set({});
-  }
-
-  // create and initialize our records within the graphql slice
-  let slice = graphql.slice(key);
-  if (!slice.get()) {
-    slice.set({});
-  }
-  return slice;
-}
-
+import { records } from './scenarios';
+import { Context } from "../schema/types";
 
 export const createSimulationContext = (store: Store): Context => {
-  let characters = records<Character>(store, 'characters');
+  let characters = records(store).slice('characters');
 
   return {
     store: {

--- a/packages/graphql-starwars/src/simulation/effects.ts
+++ b/packages/graphql-starwars/src/simulation/effects.ts
@@ -1,0 +1,23 @@
+
+import { Slice } from '@effection/atom';
+import { onPerson, SimulationState, Faker } from '@simulacrum/server';
+import { Operation } from 'effection';
+
+import { human, records } from './scenarios';
+
+export function *createHumanFromPerson(slice: Slice<SimulationState>, faker: Faker): Operation<void> {
+  let store = slice.slice('store');
+
+  yield onPerson(store, function *(person) {
+    let { id, name } = person.get();
+    let characters = records(store).slice('characters').get();
+    let existingHuman = Object.values(characters).find(({ __personId }) => __personId === id);
+    if (!existingHuman) {
+      yield human(store, faker, { name });
+    }
+  });
+}
+
+export const effects = {
+  createHumanFromPerson
+};

--- a/packages/graphql-starwars/src/simulation/effects.ts
+++ b/packages/graphql-starwars/src/simulation/effects.ts
@@ -1,13 +1,10 @@
 
-import { Slice } from '@effection/atom';
-import { onPerson, SimulationState, Faker } from '@simulacrum/server';
+import { onPerson, Faker, Store } from '@simulacrum/server';
 import { Operation } from 'effection';
 
 import { human, records } from './scenarios';
 
-export function *createHumanFromPerson(slice: Slice<SimulationState>, faker: Faker): Operation<void> {
-  let store = slice.slice('store');
-
+export function *createHumanFromPerson(store: Store, faker: Faker): Operation<void> {
   yield onPerson(store, function *(person) {
     let { id, name } = person.get();
     let characters = records(store).slice('characters').get();

--- a/packages/graphql-starwars/src/simulation/index.ts
+++ b/packages/graphql-starwars/src/simulation/index.ts
@@ -1,2 +1,3 @@
 export { createSimulationContext } from './context';
+export { effects } from './effects';
 export { scenarios } from './scenarios';

--- a/packages/graphql-starwars/src/simulation/scenarios.ts
+++ b/packages/graphql-starwars/src/simulation/scenarios.ts
@@ -1,49 +1,74 @@
-import { Store, Faker } from '@simulacrum/server';
+import { Slice } from '@effection/atom';
+import { Store, Faker, OptionalParams } from '@simulacrum/server';
 import { Operation } from 'effection';
 
-import { records } from './context';
 import { droidNames, droidFunctions, humanNames, planetNames } from './data';
-import { Character, Episode } from '../schema/types';
-
+import { Character as CharacterBase, Droid, Episode, Human } from '../schema/types';
 
 export type ManyScenarioParams = {
   n?: number;
 }
 
-function *droid(store: Store, faker: Faker): Operation<void> {
-  let characters = records<Character>(store, 'characters');
+export type Character = CharacterBase & {
+  __personId?: string;
+}
+
+export interface StarWarsState {
+  characters: Record<string, Character>;
+}
+
+// atom doesn't quite work right in the sense that we can't make a
+// deep slice and have it create parents on demand.
+export function records(store: Store): Slice<StarWarsState> {
+  // create and initialize the graphql slice
+  let graphql = store.slice("graphql");
+  if (!graphql.get()) {
+    graphql.set({});
+  }
+
+  // create and initialize our records within the graphql slice
+  let characters = graphql.slice('characters');
+  if (!characters.get()) {
+    characters.set({});
+  }
+
+  return graphql as unknown as Slice<StarWarsState>;
+}
+
+export function *droid(store: Store, faker: Faker, params: OptionalParams<Droid> = {}): Operation<void> {
+  let characters = records(store).slice('characters');
   let id = faker.datatype.uuid();
 
   characters.slice(id).set({
     __typename: 'Droid',
     id,
     friends: [],
-    name: faker.random.arrayElement(droidNames),
-    appearsIn: faker.random.arrayElements(Object.values(Episode)),
-    primaryFunction: faker.random.arrayElement(droidFunctions),
+    name: params.name ?? faker.random.arrayElement(droidNames),
+    appearsIn: params.appearsIn ?? faker.random.arrayElements(Object.values(Episode)),
+    primaryFunction: params.primaryFunction ?? faker.random.arrayElement(droidFunctions),
   });
 
   yield makeFriends(id, store, faker);
 }
 
-function *human(store: Store, faker: Faker): Operation<void> {
-  let characters = records<Character>(store, 'characters');
+export function *human(store: Store, faker: Faker, params: OptionalParams<Human> = {}): Operation<void> {
+  let characters = records(store).slice('characters');
   let id = faker.datatype.uuid();
 
   characters.slice(id).set({
     __typename: 'Human',
     id,
     friends: [],
-    name: faker.random.arrayElement(humanNames),
-    appearsIn: faker.random.arrayElements(Object.values(Episode)),
-    homePlanet: faker.random.arrayElement(planetNames),
+    name: params.name ?? faker.random.arrayElement(humanNames),
+    appearsIn: params.appearsIn ?? faker.random.arrayElements(Object.values(Episode)),
+    homePlanet: params.homePlanet ?? faker.random.arrayElement(planetNames),
   });
 
   yield makeFriends(id, store, faker);
 }
 
-function *makeFriends(id: string, store: Store, faker: Faker): Operation<void> {
-  let characters = records<Character>(store, 'characters');
+export function *makeFriends(id: string, store: Store, faker: Faker): Operation<void> {
+  let characters = records(store).slice('characters');
   let target = characters.slice(id);
   let newFriends = faker.random.arrayElements(
     Object.keys(characters.get()).filter(friendId => friendId !== id),
@@ -65,19 +90,19 @@ function *makeFriends(id: string, store: Store, faker: Faker): Operation<void> {
     });
 }
 
-function *droids(store: Store, faker: Faker, { n = 1 }: ManyScenarioParams): Operation<void> {
+export function *droids(store: Store, faker: Faker, { n = 1 }: ManyScenarioParams): Operation<void> {
   for(let i = 0; i < n; i++) {
     yield droid(store, faker);
   }
 }
 
-function *humans(store: Store, faker: Faker, { n = 1 }: ManyScenarioParams): Operation<void> {
+export function *humans(store: Store, faker: Faker, { n = 1 }: ManyScenarioParams): Operation<void> {
   for(let i = 0; i < n; i++) {
     yield human(store, faker);
   }
 }
 
-function *droidsAndHumans(store: Store, faker: Faker, { n = 1 }: ManyScenarioParams): Operation<void> {
+export function *droidsAndHumans(store: Store, faker: Faker, { n = 1 }: ManyScenarioParams): Operation<void> {
   for(let i = 0; i < n; i++) {
     yield faker.datatype.boolean() ?
       droid(store, faker) :

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -14,7 +14,7 @@ export function createGraphQLService(options: Options): Service {
   };
 }
 
-export function createGraphQLSimulator({ schema, createContext, scenarios }: SimulatorOptions): Simulator {
+export function createGraphQLSimulator({ schema, scenarios,createContext, effects }: SimulatorOptions): Simulator {
   return (state) => {
     let store = state.slice('store');
 
@@ -26,6 +26,7 @@ export function createGraphQLSimulator({ schema, createContext, scenarios }: Sim
         })
       },
       scenarios,
+      effects,
     };
   };
 }

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -1,4 +1,4 @@
-import { Scenarios, Store } from '@simulacrum/server';
+import { Effects, Scenarios, Store } from '@simulacrum/server';
 import { GraphQLSchema } from 'graphql';
 
 export type ContextCreator<TContext> = (store: Store) => TContext;
@@ -14,4 +14,5 @@ export interface SimulatorOptions<TContext = any> {
   schema: GraphQLSchema;
   scenarios: Scenarios;
   createContext?: ContextCreator<TContext>;
+  effects?: Effects;
 }

--- a/packages/graphql/test/graphql.test.ts
+++ b/packages/graphql/test/graphql.test.ts
@@ -33,8 +33,8 @@ describe('GraphQL simulator', () => {
             ...scenarios,
             person
           },
-          *effects(slice, faker) {
-            yield effects.createHumanFromPerson(slice, faker);
+          *effects(store, faker) {
+            yield effects.createHumanFromPerson(store, faker);
           }
         })
       }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,15 @@
 export { createSimulationServer, Server } from './server';
-export { Simulator, ServerOptions, Store, StoreState } from './interfaces';
-export type { Scenarios, Service, SimulationState } from './interfaces';
+export type {
+  Behaviors,
+  Effects,
+  Scenarios,
+  ServerOptions,
+  ServiceState,
+  Service,
+  SimulationState,
+  Simulator,
+  Store,
+} from './interfaces';
 export type { Faker } from './faker';
 export * from './http';
 export * from './simulators/person';

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -7,7 +7,7 @@ export type Services = Record<string, Service>;
 
 export type Scenarios = Record<string, Scenario>;
 
-export type Effects = (slice: Slice<SimulationState>, faker: Faker) => Operation<void>;
+export type Effects = (store: Store, faker: Faker) => Operation<void>;
 
 export interface Behaviors {
   services: Record<string, Service>;

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -7,10 +7,12 @@ export type Services = Record<string, Service>;
 
 export type Scenarios = Record<string, Scenario>;
 
+export type Effects = (slice: Slice<SimulationState>, faker: Faker) => Operation<void>;
+
 export interface Behaviors {
-  services: Services;
-  scenarios: Scenarios;
-  effects?: () => Operation<void>;
+  services: Record<string, Service>;
+  scenarios: Record<string, Scenario>;
+  effects?: Effects;
 }
 
 export type Params = Record<string, unknown>;
@@ -54,6 +56,11 @@ export interface SimulationOptions {
   }>
 }
 
+export interface ServiceState {
+  name: string;
+  url: string;
+}
+
 export type SimulationState =
   {
     id: string;
@@ -61,7 +68,7 @@ export type SimulationState =
     simulator: string,
     options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
-    services: [];
+    services: Record<string, ServiceState>;
     store: StoreState;
   } |
   {
@@ -69,10 +76,7 @@ export type SimulationState =
     status: 'running',
     simulator: string,
     options: SimulationOptions;
-    services: {
-      name: string;
-      url: string;
-    }[];
+    services: Record<string, ServiceState>;
     scenarios: Record<string, ScenarioState>;
     store: StoreState;
   } |
@@ -82,7 +86,7 @@ export type SimulationState =
     simulator: string,
     options: SimulationOptions;
     scenarios: Record<string, ScenarioState>;
-    services: [];
+    services: Record<string, ServiceState>;
     store: StoreState;
     error: Error
   }

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -105,7 +105,7 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
       }));
 
       if(typeof effects !== 'undefined') {
-        yield spawn(effects(slice, faker));
+        yield spawn(effects(store, faker));
       }
 
       slice.update(state => ({

--- a/packages/server/src/simulators/person.ts
+++ b/packages/server/src/simulators/person.ts
@@ -1,6 +1,8 @@
 import { Slice } from '@effection/atom';
 import { Operation } from 'effection';
 import { v4 } from 'uuid';
+
+import { map, Effect } from '../effect';
 import { Faker } from '../faker';
 import { Behaviors, Store } from "../interfaces";
 
@@ -41,7 +43,11 @@ export function person(store: Store, faker: Faker, params: OptionalParams<Person
   };
 }
 
-function records(store: Store): Slice<Record<string, Record<string, unknown>>> {
+export function *onPerson(store: Store, effect: Effect<Person>): Operation<void> {
+  yield map<Person>(records(store) as Slice<Record<string, Person>>, effect);
+}
+
+function records(store: Store): Slice<Record<string, Person>> {
   let people = store.slice("people");
 
   // atom doesn't quite work right in the sense that we can't make a
@@ -49,5 +55,5 @@ function records(store: Store): Slice<Record<string, Record<string, unknown>>> {
   if (!people.get()) {
     people.set({});
   }
-  return people;
+  return people as unknown as Slice<Record<string, Person>>;
 }

--- a/packages/server/test/simulator-effects.test.ts
+++ b/packages/server/test/simulator-effects.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import { Simulator } from '../src/interfaces';
-import { person as createPerson } from '../src/simulators/person';
-import { map } from '../src/effect';
+import { onPerson, person as createPerson } from '../src/simulators/person';
 import { Client, Simulation } from '@simulacrum/client';
 import type { Person } from '../src/simulators/person';
 import { createTestServer } from './helpers';
@@ -16,13 +15,13 @@ describe('simulator effects', () => {
   beforeEach(function* () {
     people = {};
 
-    let test: Simulator = (slice) => ({
+    let test: Simulator = () => ({
       services: {},
       scenarios: {
         person: createPerson
       },
-      * effects() {
-        yield map(slice.slice('store', 'people'), function* (slice) {
+      * effects(slice) {
+        yield onPerson(slice.slice('store'), function* (slice) {
           let newPerson = slice.get();
 
           people[newPerson.id] = newPerson;

--- a/packages/server/test/simulator-effects.test.ts
+++ b/packages/server/test/simulator-effects.test.ts
@@ -20,8 +20,8 @@ describe('simulator effects', () => {
       scenarios: {
         person: createPerson
       },
-      * effects(slice) {
-        yield onPerson(slice.slice('store'), function* (slice) {
+      * effects(store) {
+        yield onPerson(store, function* (slice) {
           let newPerson = slice.get();
 
           people[newPerson.id] = newPerson;


### PR DESCRIPTION
## Motivation
The Auth0 store is currently coupled to the 'person' simulator, in that it uses its scenario and reaches directly into its slice of the store.

Ideally services should play within their own slice of the store, and should respond to other services with effects.

## Approach
This took a bit of exploration to come around to a final design. I started by having the `simulation` define a slice of the store for each service, so that each service literally only has access to its own store. This created more harm than good; it created divergent data access patterns since scenarios still require access to the entire store.

So, the final approach.

The 'person' simulator now exports an `onPerson` helper that allows other services to subscribe to changes in its store. Services may specify effects that leverage the `onPerson` helper to mutate their store accordingly.

To that end, the Auth0 simulator now defines its own `auth0` store, with `nonce` and `users` substates. It does this via a `records` helper that introduces some strong-typing to improve the ergonomics of working with its store. A `createUserFromPerson` effect has been introduced that will create an Auth0 user in response to the `person` scenario being called.

Similarly, the GraphQL simulator now has a `createHumanFromPerson` effect that does the same thing.

A simulator's `effects` now accepts two arguments: `store` and `faker`. This enables effects to leverage scenarios in response to events such as `onPerson`.

One more thing to mention. In my earlier exploratory work I modified `services` to be an object-y piece of state, rather than an array. This makes it significantly easier for a service to access its own metadata (such as its url). The trade-off there is that the `createSimulation` resolver now is responsible for transforming that piece of state to a list. I like this, but readers may not; happy to revert this change if it's not desired.