### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/bump-effection-past-missing-dist.md
+++ b/.changes/bump-effection-past-missing-dist.md
@@ -1,7 +1,0 @@
----
-"@simulacrum/client": patch
-"@simulacrum/server": patch
-"@simulacrum/auth0-simulator": patch
----
-
-Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.

--- a/.changes/no-spawn-dead-task.md
+++ b/.changes/no-spawn-dead-task.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/server": patch
----
-Ignore simulation service requests if the simulation has already been
-shut down

--- a/.changes/npx-auth0-simulator.md
+++ b/.changes/npx-auth0-simulator.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-
-Add bin script to auth0-simulator so it can be started via npx.

--- a/examples/nextjs-with-auth0-react/CHANGELOG.md
+++ b/examples/nextjs-with-auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.4]
+
+- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
+  - Bumped due to a bump in @simulacrum/client.
+  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
+
 ## \[0.1.3]
 
 - Fix bug where person scenario was not passing parameters down

--- a/examples/nextjs-with-auth0-react/package.json
+++ b/examples/nextjs-with-auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.2.2",
-    "@simulacrum/client": "0.5.0",
-    "@simulacrum/server": "0.3.1",
+    "@simulacrum/auth0-simulator": "0.2.3",
+    "@simulacrum/client": "0.5.1",
+    "@simulacrum/server": "0.3.2",
     "@types/react": "17.0.14",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs-with-nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs-with-nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.5]
+
+- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
+  - Bumped due to a bump in @simulacrum/client.
+  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
+
 ## \[0.0.4]
 
 - Fix bug where person scenario was not passing parameters down

--- a/examples/nextjs-with-nextjs-auth0/package.json
+++ b/examples/nextjs-with-nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.2.2",
-    "@simulacrum/client": "0.5.0",
-    "@simulacrum/server": "0.3.1",
+    "@simulacrum/auth0-simulator": "0.2.3",
+    "@simulacrum/client": "0.5.1",
+    "@simulacrum/server": "0.3.2",
     "@types/react": "17.0.14",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7184,7 +7184,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -17925,11 +17924,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "2.0.0-beta.9",
-        "@simulacrum/server": "0.3.1",
+        "@simulacrum/server": "0.3.2",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -17946,7 +17945,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^2.0.0",
-        "@simulacrum/client": "0.5.0",
+        "@simulacrum/client": "0.5.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -17977,7 +17976,7 @@
     },
     "packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "effection": "2.0.0-beta.9",
@@ -17994,7 +17993,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "2.0.0-beta.9",
@@ -18019,7 +18018,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^2.0.0",
-        "@simulacrum/client": "0.5.0",
+        "@simulacrum/client": "0.5.1",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -18501,9 +18500,7 @@
       "resolved": "https://registry.npmjs.org/@effection/mocha/-/mocha-2.0.0-beta.8.tgz",
       "integrity": "sha512-q9pbK6EuunR1gAZg70jbv/TaOaCoJsDLdeBh4/KHF3JcLBVR2D4otMECGeR4fyQZwF/yLzxVXu1R5k6sBq9mVw==",
       "dev": true,
-      "requires": {
-        "@effection/core": "^2.0.0-beta.3"
-      }
+      "requires": {}
     },
     "@effection/process": {
       "version": "2.0.0-beta.9",
@@ -19672,8 +19669,8 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^2.0.0",
-        "@simulacrum/client": "0.5.0",
-        "@simulacrum/server": "0.3.1",
+        "@simulacrum/client": "0.5.1",
+        "@simulacrum/server": "0.3.2",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -19729,7 +19726,7 @@
         "@frontside/eslint-config": "^2.0.0",
         "@frontside/tsconfig": "^1.2.0",
         "@frontside/typescript": "^2.0.0",
-        "@simulacrum/client": "0.5.0",
+        "@simulacrum/client": "0.5.1",
         "@simulacrum/ui": "0.2.0",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
@@ -23820,8 +23817,7 @@
     "get-port": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-value": {
       "version": "2.0.6",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.2.3]
+
+- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
+  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
+- Add bin script to auth0-simulator so it can be started via npx.
+  - [88292f4](https://github.com/thefrontside/simulacrum/commit/88292f4f7f0f73ad8832943abcf342d7756fa2b5) add bin script to enable npx auth0-simulator via [#113](https://github.com/thefrontside/simulacrum/pull/113) on 2021-08-16
+
 ## \[0.2.2]
 
 - Fix bug where person scenario was not passing parameters down

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Simulate Auth0",
   "main": "dist/index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
     "@effection/process": "2.0.0-beta.9",
-    "@simulacrum/server": "0.3.1",
+    "@simulacrum/server": "0.3.2",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",
@@ -51,7 +51,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^2.0.0",
-    "@simulacrum/client": "0.5.0",
+    "@simulacrum/client": "0.5.1",
     "@types/dedent": "^0.7.0",
     "@types/base64-url": "^2.2.0",
     "@types/cookie-session": "^2.0.42",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.1]
+
+- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
+  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
+
 ## \[0.5.0]
 
 - rollback effection to beta-5.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "connect to simulacrum servers and manipulate them via the control API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## \[0.3.2]
+
+- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
+  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
+- Ignore simulation service requests if the simulation has already been
+  shut down
+  - [11d7b63](https://github.com/thefrontside/simulacrum/commit/11d7b63340105e7fc6f340d02c6114ac8381c53f) 🐛Ignore requests in the event that the scope is not running on 2021-08-11
+
 ## \[0.3.1]
 
 - rollback effection to beta-5.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "@frontside/eslint-config": "^2.0.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^2.0.0",
-    "@simulacrum/client": "0.5.0",
+    "@simulacrum/client": "0.5.1",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/mocha": "^8.2.1",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/client

## [0.5.1]
- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13



# @simulacrum/server

## [0.3.2]
- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
- Ignore simulation service requests if the simulation has already been
shut down
  - [11d7b63](https://github.com/thefrontside/simulacrum/commit/11d7b63340105e7fc6f340d02c6114ac8381c53f) 🐛Ignore requests in the event that the scope is not running on 2021-08-11



# @simulacrum/auth0-simulator

## [0.2.3]
- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13
- Add bin script to auth0-simulator so it can be started via npx.
  - [88292f4](https://github.com/thefrontside/simulacrum/commit/88292f4f7f0f73ad8832943abcf342d7756fa2b5) add bin script to enable npx auth0-simulator via [#113](https://github.com/thefrontside/simulacrum/pull/113) on 2021-08-16



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.4]
- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
  - Bumped due to a bump in @simulacrum/client.
  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.5]
- Increment all of the `effection` and related `@effection` packages. There was an issue in `@effection/core` with `dist` assets and this ensures it won't exist in the user's lock file.
  - Bumped due to a bump in @simulacrum/client.
  - [30d575b](https://github.com/thefrontside/simulacrum/commit/30d575bc652a5329d67568b013f657691d1d86b6) upgrade past @effection/core dist issue on 2021-08-13