### PR TITLE
🐛Ignore requests in the event that the scope is not running

### DIFF
--- a/.changes/no-spawn-dead-task.md
+++ b/.changes/no-spawn-dead-task.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": patch
+---
+Ignore simulation service requests if the simulation has already been
+shut down

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -41,17 +41,21 @@ export function simulation(simulators: Record<string, Simulator>): Effect<Simula
 
         for (let handler of service.app.handlers) {
           app[handler.method](handler.path, (request, response) => {
-            scope.run(function*() {
-              try {
-                yield handler.handler(request, response);
-              } catch(err) {
+            // if the scope is already shutting down or shut down
+            // just ignore this request.
+            if (scope.state === 'running') {
+              scope.run(function*() {
+                try {
+                  yield handler.handler(request, response);
+                } catch(err) {
 
-                response.status(500);
-                response.write('server error');
-              } finally {
-                response.end();
-              }
-            });
+                  response.status(500);
+                  response.write('server error');
+                } finally {
+                  response.end();
+                }
+              });
+            }
           });
         }
 


### PR DESCRIPTION
## Motivation

Synchronously invoking a task is an operation that can fail in effection. In general, this is why you want to use a spawn operation rather than `task.run`. This isn't always possible because sometimes you need to start running a task in reaction to an event that happens outside of the effection world such as an express http request handler.

What was happening in this case was that an http requset for the simulation was arriving _after_ the simulation had been shut down already. Because the simulation was halted, it's corresponding `Task` was halted. That meant when the request came in, it raised an error trying to spawn a handler on a 'halted' scope.

## Approach

This just wraps an if statement around the handler, so that the request is ignored if the task has been halted. It should be noted that we probably want a better API for doing this in the future as external integration is an ever-present concern, and this is not really a satisfactory solution going forward. Perhaps something like what is provided by ember-concurrency. E.g.:

```js
let spawnRequestHandler = createSpawnPoint(scope, {
  maxConcurrency: 10,
  maxEnqueued: 200,
  *operation(request, response) {
    //handle the request
  }
});

server.on('request', spawnRequestHandler);
```



That would handle the concurrency aspects of the request for you, including ignoring if `scope` was already not running for any reason.
