### PR TITLE
Fix auth0-simulator dependencies in examples

### DIFF
--- a/.changes/auth0-simulator-dependencies.md
+++ b/.changes/auth0-simulator-dependencies.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-simulator": minor
+---
+Fix auth0-simulator dependencies in examples

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -31,7 +31,7 @@
       "path": "./examples/nextjs-with-auth0-react",
       "manager": "javascript",
       "dependencies": [
-        "@simulacrum/auth0",
+        "@simulacrum/auth0-simulator",
         "@simulacrum/server",
         "@simulacrum/client"
       ],
@@ -42,7 +42,7 @@
       "path": "./examples/nextjs-with-nextjs-auth0",
       "manager": "javascript",
       "dependencies": [
-        "@simulacrum/auth0",
+        "@simulacrum/auth0-simulator",
         "@simulacrum/server",
         "@simulacrum/client"
       ],

--- a/examples/nextjs-with-auth0-react/package-lock.json
+++ b/examples/nextjs-with-auth0-react/package-lock.json
@@ -1,26 +1,26 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum-examples/nextjs-with-auth0-react",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "workspaces": [
         "../../packages/*"
       ],
       "dependencies": {
         "@auth0/auth0-react": "^1.6.0",
-        "effection": "^2.0.0-beta.3",
+        "effection": "2.0.0-beta.5",
         "next": "11.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@simulacrum/auth0": "0.0.0",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/server": "0.2.0",
+        "@simulacrum/auth0-simulator": "0.1.0",
+        "@simulacrum/client": "0.4.0",
+        "@simulacrum/server": "0.3.0",
         "@types/react": "17.0.14",
         "eslint": "7.30.0",
         "eslint-config-next": "11.0.1",
@@ -29,27 +29,27 @@
     },
     "../../packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@effection/process": "^2.0.0-beta.3",
-        "@simulacrum/server": "0.2.0",
+        "@effection/process": "^2.0.0-beta.6",
+        "@simulacrum/server": "0.3.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
         "cookie-session": "^1.4.0",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "html-entities": "^2.3.2",
         "jsesc": "^3.0.2",
         "jsonwebtoken": "^8.5.1"
       },
       "devDependencies": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/mocha": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
+        "@simulacrum/client": "0.4.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/jsesc": "^2.5.1",
@@ -68,10 +68,10 @@
     },
     "../../packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "graphql-ws": "^4.2.3",
         "isomorphic-ws": "^4.0.1"
       },
@@ -85,16 +85,16 @@
     },
     "../../packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
-        "@simulacrum/ui": "0.0.2",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/process": "^2.0.0-beta.6",
+        "@simulacrum/ui": "0.1.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
         "faker": "^5.5.0",
@@ -106,11 +106,11 @@
         "ws": "^7.4.4"
       },
       "devDependencies": {
-        "@effection/mocha": "^2.0.0-beta.3",
+        "@effection/mocha": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
+        "@simulacrum/client": "0.4.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -127,7 +127,7 @@
     },
     "../../packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
         "@frontside/eslint-config": "^2.0.0",
@@ -228,35 +228,35 @@
       }
     },
     "node_modules/@effection/channel": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.5.tgz",
+      "integrity": "sha512-stGkHcm2pqk5GvBrQWDfiwSIFjd/xgzxYwYV0p2Fm+fcO0VU+KysnQlZYAd/243JHve8iLwPIv3B98ec6UQRUw==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.5"
       }
     },
     "node_modules/@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-S2q3bkb04Z5t8eB7YXZ6fwd5C1KIfi7VnBt9J00j2DyPupDYaPu0CY5CvQ7fbm0XIg5RxHYNcyoy0NY9mjQmxA=="
     },
     "node_modules/@effection/events": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.5.tgz",
+      "integrity": "sha512-WqHGOI++FblwMqdL4/+Wpdk5G2WmEL6G+SHeV5jazxWjwRrdrn/a/rq/jzDz6cvIKEeW19hNAuVMYi4GB5R4wg==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.5"
       }
     },
     "node_modules/@effection/main": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.3.tgz",
-      "integrity": "sha512-8AKM/jCbQJowFe8Yh6ctFx0cBrujOUg9PkBKDLktXGS41dauscvkzYI3lZfrJncO0V/4ynjXt+5ysMgfFGMqrQ==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.5.tgz",
+      "integrity": "sha512-lE8R8IcsSyBXZg0f9q6tCY3iR3gXkMiSQJ4VNfXMo/X8LA6ov35M7hILiN6hl70U3GKs+9pP87cPs7nqPbq0wQ==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
+        "@effection/core": "2.0.0-beta.5",
         "chalk": "^4.1.1",
         "stacktrace-parser": "^0.1.10"
       }
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@effection/main/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -326,11 +326,11 @@
       }
     },
     "node_modules/@effection/subscription": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.5.tgz",
+      "integrity": "sha512-kEJV+iYRjLdbMc9Rba849YKsECIW1/i4MniGzWb8W5YezsE+0fTH4vEMvYY6Up1eIzXNaV/7iR+XD38PViiozA==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -597,10 +597,6 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.0.6.tgz",
       "integrity": "sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==",
       "dev": true
-    },
-    "node_modules/@simulacrum/auth0": {
-      "resolved": "../../packages/auth0",
-      "link": true
     },
     "node_modules/@simulacrum/auth0-simulator": {
       "resolved": "../../packages/auth0",
@@ -1627,15 +1623,16 @@
       }
     },
     "node_modules/effection": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.3.tgz",
-      "integrity": "sha512-iNcBfF2txr0yOj7h1mEd0RHp10BDM+lDUGmn0smnCNMqyHyclTaQ3nIAK1fjgPuWNkeGjzhNlOi/pp7WHWzNkg==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.5.tgz",
+      "integrity": "sha512-tVoj0yuROh+3erdik5UePnnFPAPoJ6jwTgyzhekWzKL3FRr9xOy0kY4AVkb9kqmDA2X+C6vqUhF6qkA2gnGy1Q==",
+      "license": "MIT",
       "dependencies": {
-        "@effection/channel": "2.0.0-beta.3",
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/main": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/channel": "2.0.0-beta.5",
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.5",
+        "@effection/main": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.5"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5651,35 +5648,35 @@
       }
     },
     "@effection/channel": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.5.tgz",
+      "integrity": "sha512-stGkHcm2pqk5GvBrQWDfiwSIFjd/xgzxYwYV0p2Fm+fcO0VU+KysnQlZYAd/243JHve8iLwPIv3B98ec6UQRUw==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.5"
       }
     },
     "@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-S2q3bkb04Z5t8eB7YXZ6fwd5C1KIfi7VnBt9J00j2DyPupDYaPu0CY5CvQ7fbm0XIg5RxHYNcyoy0NY9mjQmxA=="
     },
     "@effection/events": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.5.tgz",
+      "integrity": "sha512-WqHGOI++FblwMqdL4/+Wpdk5G2WmEL6G+SHeV5jazxWjwRrdrn/a/rq/jzDz6cvIKEeW19hNAuVMYi4GB5R4wg==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.5"
       }
     },
     "@effection/main": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.3.tgz",
-      "integrity": "sha512-8AKM/jCbQJowFe8Yh6ctFx0cBrujOUg9PkBKDLktXGS41dauscvkzYI3lZfrJncO0V/4ynjXt+5ysMgfFGMqrQ==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.5.tgz",
+      "integrity": "sha512-lE8R8IcsSyBXZg0f9q6tCY3iR3gXkMiSQJ4VNfXMo/X8LA6ov35M7hILiN6hl70U3GKs+9pP87cPs7nqPbq0wQ==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3",
+        "@effection/core": "2.0.0-beta.5",
         "chalk": "^4.1.1",
         "stacktrace-parser": "^0.1.10"
       },
@@ -5693,9 +5690,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -5730,11 +5727,11 @@
       }
     },
     "@effection/subscription": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.5.tgz",
+      "integrity": "sha512-kEJV+iYRjLdbMc9Rba849YKsECIW1/i4MniGzWb8W5YezsE+0fTH4vEMvYY6Up1eIzXNaV/7iR+XD38PViiozA==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5"
       }
     },
     "@eslint/eslintrc": {
@@ -5944,52 +5941,17 @@
       "integrity": "sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==",
       "dev": true
     },
-    "@simulacrum/auth0": {
-      "version": "file:../../packages/auth0",
-      "requires": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
-        "@frontside/eslint-config": "^2.0.0",
-        "@frontside/tsconfig": "^1.2.0",
-        "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/server": "0.2.0",
-        "@types/base64-url": "^2.2.0",
-        "@types/cookie-session": "^2.0.42",
-        "@types/faker": "^5.1.7",
-        "@types/jsesc": "^2.5.1",
-        "@types/jsonwebtoken": "^8.5.1",
-        "@types/mocha": "^8.2.1",
-        "@types/ws": "^7.4.4",
-        "assert-ts": "^0.3.2",
-        "base64-url": "^2.3.3",
-        "cookie-session": "^1.4.0",
-        "copy": "^0.3.2",
-        "effection": "^2.0.0-beta.3",
-        "expect": "^26.6.2",
-        "html-entities": "^2.3.2",
-        "jsesc": "^3.0.2",
-        "jsonwebtoken": "^8.5.1",
-        "keygrip": "^1.1.0",
-        "mocha": "^8.0.0",
-        "rimraf": "^3.0.2",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.2.3",
-        "ws": "^7.4.4"
-      }
-    },
     "@simulacrum/auth0-simulator": {
       "version": "file:../../packages/auth0",
       "requires": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/mocha": "^2.0.0-beta.6",
+        "@effection/process": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/server": "0.2.0",
+        "@simulacrum/client": "0.4.0",
+        "@simulacrum/server": "0.3.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/faker": "^5.1.7",
@@ -6001,7 +5963,7 @@
         "base64-url": "^2.3.3",
         "cookie-session": "^1.4.0",
         "copy": "^0.3.2",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "expect": "^26.6.2",
         "html-entities": "^2.3.2",
         "jsesc": "^3.0.2",
@@ -6020,7 +5982,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "graphql-ws": "^4.2.3",
         "isomorphic-ws": "^4.0.1",
         "ts-node": "^9.1.1",
@@ -6030,14 +5992,14 @@
     "@simulacrum/server": {
       "version": "file:../../packages/server",
       "requires": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/mocha": "^2.0.0-beta.6",
+        "@effection/process": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/ui": "0.0.2",
+        "@simulacrum/client": "0.4.0",
+        "@simulacrum/ui": "0.1.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",
@@ -6047,7 +6009,7 @@
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
         "cross-fetch": "^3.1.0",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "expect": "^26.6.2",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
@@ -6868,15 +6830,15 @@
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
     },
     "effection": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.3.tgz",
-      "integrity": "sha512-iNcBfF2txr0yOj7h1mEd0RHp10BDM+lDUGmn0smnCNMqyHyclTaQ3nIAK1fjgPuWNkeGjzhNlOi/pp7WHWzNkg==",
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.5.tgz",
+      "integrity": "sha512-tVoj0yuROh+3erdik5UePnnFPAPoJ6jwTgyzhekWzKL3FRr9xOy0kY4AVkb9kqmDA2X+C6vqUhF6qkA2gnGy1Q==",
       "requires": {
-        "@effection/channel": "2.0.0-beta.3",
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/main": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/channel": "2.0.0-beta.5",
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.5",
+        "@effection/main": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.5"
       }
     },
     "electron-to-chromium": {

--- a/examples/nextjs-with-auth0-react/package.json
+++ b/examples/nextjs-with-auth0-react/package.json
@@ -15,13 +15,13 @@
   ],
   "dependencies": {
     "@auth0/auth0-react": "^1.6.0",
-    "effection": "^2.0.0-beta.3",
+    "effection": "2.0.0-beta.5",
     "next": "11.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0": "0.0.0",
+    "@simulacrum/auth0-simulator": "0.1.0",
     "@simulacrum/client": "0.4.0",
     "@simulacrum/server": "0.3.0",
     "@types/react": "17.0.14",

--- a/examples/nextjs-with-auth0-react/simulator-server.mjs
+++ b/examples/nextjs-with-auth0-react/simulator-server.mjs
@@ -1,6 +1,6 @@
 import { main } from "effection";
 import { createSimulationServer } from "@simulacrum/server";
-import { auth0 } from "@simulacrum/auth0";
+import { auth0 } from "@simulacrum/auth0-simulator";
 import { createClient } from "@simulacrum/client";
 
 const port = Number(process.env.PORT) || 4000; // port for the main simulation service

--- a/examples/nextjs-with-nextjs-auth0/package-lock.json
+++ b/examples/nextjs-with-nextjs-auth0/package-lock.json
@@ -1,27 +1,27 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "workspaces": [
         "../../packages/*"
       ],
       "dependencies": {
         "@auth0/nextjs-auth0": "^1.5.0",
         "assert-ts": "^0.3.3",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.5",
         "next": "11.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@simulacrum/auth0": "0.0.0",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/server": "0.2.0",
+        "@simulacrum/auth0-simulator": "0.1.0",
+        "@simulacrum/client": "0.4.0",
+        "@simulacrum/server": "0.3.0",
         "@types/react": "17.0.14",
         "eslint": "7.30.0",
         "eslint-config-next": "11.0.1",
@@ -30,27 +30,27 @@
     },
     "../../packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@effection/process": "^2.0.0-beta.3",
-        "@simulacrum/server": "0.2.0",
+        "@effection/process": "^2.0.0-beta.6",
+        "@simulacrum/server": "0.3.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
         "cookie-session": "^1.4.0",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "html-entities": "^2.3.2",
         "jsesc": "^3.0.2",
         "jsonwebtoken": "^8.5.1"
       },
       "devDependencies": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/mocha": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
+        "@simulacrum/client": "0.4.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/jsesc": "^2.5.1",
@@ -69,10 +69,10 @@
     },
     "../../packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "graphql-ws": "^4.2.3",
         "isomorphic-ws": "^4.0.1"
       },
@@ -86,16 +86,16 @@
     },
     "../../packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
-        "@simulacrum/ui": "0.0.2",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/process": "^2.0.0-beta.6",
+        "@simulacrum/ui": "0.1.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
         "faker": "^5.5.0",
@@ -107,11 +107,11 @@
         "ws": "^7.4.4"
       },
       "devDependencies": {
-        "@effection/mocha": "^2.0.0-beta.3",
+        "@effection/mocha": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
+        "@simulacrum/client": "0.4.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -128,7 +128,7 @@
     },
     "../../packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
         "@frontside/eslint-config": "^2.0.0",
@@ -273,35 +273,35 @@
       }
     },
     "node_modules/@effection/channel": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.6.tgz",
+      "integrity": "sha512-uyHjHYk1k6enduDZLQA7LFRp33pDc5rA4T/Fgw2wSUsxwENxjLYgS2N1hXn6ytHbS4TXlWFi1MV4F7iC3HDFSw==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.6",
+        "@effection/subscription": "2.0.0-beta.6"
       }
     },
     "node_modules/@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-S2q3bkb04Z5t8eB7YXZ6fwd5C1KIfi7VnBt9J00j2DyPupDYaPu0CY5CvQ7fbm0XIg5RxHYNcyoy0NY9mjQmxA=="
     },
     "node_modules/@effection/events": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.6.tgz",
+      "integrity": "sha512-6G5FoOsj1olnW5Yq2ZdU83eZ8d5A3mR6t908Xa/cmzDVGbrSQsYsqevEj65aCcIWClWLRcXovCNaR7sUu8rO9A==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.6"
       }
     },
     "node_modules/@effection/main": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.3.tgz",
-      "integrity": "sha512-8AKM/jCbQJowFe8Yh6ctFx0cBrujOUg9PkBKDLktXGS41dauscvkzYI3lZfrJncO0V/4ynjXt+5ysMgfFGMqrQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.6.tgz",
+      "integrity": "sha512-xDfNQp0/l7lz5Mzbdeoug1tymz0974PAVZBfgWttjuC3G/tMs5nj3q8Jn5tf+gUGmlcK8rZmPDrBsiEJ53PTYw==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3",
+        "@effection/core": "2.0.0-beta.5",
         "chalk": "^4.1.1",
         "stacktrace-parser": "^0.1.10"
       }
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@effection/main/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -371,11 +371,11 @@
       }
     },
     "node_modules/@effection/subscription": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.6.tgz",
+      "integrity": "sha512-psE6eml8EQZhbgJ2SWqLvK7ssm0U+JxHDJy4Pqak6wcjysVgWrP7ANgycRytUHslle2mb0vnC9tU/6+m951PSg==",
       "dependencies": {
-        "@effection/core": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -676,10 +676,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
-    },
-    "node_modules/@simulacrum/auth0": {
-      "resolved": "../../packages/auth0",
-      "link": true
     },
     "node_modules/@simulacrum/auth0-simulator": {
       "resolved": "../../packages/auth0",
@@ -1843,15 +1839,16 @@
       }
     },
     "node_modules/effection": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.3.tgz",
-      "integrity": "sha512-iNcBfF2txr0yOj7h1mEd0RHp10BDM+lDUGmn0smnCNMqyHyclTaQ3nIAK1fjgPuWNkeGjzhNlOi/pp7WHWzNkg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.6.tgz",
+      "integrity": "sha512-RB8owFe1f8GL3xzoxr/mXknYyZ0mZqbCGBMKpomXzOJT2xqPFHASMffWfsiEbvsoH3cw7HXIiZvZn+wfQzQL9g==",
+      "license": "MIT",
       "dependencies": {
-        "@effection/channel": "2.0.0-beta.3",
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/main": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/channel": "2.0.0-beta.6",
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.6",
+        "@effection/main": "2.0.0-beta.6",
+        "@effection/subscription": "2.0.0-beta.6"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6116,35 +6113,35 @@
       }
     },
     "@effection/channel": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.3.tgz",
-      "integrity": "sha512-EUU/qna8Rg/0OeXJW6EucXOjB3zM8g/Zh8eMtgjaj3UClEdqdgS/Pc6LbjZnuVubD5bvONhIkYbeHLOjCK/7yg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-2.0.0-beta.6.tgz",
+      "integrity": "sha512-uyHjHYk1k6enduDZLQA7LFRp33pDc5rA4T/Fgw2wSUsxwENxjLYgS2N1hXn6ytHbS4TXlWFi1MV4F7iC3HDFSw==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.6",
+        "@effection/subscription": "2.0.0-beta.6"
       }
     },
     "@effection/core": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.3.tgz",
-      "integrity": "sha512-VT6Y/JNyKGZ0Z1smFEOt4jntztUJULPGJoln2IJKY2rAOQhO3XATtH43n25KfyXXZkZpWga3LnA9ROBd7BFSBQ=="
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@effection/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-S2q3bkb04Z5t8eB7YXZ6fwd5C1KIfi7VnBt9J00j2DyPupDYaPu0CY5CvQ7fbm0XIg5RxHYNcyoy0NY9mjQmxA=="
     },
     "@effection/events": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.3.tgz",
-      "integrity": "sha512-H+42DtB7eGLV/JKZxwS/OkqLHciUlBNRiffs0fron4d8pIu3KJIVB2ZihjbgxuquDLwSp6SPo8LexxNwLDHJLQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/events/-/events-2.0.0-beta.6.tgz",
+      "integrity": "sha512-6G5FoOsj1olnW5Yq2ZdU83eZ8d5A3mR6t908Xa/cmzDVGbrSQsYsqevEj65aCcIWClWLRcXovCNaR7sUu8rO9A==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/subscription": "2.0.0-beta.6"
       }
     },
     "@effection/main": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.3.tgz",
-      "integrity": "sha512-8AKM/jCbQJowFe8Yh6ctFx0cBrujOUg9PkBKDLktXGS41dauscvkzYI3lZfrJncO0V/4ynjXt+5ysMgfFGMqrQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/main/-/main-2.0.0-beta.6.tgz",
+      "integrity": "sha512-xDfNQp0/l7lz5Mzbdeoug1tymz0974PAVZBfgWttjuC3G/tMs5nj3q8Jn5tf+gUGmlcK8rZmPDrBsiEJ53PTYw==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3",
+        "@effection/core": "2.0.0-beta.5",
         "chalk": "^4.1.1",
         "stacktrace-parser": "^0.1.10"
       },
@@ -6158,9 +6155,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -6195,11 +6192,11 @@
       }
     },
     "@effection/subscription": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.3.tgz",
-      "integrity": "sha512-RxZQ/kfBBHiGUWGbYed80og9YrN5xpSV1XLDw2p/AHvaVGYgCU+jui/0hdGUsjcDB5V9iNYhcmIJC5cz0wXW5w==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@effection/subscription/-/subscription-2.0.0-beta.6.tgz",
+      "integrity": "sha512-psE6eml8EQZhbgJ2SWqLvK7ssm0U+JxHDJy4Pqak6wcjysVgWrP7ANgycRytUHslle2mb0vnC9tU/6+m951PSg==",
       "requires": {
-        "@effection/core": "2.0.0-beta.3"
+        "@effection/core": "2.0.0-beta.5"
       }
     },
     "@eslint/eslintrc": {
@@ -6440,52 +6437,17 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "@simulacrum/auth0": {
-      "version": "file:../../packages/auth0",
-      "requires": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
-        "@frontside/eslint-config": "^2.0.0",
-        "@frontside/tsconfig": "^1.2.0",
-        "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/server": "0.2.0",
-        "@types/base64-url": "^2.2.0",
-        "@types/cookie-session": "^2.0.42",
-        "@types/faker": "^5.1.7",
-        "@types/jsesc": "^2.5.1",
-        "@types/jsonwebtoken": "^8.5.1",
-        "@types/mocha": "^8.2.1",
-        "@types/ws": "^7.4.4",
-        "assert-ts": "^0.3.2",
-        "base64-url": "^2.3.3",
-        "cookie-session": "^1.4.0",
-        "copy": "^0.3.2",
-        "effection": "^2.0.0-beta.3",
-        "expect": "^26.6.2",
-        "html-entities": "^2.3.2",
-        "jsesc": "^3.0.2",
-        "jsonwebtoken": "^8.5.1",
-        "keygrip": "^1.1.0",
-        "mocha": "^8.0.0",
-        "rimraf": "^3.0.2",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.2.3",
-        "ws": "^7.4.4"
-      }
-    },
     "@simulacrum/auth0-simulator": {
       "version": "file:../../packages/auth0",
       "requires": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/mocha": "^2.0.0-beta.6",
+        "@effection/process": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/server": "0.2.0",
+        "@simulacrum/client": "0.4.0",
+        "@simulacrum/server": "0.3.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/faker": "^5.1.7",
@@ -6497,7 +6459,7 @@
         "base64-url": "^2.3.3",
         "cookie-session": "^1.4.0",
         "copy": "^0.3.2",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "expect": "^26.6.2",
         "html-entities": "^2.3.2",
         "jsesc": "^3.0.2",
@@ -6516,7 +6478,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "graphql-ws": "^4.2.3",
         "isomorphic-ws": "^4.0.1",
         "ts-node": "^9.1.1",
@@ -6526,14 +6488,14 @@
     "@simulacrum/server": {
       "version": "file:../../packages/server",
       "requires": {
-        "@effection/atom": "^2.0.0-beta.3",
-        "@effection/mocha": "^2.0.0-beta.3",
-        "@effection/process": "^2.0.0-beta.3",
+        "@effection/atom": "^2.0.0-beta.6",
+        "@effection/mocha": "^2.0.0-beta.6",
+        "@effection/process": "^2.0.0-beta.6",
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.3.0",
-        "@simulacrum/ui": "0.0.2",
+        "@simulacrum/client": "0.4.0",
+        "@simulacrum/ui": "0.1.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",
@@ -6543,7 +6505,7 @@
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
         "cross-fetch": "^3.1.0",
-        "effection": "^2.0.0-beta.3",
+        "effection": "^2.0.0-beta.6",
         "expect": "^26.6.2",
         "express": "^4.17.1",
         "express-graphql": "^0.12.0",
@@ -7467,15 +7429,15 @@
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
     },
     "effection": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.3.tgz",
-      "integrity": "sha512-iNcBfF2txr0yOj7h1mEd0RHp10BDM+lDUGmn0smnCNMqyHyclTaQ3nIAK1fjgPuWNkeGjzhNlOi/pp7WHWzNkg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/effection/-/effection-2.0.0-beta.6.tgz",
+      "integrity": "sha512-RB8owFe1f8GL3xzoxr/mXknYyZ0mZqbCGBMKpomXzOJT2xqPFHASMffWfsiEbvsoH3cw7HXIiZvZn+wfQzQL9g==",
       "requires": {
-        "@effection/channel": "2.0.0-beta.3",
-        "@effection/core": "2.0.0-beta.3",
-        "@effection/events": "2.0.0-beta.3",
-        "@effection/main": "2.0.0-beta.3",
-        "@effection/subscription": "2.0.0-beta.3"
+        "@effection/channel": "2.0.0-beta.6",
+        "@effection/core": "2.0.0-beta.5",
+        "@effection/events": "2.0.0-beta.6",
+        "@effection/main": "2.0.0-beta.6",
+        "@effection/subscription": "2.0.0-beta.6"
       }
     },
     "electron-to-chromium": {

--- a/examples/nextjs-with-nextjs-auth0/package.json
+++ b/examples/nextjs-with-nextjs-auth0/package.json
@@ -15,13 +15,13 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^1.5.0",
     "assert-ts": "^0.3.3",
-    "effection": "^2.0.0-beta.3",
+    "effection": "^2.0.0-beta.5",
     "next": "11.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0": "0.0.0",
+    "@simulacrum/auth0-simulator": "0.1.0",
     "@simulacrum/client": "0.4.0",
     "@simulacrum/server": "0.3.0",
     "@types/react": "17.0.14",

--- a/examples/nextjs-with-nextjs-auth0/simulator-server.mjs
+++ b/examples/nextjs-with-nextjs-auth0/simulator-server.mjs
@@ -1,6 +1,6 @@
 import { main } from "effection";
 import { createSimulationServer } from "@simulacrum/server";
-import { auth0 } from "@simulacrum/auth0";
+import { auth0 } from "@simulacrum/auth0-simulator";
 import { createClient } from "@simulacrum/client";
 
 const port = Number(process.env.PORT) || 4000; // port for the main simulation service

--- a/package-lock.json
+++ b/package-lock.json
@@ -7173,6 +7173,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -18487,7 +18488,9 @@
       "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-beta.6.tgz",
       "integrity": "sha512-kV0OxApKP0kchDchUz4GPEUyfoT1do5Csp7wHf42Q0BnIpRUR4orKVRllJAEq+Ur15iPiQX36AKPYc9vKpZvUw==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "@effection/core": "^2.0.0-beta.3"
+      }
     },
     "@effection/process": {
       "version": "2.0.0-beta.6",
@@ -23791,7 +23794,8 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -61,7 +61,7 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
     },
 
     ['/authorize']: function *(req, res) {
-      let responseMode = req.query.response_mode as ResponseModes;
+      let responseMode = (req.query.response_mode ?? 'query') as ResponseModes;
 
       assert(['query', 'web_message'].includes(responseMode), `unknown response_mode ${responseMode}`);
 


### PR DESCRIPTION
## Motivation

The examples repos are still pointing to `@simulacrum/auth0` and old effection versions.

## Approach

Update to `@simulatcrum/auth0-simulator` and `effection@2.0.0-beta.5`
