### PR TITLE
specifically use copy-cli to avoid clash on windows

### DIFF
--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf *.tsbuildinfo dist",
     "test": "NODE_EXTRA_CA_CERTS=\"$(mkcert -CAROOT)/rootCA.pem\" mocha -r ts-node/register --timeout 10000 test/**/*.test.ts",
-    "prepack": "tsc --build tsconfig.dist.json && copy \"./src/views/**/*.png\" ./dist/views/",
+    "prepack": "tsc --build tsconfig.dist.json && copy-cli \"./src/views/**/*.png\" ./dist/views/",
     "build": "npm run prepack",
     "lint": "eslint src bin test",
     "start": "node dist/start.js",


### PR DESCRIPTION
## Motivation

The npm package `copy` has a CLI. There is also a `copy` command on Windows. We need to specify `copy-cli` per their docs that it doesn't clash with the Windows version.
