### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/bare-export-person-scenario.md
+++ b/.changes/bare-export-person-scenario.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-Fix bug where person scenario was not passing parameters down

--- a/.changes/email-typo.md
+++ b/.changes/email-typo.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-fix malformed token that had `mail` field, not `email` field

--- a/.changes/error.md
+++ b/.changes/error.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-Add a `debug` option to server that will log errors when
-createSimulation() fails

--- a/examples/nextjs-with-auth0-react/CHANGELOG.md
+++ b/examples/nextjs-with-auth0-react/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## \[0.1.3]
+
+- Fix bug where person scenario was not passing parameters down
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [cfe6862](https://github.com/thefrontside/simulacrum/commit/cfe68622e3609336e0cde6ea40c3d144710c3734) Transparently pass through person scenario on 2021-08-05
+- fix malformed token that had `mail` field, not `email` field
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [da75afd](https://github.com/thefrontside/simulacrum/commit/da75afdd0b5c47901e05ae7df5a4f968d0d2d613) add changefile on 2021-08-05
+- Add a `debug` option to server that will log errors when
+  createSimulation() fails
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [7db8e11](https://github.com/thefrontside/simulacrum/commit/7db8e110f5d262f37d7dbf670d10a98cfe29f066) add changeset on 2021-07-15
+  - [c2525dc](https://github.com/thefrontside/simulacrum/commit/c2525dcab303cc37a638c7cefe180ef9926ab9ee) remove redundant task.halt from logging effect on 2021-07-27
+  - [6c2f83e](https://github.com/thefrontside/simulacrum/commit/6c2f83e5b183906a0a45ec6f3b8c8b06369dbfdb) add description to change file on 2021-07-30
+
 ## \[0.1.2]
 
 - rollback effection to beta-5.

--- a/examples/nextjs-with-auth0-react/package.json
+++ b/examples/nextjs-with-auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.2.1",
+    "@simulacrum/auth0-simulator": "0.2.2",
     "@simulacrum/client": "0.5.0",
     "@simulacrum/server": "0.3.1",
     "@types/react": "17.0.14",

--- a/examples/nextjs-with-nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs-with-nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## \[0.0.4]
+
+- Fix bug where person scenario was not passing parameters down
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [cfe6862](https://github.com/thefrontside/simulacrum/commit/cfe68622e3609336e0cde6ea40c3d144710c3734) Transparently pass through person scenario on 2021-08-05
+- fix malformed token that had `mail` field, not `email` field
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [da75afd](https://github.com/thefrontside/simulacrum/commit/da75afdd0b5c47901e05ae7df5a4f968d0d2d613) add changefile on 2021-08-05
+- Add a `debug` option to server that will log errors when
+  createSimulation() fails
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [7db8e11](https://github.com/thefrontside/simulacrum/commit/7db8e110f5d262f37d7dbf670d10a98cfe29f066) add changeset on 2021-07-15
+  - [c2525dc](https://github.com/thefrontside/simulacrum/commit/c2525dcab303cc37a638c7cefe180ef9926ab9ee) remove redundant task.halt from logging effect on 2021-07-27
+  - [6c2f83e](https://github.com/thefrontside/simulacrum/commit/6c2f83e5b183906a0a45ec6f3b8c8b06369dbfdb) add description to change file on 2021-07-30
+
 ## \[0.0.3]
 
 - rollback effection to beta-5.

--- a/examples/nextjs-with-nextjs-auth0/package.json
+++ b/examples/nextjs-with-nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.2.1",
+    "@simulacrum/auth0-simulator": "0.2.2",
     "@simulacrum/client": "0.5.0",
     "@simulacrum/server": "0.3.1",
     "@types/react": "17.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7184,7 +7184,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -17925,7 +17924,7 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.0-beta.5",
@@ -17939,9 +17938,6 @@
         "html-entities": "^2.3.2",
         "jsesc": "^3.0.2",
         "jsonwebtoken": "^8.5.1"
-      },
-      "bin": {
-        "auth0-simulator": "bin/index.js"
       },
       "devDependencies": {
         "@effection/atom": "^2.0.0-beta.5",
@@ -18504,9 +18500,7 @@
       "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-beta.6.tgz",
       "integrity": "sha512-kV0OxApKP0kchDchUz4GPEUyfoT1do5Csp7wHf42Q0BnIpRUR4orKVRllJAEq+Ur15iPiQX36AKPYc9vKpZvUw==",
       "dev": true,
-      "requires": {
-        "@effection/core": "^2.0.0-beta.3"
-      }
+      "requires": {}
     },
     "@effection/process": {
       "version": "2.0.0-beta.6",
@@ -23823,8 +23817,7 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-value": {
       "version": "2.0.6",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## \[0.2.2]
+
+- Fix bug where person scenario was not passing parameters down
+  - [cfe6862](https://github.com/thefrontside/simulacrum/commit/cfe68622e3609336e0cde6ea40c3d144710c3734) Transparently pass through person scenario on 2021-08-05
+- fix malformed token that had `mail` field, not `email` field
+  - [da75afd](https://github.com/thefrontside/simulacrum/commit/da75afdd0b5c47901e05ae7df5a4f968d0d2d613) add changefile on 2021-08-05
+- Add a `debug` option to server that will log errors when
+  createSimulation() fails
+  - [7db8e11](https://github.com/thefrontside/simulacrum/commit/7db8e110f5d262f37d7dbf670d10a98cfe29f066) add changeset on 2021-07-15
+  - [c2525dc](https://github.com/thefrontside/simulacrum/commit/c2525dcab303cc37a638c7cefe180ef9926ab9ee) remove redundant task.halt from logging effect on 2021-07-27
+  - [6c2f83e](https://github.com/thefrontside/simulacrum/commit/6c2f83e5b183906a0a45ec6f3b8c8b06369dbfdb) add description to change file on 2021-07-30
+
 ## \[0.2.1]
 
 - rollback effection to beta-5.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Simulate Auth0",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/auth0-simulator

## [0.2.2]
- Fix bug where person scenario was not passing parameters down
  - [cfe6862](https://github.com/thefrontside/simulacrum/commit/cfe68622e3609336e0cde6ea40c3d144710c3734) Transparently pass through person scenario on 2021-08-05
- fix malformed token that had `mail` field, not `email` field
  - [da75afd](https://github.com/thefrontside/simulacrum/commit/da75afdd0b5c47901e05ae7df5a4f968d0d2d613) add changefile on 2021-08-05
- Add a `debug` option to server that will log errors when
createSimulation() fails
  - [7db8e11](https://github.com/thefrontside/simulacrum/commit/7db8e110f5d262f37d7dbf670d10a98cfe29f066) add changeset on 2021-07-15
  - [c2525dc](https://github.com/thefrontside/simulacrum/commit/c2525dcab303cc37a638c7cefe180ef9926ab9ee) remove redundant task.halt from logging effect on 2021-07-27
  - [6c2f83e](https://github.com/thefrontside/simulacrum/commit/6c2f83e5b183906a0a45ec6f3b8c8b06369dbfdb) add description to change file on 2021-07-30



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.3]
- Fix bug where person scenario was not passing parameters down
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [cfe6862](https://github.com/thefrontside/simulacrum/commit/cfe68622e3609336e0cde6ea40c3d144710c3734) Transparently pass through person scenario on 2021-08-05
- fix malformed token that had `mail` field, not `email` field
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [da75afd](https://github.com/thefrontside/simulacrum/commit/da75afdd0b5c47901e05ae7df5a4f968d0d2d613) add changefile on 2021-08-05
- Add a `debug` option to server that will log errors when
createSimulation() fails
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [7db8e11](https://github.com/thefrontside/simulacrum/commit/7db8e110f5d262f37d7dbf670d10a98cfe29f066) add changeset on 2021-07-15
  - [c2525dc](https://github.com/thefrontside/simulacrum/commit/c2525dcab303cc37a638c7cefe180ef9926ab9ee) remove redundant task.halt from logging effect on 2021-07-27
  - [6c2f83e](https://github.com/thefrontside/simulacrum/commit/6c2f83e5b183906a0a45ec6f3b8c8b06369dbfdb) add description to change file on 2021-07-30



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.4]
- Fix bug where person scenario was not passing parameters down
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [cfe6862](https://github.com/thefrontside/simulacrum/commit/cfe68622e3609336e0cde6ea40c3d144710c3734) Transparently pass through person scenario on 2021-08-05
- fix malformed token that had `mail` field, not `email` field
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [da75afd](https://github.com/thefrontside/simulacrum/commit/da75afdd0b5c47901e05ae7df5a4f968d0d2d613) add changefile on 2021-08-05
- Add a `debug` option to server that will log errors when
createSimulation() fails
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [7db8e11](https://github.com/thefrontside/simulacrum/commit/7db8e110f5d262f37d7dbf670d10a98cfe29f066) add changeset on 2021-07-15
  - [c2525dc](https://github.com/thefrontside/simulacrum/commit/c2525dcab303cc37a638c7cefe180ef9926ab9ee) remove redundant task.halt from logging effect on 2021-07-27
  - [6c2f83e](https://github.com/thefrontside/simulacrum/commit/6c2f83e5b183906a0a45ec6f3b8c8b06369dbfdb) add description to change file on 2021-07-30