### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/cypress-logger.md
+++ b/.changes/cypress-logger.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-cypress": minor
----
-Simplify cypress logging

--- a/.changes/cypress-update.md
+++ b/.changes/cypress-update.md
@@ -1,6 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor
-"@simulacrum/auth0-cypress": minor
----
-
-Enable @simulacrum/auth0-cypress to run against nextjs-auth0.

--- a/.changes/debug.md
+++ b/.changes/debug.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-cypress": patch
----
-Add debug option to createSimulation to add express middleware logging

--- a/.changes/eslint-update.md
+++ b/.changes/eslint-update.md
@@ -1,9 +1,0 @@
----
-"@simulacrum/auth0-cypress": patch
-"@simulacrum/auth0-simulator": patch
-"@simulacrum/client": patch
-"@simulacrum/server": patch
-"@simulacrum/ui": patch
----
-
-Update eslint-config and typescript versions

--- a/.changes/rerun-cypress-tests.md
+++ b/.changes/rerun-cypress-tests.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-cypress": minor
----
-Destroy simulation before creating a new one

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.1.6]
+
+- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
+- Update eslint-config and typescript versions
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.1.5]
 
 - Add @simulacrum/auth0-cypress package

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.3.0",
-    "@simulacrum/client": "0.5.2",
-    "@simulacrum/server": "0.4.0",
+    "@simulacrum/auth0-simulator": "0.4.0",
+    "@simulacrum/client": "0.5.3",
+    "@simulacrum/server": "0.4.1",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.0.7]
+
+- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
+- Update eslint-config and typescript versions
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.0.6]
 
 - Add @simulacrum/auth0-cypress package

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.3.0",
-    "@simulacrum/client": "0.5.2",
-    "@simulacrum/server": "0.4.0",
+    "@simulacrum/auth0-simulator": "0.4.0",
+    "@simulacrum/client": "0.5.3",
+    "@simulacrum/server": "0.4.1",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## \[0.3.0]
+
+- Simplify cypress logging
+  - [9b9d82f](https://github.com/thefrontside/simulacrum/commit/9b9d82f27795f745cd9d23b7d16f42ed0c204b3d) simplify cypress logging ([#163](https://github.com/thefrontside/simulacrum/pull/163)) on 2022-01-06
+- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
+  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
+- Add debug option to createSimulation to add express middleware logging
+  - [9df79b5](https://github.com/thefrontside/simulacrum/commit/9df79b53e0891d0d3c7946abd450240d4c6cd032) Add debug option to createSimulation to add express middleware logging on 2021-11-25
+- Update eslint-config and typescript versions
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+- Destroy simulation before creating a new one
+  - [5473a01](https://github.com/thefrontside/simulacrum/commit/5473a01f22a3ccae8186ab8b1c7e785a1be9bdfb) Rerun cypress tests ([#164](https://github.com/thefrontside/simulacrum/pull/164)) on 2022-01-06
+
 ## \[0.2.2]
 
 - specify typeRoots for @simulacrum/auth0-cypress cypress package

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12612,11 +12612,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/server": "0.4.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12636,7 +12636,7 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
+        "@simulacrum/client": "0.5.3",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -12671,7 +12671,7 @@
     },
     "packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "effection": "^2.0.1",
@@ -12693,7 +12693,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12712,12 +12712,12 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
         "@effection/process": "^2.0.1",
-        "@simulacrum/ui": "0.3.0",
+        "@simulacrum/ui": "0.3.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
@@ -12737,7 +12737,7 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
+        "@simulacrum/client": "0.5.3",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -12759,7 +12759,7 @@
     },
     "packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "integrity": "sha1-8gohJNeFWtQCRHoGPJCE/SR0NwY=",
       "license": "ISC",
       "devDependencies": {
@@ -14378,8 +14378,8 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/server": "0.4.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -14458,8 +14458,8 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/ui": "0.3.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/ui": "0.3.1",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.4.0]
+
+- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
+  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
+- Update eslint-config and typescript versions
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.3.0]
 
 - Add @simulacrum/auth0-cypress package

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Simulate Auth0",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
     "@effection/process": "^2.0.1",
-    "@simulacrum/server": "0.4.0",
+    "@simulacrum/server": "0.4.1",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",
@@ -52,7 +52,7 @@
     "@frontside/eslint-config": "^3.0.0",
     "@frontside/tsconfig": "^3.0.0",
     "@frontside/typescript": "^3.0.0",
-    "@simulacrum/client": "0.5.2",
+    "@simulacrum/client": "0.5.3",
     "@types/base64-url": "^2.2.0",
     "@types/cookie-session": "^2.0.42",
     "@types/dedent": "^0.7.0",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.3]
+
+- Update eslint-config and typescript versions
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.5.2]
 
 - Upgrade to effection 2.0

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/client",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "connect to simulacrum servers and manipulate them via the control API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.2.1]
+
+- Update eslint-config and typescript versions
+  - Bumped due to a bump in @simulacrum/client.
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.2.0]
 
 - Add an ldap processor implementation.

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Simulate an LDAP server",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.4.1]
+
+- Update eslint-config and typescript versions
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.4.0]
 
 - Upgrade to effection 2.0

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   "dependencies": {
     "@effection/atom": "^2.0.1",
     "@effection/process": "^2.0.1",
-    "@simulacrum/ui": "0.3.0",
+    "@simulacrum/ui": "0.3.1",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "cors": "^2.8.5",
@@ -49,7 +49,7 @@
     "@frontside/eslint-config": "^3.0.0",
     "@frontside/tsconfig": "^3.0.0",
     "@frontside/typescript": "^3.0.0",
-    "@simulacrum/client": "0.5.2",
+    "@simulacrum/client": "0.5.3",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/mocha": "^8.2.1",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.3.1]
+
+- Update eslint-config and typescript versions
+  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
+
 ## \[0.3.0]
 
 - update parcel

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A web UI to work with a Simulacrum Server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/client

## [0.5.3]
- Update eslint-config and typescript versions
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26



# @simulacrum/server

## [0.4.1]
- Update eslint-config and typescript versions
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26



# @simulacrum/auth0-simulator

## [0.4.0]
- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
- Update eslint-config and typescript versions
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26



# @simulacrum/ui

## [0.3.1]
- Update eslint-config and typescript versions
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26



# @simulacrum/ldap-simulator

## [0.2.1]
- Update eslint-config and typescript versions
  - Bumped due to a bump in @simulacrum/client.
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26



# @simulacrum/auth0-cypress

## [0.3.0]
- Simplify cypress logging
  - [9b9d82f](https://github.com/thefrontside/simulacrum/commit/9b9d82f27795f745cd9d23b7d16f42ed0c204b3d) simplify cypress logging ([#163](https://github.com/thefrontside/simulacrum/pull/163)) on 2022-01-06
- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
- Add debug option to createSimulation to add express middleware logging
  - [9df79b5](https://github.com/thefrontside/simulacrum/commit/9df79b53e0891d0d3c7946abd450240d4c6cd032) Add debug option to createSimulation to add express middleware logging on 2021-11-25
- Update eslint-config and typescript versions
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26
- Destroy simulation before creating a new one
  - [5473a01](https://github.com/thefrontside/simulacrum/commit/5473a01f22a3ccae8186ab8b1c7e785a1be9bdfb) Rerun cypress tests ([#164](https://github.com/thefrontside/simulacrum/pull/164)) on 2022-01-06



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.6]
- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
- Update eslint-config and typescript versions
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.7]
- Enable @simulacrum/auth0-cypress to run against nextjs-auth0.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [79a6f11](https://github.com/thefrontside/simulacrum/commit/79a6f11e6a5d516314182d5466f0d9657465c92e) Get user tokens ([#162](https://github.com/thefrontside/simulacrum/pull/162)) on 2022-01-04
- Update eslint-config and typescript versions
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [f852573](https://github.com/thefrontside/simulacrum/commit/f852573daefaf3da2675b1233c3c2db38a2b43ba) update eslint-config and typescript on 2021-10-26