### PR TITLE
Resource service creator

### DIFF
--- a/.changes/non-http-services.md
+++ b/.changes/non-http-services.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": minor
+---
+
+Create a new ResouceServiceCreator interface for a more generic way of creating services.

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -1,4 +1,4 @@
-import type { Simulator, Service } from '@simulacrum/server';
+import type { Simulator, LegacyServiceCreator } from '@simulacrum/server';
 import { createHttpApp } from '@simulacrum/server';
 import { urlencoded, json } from 'express';
 import { createAuth0Handlers } from './handlers/auth0-handlers';
@@ -20,7 +20,7 @@ const DefaultOptions = {
   scope: "openid profile email offline_access",
 };
 
-const createAuth0Service = (handlers: ReturnType<typeof createAuth0Handlers> & ReturnType<typeof createOpenIdHandlers>): Service => {
+const createAuth0Service = (handlers: ReturnType<typeof createAuth0Handlers> & ReturnType<typeof createOpenIdHandlers>): LegacyServiceCreator => {
   return {
     protocol: 'https',
     app: createHttpApp()

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -1,6 +1,6 @@
 import type { ServerOptions as SSLOptions } from 'https';
 import type { AddressInfo } from 'net';
-import type { Service } from './interfaces';
+import type { LegacyServiceCreator } from './interfaces';
 import { Operation, once, Resource, spawn } from 'effection';
 import { Request, Response, Application, RequestHandler } from 'express';
 import { createServer as createHttpsServer } from 'https';
@@ -15,7 +15,7 @@ export interface Server {
 
 export interface ServerOptions {
   port?: number;
-  protocol: Service['protocol'];
+  protocol: LegacyServiceCreator['protocol'];
 }
 
 const createAppServer = (app: Application, options: ServerOptions) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,6 @@
 export { createSimulationServer, Server } from './server';
 export { Simulator, ServerOptions, Store, StoreState } from './interfaces';
-export type { Service, SimulationState } from './interfaces';
+export type { LegacyServiceCreator, SimulationState } from './interfaces';
 export * from './http';
 export * from './simulators/person';
 export * from './config/paths';

--- a/packages/server/src/interfaces.ts
+++ b/packages/server/src/interfaces.ts
@@ -1,10 +1,10 @@
-import type { Operation } from 'effection';
+import type { Operation, Resource } from 'effection';
 import type { Slice } from '@effection/atom';
 import type { HttpApp } from './http';
 import type { Faker } from './faker';
 
 export interface Behaviors {
-  services: Record<string, Service>;
+  services: Record<string, ServiceCreator>;
   scenarios: Record<string, Scenario>;
   effects?: () => Operation<void>;
 }
@@ -29,11 +29,25 @@ export interface ServerOptions {
   debug?: boolean;
 }
 
-export interface Service {
+export interface LegacyServiceCreator {
   protocol: 'http' | 'https';
   app: HttpApp;
   port?: number;
 }
+
+export interface Service {
+  port: number;
+  protocol: string;
+}
+
+export interface ServiceOptions {
+  port?: number;
+}
+
+
+export type ResourceServiceCreator = (slice: Slice<SimulationState>, options: ServiceOptions) => Resource<Service>;
+
+export type ServiceCreator = ResourceServiceCreator | LegacyServiceCreator;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type StoreState = Record<string, Record<string, Record<string, any>>>;
@@ -47,9 +61,7 @@ export interface ServerState {
 
 export interface SimulationOptions {
   options?: Record<string, unknown>;
-  services?: Record<string, {
-    port?: number;
-  }>
+  services?: Record<string, ServiceOptions>
 }
 
 export type SimulationState =


### PR DESCRIPTION
## Motivation

We need to create services with protocols other than HTTP, e.g. LDAP.

The current Service interface only supports HTTP.

## Approach

A new `ResourceServiceCreator` interface is added which should allow simulacrum to cater for any protocol we want to throw at it.

```ts
export type ResourceServiceCreator = (slice: Slice<SimulationState>, options: ServiceOptions) => Resource<Service>;
```

As we are returning a resource, the creation is totally up to the client.