### PR TITLE
pass state to auth0-js and fix trailing for openid endpoints

### DIFF
--- a/.changes/state-iss.md
+++ b/.changes/state-iss.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/auth0": minor
+---
+
+Ensure the same auth0 state exists throughout and fix issuer forward slash issues.

--- a/packages/auth0/src/handlers/openid-handlers.ts
+++ b/packages/auth0/src/handlers/openid-handlers.ts
@@ -2,12 +2,21 @@ import type { HttpHandler } from '@simulacrum/server';
 import { Options } from 'src/types';
 import { JWKS } from '../auth/constants';
 import { getServiceUrl } from './get-service-url';
+import { removeTrailingSlash } from './url';
 
 type Routes =
   | '/jwks.json'
   | '/openid-configuration'
 
 export type OpenIdRoutes = `${`/.well-known`}${Routes}`
+
+export interface OpenIdConfiguration {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+}
 
 export const createOpenIdHandlers = (options: Options): Record<OpenIdRoutes, HttpHandler> => {
   return {
@@ -16,10 +25,10 @@ export const createOpenIdHandlers = (options: Options): Record<OpenIdRoutes, Htt
     },
 
     ['/.well-known/openid-configuration']: function* (_, res) {
-      let url = getServiceUrl(options).toString().replace(/\/$/, '');
+      let url = removeTrailingSlash(getServiceUrl(options).toString());
 
       res.json({
-        issuer: url,
+        issuer: `${url}/`,
         authorization_endpoint: [url, "authorize"].join('/'),
         token_endpoint: [url, "oauth", "token"].join('/'),
         userinfo_endpoint: [url, "userinfo"].join('/'),

--- a/packages/auth0/src/handlers/url.ts
+++ b/packages/auth0/src/handlers/url.ts
@@ -1,0 +1,1 @@
+export const removeTrailingSlash = (url: string): string => url.replace(/\/$/, '');

--- a/packages/auth0/src/views/login.ts
+++ b/packages/auth0/src/views/login.ts
@@ -76,7 +76,7 @@ export const loginView = ({
             var button = document.querySelector('#sumbit');
 
             submit.addEventListener('click', function(e) {
-              let nonce = new URLSearchParams(window.location.search).get('nonce');
+              let params = new URLSearchParams(window.location.search);
 
               var username = document.querySelector('#username');
               var password = document.querySelector('#password');
@@ -87,11 +87,11 @@ export const loginView = ({
                   password: password.value,
                   realm: 'Username-Password-Authentication',
                   scope: '${scope}',
-                  nonce: nonce
+                  nonce: params.get('nonce'),
+                  state: params.get('state')
                 },
                 function(err, authResult) {
                   if (err) {
-
                     [username, password].forEach(e => e.classList.add('border-red-500'));
                     document.querySelector('.error').classList.remove('hidden');
                   }

--- a/packages/auth0/test/openid-handlers.test.ts
+++ b/packages/auth0/test/openid-handlers.test.ts
@@ -13,13 +13,17 @@ describe('openid routes', () => {
     client = yield createTestServer({
       simulators: {
         auth0
-      }
+      },
     });
   });
 
   describe('/.well-known/*', () => {
     beforeEach(function*() {
-      let simulation: Simulation = yield client.createSimulation("auth0");
+      let simulation: Simulation = yield client.createSimulation("auth0", {
+        services: {
+          auth0: { port: 4400 }
+        }
+      });
 
       auth0Url = simulation.services[0].url;
     });
@@ -41,7 +45,13 @@ describe('openid routes', () => {
 
       expect(res.ok).toBe(true);
 
-      expect(json.token_endpoint).toContain('/oauth/token');
+      expect(json).toEqual({
+        issuer: 'https://localhost:4400/',
+        authorization_endpoint: 'https://localhost:4400/authorize',
+        token_endpoint: 'https://localhost:4400/oauth/token',
+        userinfo_endpoint: 'https://localhost:4400/userinfo',
+        jwks_uri: 'https://localhost:4400/.well-known/jwks.json'
+      });
     });
   });
 });


### PR DESCRIPTION
## Motivation

#97 exposed a couple of subtle bugs.

## Approach

There were a couple of glitches fixed in this PR

1.  The same state field was not getting passed throughout the redirects

2. The `/.well-known/openid-configuration` endpoint was not adhering to the required forward slash of the URLs.  The `iss` field of the jwt must have a forward slash.  The json object returned from `/.well-known/openid-configuration` has an `issuer` field which clients use to validate the `iss`.  Our `issuer` field did not have a forward slash. 