### PR TITLE
don't use && as it is parsed as arg in covector

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -33,7 +33,7 @@
       "dependencies": [
         "@simulacrum/auth0-simulator"
       ],
-      "prepublish": "npm install && npm run build"
+      "prepublish": ["npm install", "npm run build"]
     },
     "@simulacrum-examples/nextjs-with-auth0-react": {
       "path": "./examples/nextjs-with-auth0-react",


### PR DESCRIPTION
## Motivation

Publishing is still failing in #152.

## Approach

Shellwords upstream in effection v1 parses the && as an arg and doesn't process it as expected. Specifying it as an array has the same effect and avoids this issue.
