### PR TITLE
Transparently pass through person scenario

### DIFF
--- a/.changes/bare-export-person-scenario.md
+++ b/.changes/bare-export-person-scenario.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-simulator": patch
+---
+Fix bug where person scenario was not passing parameters down

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -57,14 +57,12 @@ export const auth0: Simulator<Options> = (slice, options) => {
     services: { auth0: createAuth0Service({ ...auth0Handlers, ...openIdHandlers }) },
     scenarios: {
       /**
-       * Here we just wrap the internal `person` scenario to augment
-       * it with a username and password
-       * but what we really need to have some way to _react_ to the person
+       * Here we just export the internal `person` scenario so that it can be
+       * used with the a standalone auth0 simulator. However,
+       * what we really need to have some way to _react_ to the person
        * having been created and augment the record at that point.
        */
-      *person(store, faker) {
-        return yield person(store, faker);
-      }
+      person
     }
   };
 };


### PR DESCRIPTION
## Motivation
Originally, so that the auth0 simulator could run as a standalone, it included the person scenario by itself. To do this, it needed to augment the person scenario by allocating also an email so that the person could be identified inside Auth0. Later on,  when the capability to pass parameters to any scenario was added, the wrapper was not expanded to pass the `params` down to the underlying scenario.

## Approach

This just passes the person scenario through un-altered with no wrapper.