### PR TITLE
covector publish when package doesn't exist

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -3,7 +3,7 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
+      "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version || echo \"not published\"",
       "publish": "npm publish --access public"
     }
   },


### PR DESCRIPTION
## Motivation

The existing command for the covector checks if a package has been published and the version. If the package has yet to be published, this command throws an error which breaks the publish sequence. This changes adjust the command to not throw an error and attempt to publish.

## Approach

A little extra bash.

### Alternate Designs

We want to make this more robust, and fetch via the API. This way we could check specifically for a 404 error. This likely makes sense after an effection upgrade and implementing presets. I can work on that next week, but have been focusing on simulacrum this week and haven't gotten to it. Don't want to hold up our publishing.
