### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/effection-beta-5.md
+++ b/.changes/effection-beta-5.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/client": minor
-"@simulacrum/ui": minor
----
-rollback effection to beta-5.

--- a/examples/nextjs-with-auth0-react/CHANGELOG.md
+++ b/examples/nextjs-with-auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.2]
+
+- rollback effection to beta-5.
+  - Bumped due to a bump in @simulacrum/client.
+  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30
+
 ## \[0.1.1]
 
 - Fix auth0-simulator dependencies in examples

--- a/examples/nextjs-with-auth0-react/package.json
+++ b/examples/nextjs-with-auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.2.0",
-    "@simulacrum/client": "0.4.0",
-    "@simulacrum/server": "0.3.0",
+    "@simulacrum/auth0-simulator": "0.2.1",
+    "@simulacrum/client": "0.5.0",
+    "@simulacrum/server": "0.3.1",
     "@types/react": "17.0.14",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs-with-nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs-with-nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.3]
+
+- rollback effection to beta-5.
+  - Bumped due to a bump in @simulacrum/client.
+  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30
+
 ## \[0.0.2]
 
 - Fix auth0-simulator dependencies in examples

--- a/examples/nextjs-with-nextjs-auth0/package.json
+++ b/examples/nextjs-with-nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.2.0",
-    "@simulacrum/client": "0.4.0",
-    "@simulacrum/server": "0.3.0",
+    "@simulacrum/auth0-simulator": "0.2.1",
+    "@simulacrum/client": "0.5.0",
+    "@simulacrum/server": "0.3.1",
     "@types/react": "17.0.14",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7173,7 +7173,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -17914,11 +17913,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.0-beta.5",
-        "@simulacrum/server": "0.3.0",
+        "@simulacrum/server": "0.3.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -17934,7 +17933,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.4.0",
+        "@simulacrum/client": "0.5.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/jsesc": "^2.5.1",
@@ -17964,7 +17963,7 @@
     },
     "packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "effection": "^2.0.0-beta.5",
@@ -17981,12 +17980,12 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.0-beta.5",
         "@effection/process": "^2.0.0-beta.5",
-        "@simulacrum/ui": "0.1.0",
+        "@simulacrum/ui": "0.2.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
@@ -18006,7 +18005,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.4.0",
+        "@simulacrum/client": "0.5.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -18023,7 +18022,7 @@
     },
     "packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "devDependencies": {
         "@frontside/eslint-config": "^2.0.0",
@@ -18488,9 +18487,7 @@
       "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-beta.6.tgz",
       "integrity": "sha512-kV0OxApKP0kchDchUz4GPEUyfoT1do5Csp7wHf42Q0BnIpRUR4orKVRllJAEq+Ur15iPiQX36AKPYc9vKpZvUw==",
       "dev": true,
-      "requires": {
-        "@effection/core": "^2.0.0-beta.3"
-      }
+      "requires": {}
     },
     "@effection/process": {
       "version": "2.0.0-beta.6",
@@ -19659,8 +19656,8 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.4.0",
-        "@simulacrum/server": "0.3.0",
+        "@simulacrum/client": "0.5.0",
+        "@simulacrum/server": "0.3.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/faker": "^5.1.7",
@@ -19714,8 +19711,8 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^1.1.1",
-        "@simulacrum/client": "0.4.0",
-        "@simulacrum/ui": "0.1.0",
+        "@simulacrum/client": "0.5.0",
+        "@simulacrum/ui": "0.2.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",
@@ -23794,8 +23791,7 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-value": {
       "version": "2.0.6",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.2.1]
+
+- rollback effection to beta-5.
+  - Bumped due to a bump in @simulacrum/client.
+  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30
+
 ## \[0.2.0]
 
 - Fix auth0-simulator dependencies in examples

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Simulate Auth0",
   "main": "dist/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
     "@effection/process": "^2.0.0-beta.5",
-    "@simulacrum/server": "0.3.0",
+    "@simulacrum/server": "0.3.1",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",
@@ -46,7 +46,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
-    "@simulacrum/client": "0.4.0",
+    "@simulacrum/client": "0.5.0",
     "@types/base64-url": "^2.2.0",
     "@types/cookie-session": "^2.0.42",
     "@types/jsesc": "^2.5.1",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.0]
+
+- rollback effection to beta-5.
+  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30
+
 ## \[0.4.0]
 
 - Automatically detect platform (nodejs, browser) and use appropriate

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "connect to simulacrum servers and manipulate them via the control API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.3.1]
+
+- rollback effection to beta-5.
+  - Bumped due to a bump in @simulacrum/client.
+  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30
+
 ## \[0.3.0]
 
 - upgrade to effection@2.0.0-beta.6

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   "dependencies": {
     "@effection/atom": "^2.0.0-beta.5",
     "@effection/process": "^2.0.0-beta.5",
-    "@simulacrum/ui": "0.1.0",
+    "@simulacrum/ui": "0.2.0",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "cors": "^2.8.5",
@@ -49,7 +49,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
-    "@simulacrum/client": "0.4.0",
+    "@simulacrum/client": "0.5.0",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/mocha": "^8.2.1",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.2.0]
+
+- rollback effection to beta-5.
+  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30
+
 ## \[0.1.0]
 
 - upgrade to effection@2.0.0-beta.6

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A web UI to work with a Simulacrum Server",
   "browser": "dist/index.html",
   "main": "index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/client

## [0.5.0]
- rollback effection to beta-5.
  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30



# @simulacrum/server

## [0.3.1]
- rollback effection to beta-5.
  - Bumped due to a bump in @simulacrum/client.
  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30



# @simulacrum/auth0-simulator

## [0.2.1]
- rollback effection to beta-5.
  - Bumped due to a bump in @simulacrum/client.
  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30



# @simulacrum/ui

## [0.2.0]
- rollback effection to beta-5.
  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.2]
- rollback effection to beta-5.
  - Bumped due to a bump in @simulacrum/client.
  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.3]
- rollback effection to beta-5.
  - Bumped due to a bump in @simulacrum/client.
  - [793c074](https://github.com/thefrontside/simulacrum/commit/793c074c73d4958a9db5231b7ffdd54b5f103d4a) rollback effection to beta-5 on 2021-07-30