### PR TITLE
Apply consistent format for all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,35 +5,17 @@
 
 # Simulacrum
 
-A simulation platform to supercharge acceptance testing, enable
-high-fidelity application previews, and free up development teams to
-make progress independently.
+A simulation platform to supercharge acceptance testing, enable high-fidelity application previews, and free up development teams to make progress independently.
 
-Modern applications have modern dependencies. Whether they run on the
-server or in the browser, they rely on external services to get their
-jobs done. But along with the power to focus our business logic and
-distribute it across so many different points comes a fundamental
-weakness: The entire experience, from development, to testing, to
-continuous integration is coupled to the very in-the-moment states of
-actual deployments. This becomes problematic when those deployments
-are down, rate limited, under active development, or not functioning
-as expected in any way.
+Modern applications have modern dependencies. Whether they run on the server or in the browser, they rely on external services to get their jobs done. But along with the power to focus our business logic and distribute it across so many different points comes a fundamental weakness: The entire experience, from development, to testing, to continuous integration is coupled to the very in-the-moment states of actual deployments. This becomes problematic when those deployments are down, rate limited, under active development, or not functioning as expected in any way.
 
-Simulacrum removes these constraints from your process by allowing you
-to simulate external dependencies with a very high degree of
-reality.
+Simulacrum removes these constraints from your process by allowing you to simulate external dependencies with a very high degree of reality.
 
 ## Usage
 
-Simulacrum is based on a client server architecture. The server can hold
-any number of simulations which you can create and control via the
-client. The following examples use JavaScript, but under the hood it
-is just connects over HTTP and so can be used from any language.
+Simulacrum is based on a client server architecture. The server can hold any number of simulations which you can create and control via the client. The following examples use JavaScript, but under the hood it is just connects over HTTP and so can be used from any language.
 
-To create a simulation in a simulacrum server with one of its
-available simulators. In this case, we'll assume that there is an
-`auth0` simulator on the server that we can use to create a simulation.
-
+To create a simulation in a simulacrum server with one of its available simulators. In this case, we'll assume that there is an `auth0` simulator on the server that we can use to create a simulation.
 
 ``` javascript
 import { Client, createClient } from '@simulacrum/client';
@@ -49,23 +31,23 @@ let simulation = await client.createSimulation("auth0");
 //
 ```
 
-The resulting simulation has a list of service endpoints that you can
-use to configure whatever things needed for `auth0`.
+The resulting simulation has a list of service endpoints that you can use to configure whatever things needed for `auth0`.
 
-To create a user that you can log in as, you would run the `person`
-scenario. This will create a person with realistic data.
+To create a user that you can log in as, you would run the `person` scenario. This will create a person with realistic data.
 
 ``` javascript
 let person = await client.given(simulation, "person");
-person.name //=> Paul Waters
-person.email // => Paul
+person.name // => Paul Waters
+person.email // => paul.waters@gmail.com
 ```
 
 ## Development
 
+```
 $ npm install
 $ npm run build
 $ npm test
+```
 
 <!--
 ## Testing

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,7 +1,5 @@
 # @simulacrum/client
 
-A JavaScript client to control a `@simulacrum/server` over HTTP from
-inside your testcases, preview applications, and local development
-environment.
+A JavaScript client to control a `@simulacrum/server` over HTTP from inside your testcases, preview applications, and local development environment.
 
 https://github.com/thefrontside/simulacrum

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,6 +1,5 @@
 # @simulacrum/server
 
-Server capable of running multiple concurrent simulations that can be
-controlled by test cases, preview apps, and local developer environments.
+Server capable of running multiple concurrent simulations that can be controlled by test cases, preview apps, and local developer environments.
 
 https://github.com/thefrontside/simulacrum

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -4,17 +4,14 @@ A Web application to manage a simulacrum server
 
 ### Development
 
-To start the web application in development mode, first start your
-`@simulacrum/server`. For example to start the dev server on port
-5000, run from the server directory:
+To start the web application in development mode, first start your `@simulacrum/server`. For example to start the dev server on port 5000, run from the server directory:
 
 ``` shell
 > PORT=5000 npm start
 Simulation server running on http://localhost:5000
 ```
 
-Now you can start your development client and point it at the
-development server. from the `packages/ui` directory:
+Now you can start your development client and point it at the development server. from the `packages/ui` directory:
 
 ```
 > npm start


### PR DESCRIPTION
- Single line for paragraphs
- Development code block needed backticks