### PR TITLE
rename @simualcrum/auth0 to @simualcrum/auth0-simulator

### DIFF
--- a/.changes/auth0-simulator.md
+++ b/.changes/auth0-simulator.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-simulator": minor
+---
+rename @simualcrum/auth0 to @simualcrum/auth0-simulator

--- a/.changes/authorize.md
+++ b/.changes/authorize.md
@@ -1,4 +1,4 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 Add initial /authorize endpoint.

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -17,7 +17,7 @@
       "manager": "javascript",
       "dependencies": ["@simulacrum/ui", "@simulacrum/client"]
     },
-    "@simulacrum/auth0": {
+    "@simulacrum/auth0-simulator": {
       "path": "./packages/auth0",
       "manager": "javascript",
       "dependencies": ["@simulacrum/server", "@simulacrum/client"]

--- a/.changes/login-image.md
+++ b/.changes/login-image.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Fix public directory resolution in auth0.

--- a/.changes/login.md
+++ b/.changes/login.md
@@ -1,4 +1,4 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 Implement login functionality.

--- a/.changes/logout.md
+++ b/.changes/logout.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Add `/v2/logout` and remaining pieces

--- a/.changes/openid.md
+++ b/.changes/openid.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Add openid endpoints `/.well-known/jwks.json` and `/.well-known/openid-configuration`.

--- a/.changes/rules.md
+++ b/.changes/rules.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Add the initial rules-runner code

--- a/.changes/state-iss.md
+++ b/.changes/state-iss.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Ensure the same auth0 state exists throughout and fix issuer forward slash issues.

--- a/.changes/token.md
+++ b/.changes/token.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Add the /oauth/token endpoint that actually issues the jwt.

--- a/.changes/web_message.md
+++ b/.changes/web_message.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/auth0": minor
+"@simulacrum/auth0-simulator": minor
 ---
 
 Add a handler for `/authorize` for `response_mode` web_message

--- a/package-lock.json
+++ b/package-lock.json
@@ -2109,7 +2109,7 @@
         "@parcel/core": "^2.0.0-alpha.3.1"
       }
     },
-    "node_modules/@simulacrum/auth0": {
+    "node_modules/@simulacrum/auth0-simulator": {
       "resolved": "packages/auth0",
       "link": true
     },
@@ -17902,7 +17902,7 @@
       }
     },
     "packages/auth0": {
-      "name": "@simulacrum/auth0",
+      "name": "@simulacrum/auth0-simulator",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -19709,7 +19709,7 @@
         "nullthrows": "^1.1.1"
       }
     },
-    "@simulacrum/auth0": {
+    "@simulacrum/auth0-simulator": {
       "version": "file:packages/auth0",
       "requires": {
         "@effection/atom": "^2.0.0-beta.3",

--- a/packages/auth0/README.md
+++ b/packages/auth0/README.md
@@ -150,7 +150,7 @@ The `client` is also expected to be run in many different contexts, and, as such
 ```js
 import { main } from "effection";
 import { createSimulationServer } from "@simulacrum/server";
-import { auth0 } from "@simulacrum/auth0";
+import { auth0 } from "@simulacrum/auth0-simulator";
 import { createClient } from "@simulacrum/client";
 
 const port = Number(process.env.PORT) || 4000; // port for the main simulation service

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@simulacrum/auth0",
+  "name": "@simulacrum/auth0-simulator",
   "version": "0.0.0",
   "description": "Simulate Auth0",
   "main": "dist/index.js",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "composite": true,
     "declarationMap": true,
     "paths": {
-      "@simulacrum/auth0": ["packages/auth0/src"],
+      "@simulacrum/auth0-simulator": ["packages/auth0/src"],
       "@simulacrum/client": ["packages/client/src"],
       "@simulacrum/server": ["packages/server/src"]
     }


### PR DESCRIPTION
## Motivation

The name `@simulacrum/auth0-simulator` describes exactly what the package does

## Approach

`@simulacrum/auth0` becomes `@simulacrum/auth0-simulator`.
