### PR TITLE
specify typeRoots for @simulacrum/auth0-cypress cypress package

### DIFF
--- a/.changes/cypress-type-roots.md
+++ b/.changes/cypress-type-roots.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-cypress": patch
+---
+specify typeRoots for @simulacrum/auth0-cypress cypress package

--- a/integrations/cypress/cypress/support/commands.ts
+++ b/integrations/cypress/cypress/support/commands.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-/// <reference types="cypress" />
 
 import { Auth0ClientOptions } from '@auth0/auth0-spa-js';
 import { Client, createClient, Simulation } from '@simulacrum/client';

--- a/integrations/cypress/package-lock.json
+++ b/integrations/cypress/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum/auth0-cypress",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@auth0/auth0-spa-js": "^1.16.1",

--- a/integrations/cypress/tsconfig.dist.json
+++ b/integrations/cypress/tsconfig.dist.json
@@ -6,7 +6,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "types": ["cypress", "node"],
-    "noEmit": false
+    "noEmit": false,
+    "typeRoots": ["node_modules/@types", "node_modules/cypress/types"]
   },
   "include": [
     "node_modules/cypress",

--- a/integrations/cypress/tsconfig.json
+++ b/integrations/cypress/tsconfig.json
@@ -5,7 +5,8 @@
     "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "cypress",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "typeRoots": ["node_modules/@types", "node_modules/cypress/types"]
   },
   "include": [
     "node_modules/cypress",


### PR DESCRIPTION
## Motivation

specify typeRoots for @simulacrum/auth0-cypress cypress package

## Approach

change `typeRoots` to

`"typeRoots": ["node_modules/@types", "node_modules/cypress/types"]`