### PR TITLE
use `email` in the id token data, not `mail`

### DIFF
--- a/.changes/email-typo.md
+++ b/.changes/email-typo.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-simulator": patch
+---
+fix malformed token that had `mail` field, not `email` field

--- a/package-lock.json
+++ b/package-lock.json
@@ -7173,6 +7173,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -18487,7 +18488,9 @@
       "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-beta.6.tgz",
       "integrity": "sha512-kV0OxApKP0kchDchUz4GPEUyfoT1do5Csp7wHf42Q0BnIpRUR4orKVRllJAEq+Ur15iPiQX36AKPYc9vKpZvUw==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "@effection/core": "^2.0.0-beta.3"
+      }
     },
     "@effection/process": {
       "version": "2.0.0-beta.6",
@@ -23791,7 +23794,8 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -181,7 +181,7 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
         iss: url,
         exp: expiresAt(),
         iat: Date.now(),
-        mail: username,
+        email: username,
         aud: clientId,
         sub: user.id,
         nonce,

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -289,6 +289,10 @@ describe('Auth0 simulator', () => {
       it('should return an iss field with a forward slash', function* () {
         expect(token.payload.iss).toBe('https://localhost:4400/');
       });
+
+      it('token sould contain a valid email', function* () {
+        expect(token.payload.email).toBe(person.data.email);
+      });
     });
 
 


### PR DESCRIPTION
## Motivation

Id token data has the `email` field, not `mail` field: https://auth0.com/docs/api/authentication#get-user-info

This breaks an app if it is using the token data for the actual email.

## Approach

fix typo.