### PR TITLE
Run `npm install && npm run build` before release in covector

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -32,7 +32,8 @@
       "manager": "javascript",
       "dependencies": [
         "@simulacrum/auth0-simulator"
-      ]
+      ],
+      "prepublish": "npm install && npm run build"
     },
     "@simulacrum-examples/nextjs-with-auth0-react": {
       "path": "./examples/nextjs-with-auth0-react",


### PR DESCRIPTION
## Motivation

Publish of `@simualcrum/integration-cypress` package is failing because it's not part of the workspace and doesn't get node_modules automatically generated. We need to run `npm install && npm run build` before publish.

## Approach

Add prepublish step to covector to run `npm install && npm run build`.
