### PR TITLE
Rerun cypress tests

### DIFF
--- a/.changes/rerun-cypress-tests.md
+++ b/.changes/rerun-cypress-tests.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-cypress": minor
+---
+Destroy simulation before creating a new one

--- a/integrations/cypress/cypress.json
+++ b/integrations/cypress/cypress.json
@@ -2,7 +2,6 @@
   "baseUrl": "http://localhost:3000",
   "video": false,
   "screenshotOnRunFailure": false,
-  "defaultCommandTimeout": 20000,
   "fixturesFolder": "cypress/fixtures",
   "integrationFolder": "cypress/integration",
   "pluginsFile": "cypress/plugins/index.js",
@@ -10,6 +9,5 @@
   "videosFolder": "cypress/videos",
   "supportFile": "cypress/support/index.ts",
   "configFile": "cypress/tsconfig.json",
-  "chromeWebSecurity": false,
-  "execTimeout": 10000
+  "chromeWebSecurity": false
 }

--- a/integrations/cypress/cypress/integration/login.spec.ts
+++ b/integrations/cypress/cypress/integration/login.spec.ts
@@ -33,7 +33,6 @@ describe("auth", () => {
     });
   });
 
-
   describe("createSimulation in beforeEach and logout in afterEach", () => {
     beforeEach(() => {
       cy.createSimulation(auth0Config);
@@ -84,30 +83,30 @@ describe("auth", () => {
     });
   });
 
-  describe("logout in beforeEach", () => {
-    beforeEach(() => {
-      cy.logout()
-        .createSimulation(auth0Config)
-        .given();
-    });
+  // describe("logout in beforeEach", () => {
+  //   beforeEach(() => {
+  //     cy.logout()
+  //       .createSimulation(auth0Config)
+  //       .given();
+  //   });
 
-    it("should login once", () => {
-        cy
-          .visit("/")
-          .contains("Logout").should('not.exist')
-          .login()
-          .visit("/")
-          .contains("Logout");
-    });
+  //   it("should login once", () => {
+  //       cy
+  //         .visit("/")
+  //         .contains("Logout").should('not.exist')
+  //         .login()
+  //         .visit("/")
+  //         .contains("Logout");
+  //   });
 
-    it("should login twice without error", () => {
-      cy
-        .visit("/")
-        .contains("Logout").should('not.exist')
-        .given({ email: 'second@gmail.com' })
-        .login()
-        .visit("/")
-        .contains("Logout");
-    });
-  });
+  //   it("should login twice without error", () => {
+  //     cy
+  //       .visit("/")
+  //       .contains("Logout").should('not.exist')
+  //       .given({ email: 'second@gmail.com' })
+  //       .login()
+  //       .visit("/")
+  //       .contains("Logout");
+  //   });
+  // });
 });

--- a/integrations/cypress/cypress/integration/login.spec.ts
+++ b/integrations/cypress/cypress/integration/login.spec.ts
@@ -5,7 +5,7 @@ describe("auth", () => {
   describe("log in, create person per test", () => {
     it("should log in and log out", () => {
       cy
-        .createSimulation({ ...auth0Config, debug: true })
+        .createSimulation(auth0Config)
         .visit("/")
         .contains("Logout").should('not.exist')
         .given()

--- a/integrations/cypress/cypress/integration/login.spec.ts
+++ b/integrations/cypress/cypress/integration/login.spec.ts
@@ -5,7 +5,7 @@ describe("auth", () => {
   describe("log in, create person per test", () => {
     it("should log in and log out", () => {
       cy
-        .createSimulation(auth0Config)
+        .createSimulation({ ...auth0Config, debug: true })
         .visit("/")
         .contains("Logout").should('not.exist')
         .given()
@@ -83,30 +83,30 @@ describe("auth", () => {
     });
   });
 
-  // describe("logout in beforeEach", () => {
-  //   beforeEach(() => {
-  //     cy.logout()
-  //       .createSimulation(auth0Config)
-  //       .given();
-  //   });
+  describe("logout in beforeEach", () => {
+    beforeEach(() => {
+      cy.logout()
+        .createSimulation(auth0Config)
+        .given();
+    });
 
-  //   it("should login once", () => {
-  //       cy
-  //         .visit("/")
-  //         .contains("Logout").should('not.exist')
-  //         .login()
-  //         .visit("/")
-  //         .contains("Logout");
-  //   });
+    it("should login once", () => {
+        cy
+          .visit("/")
+          .contains("Logout").should('not.exist')
+          .login()
+          .visit("/")
+          .contains("Logout");
+    });
 
-  //   it("should login twice without error", () => {
-  //     cy
-  //       .visit("/")
-  //       .contains("Logout").should('not.exist')
-  //       .given({ email: 'second@gmail.com' })
-  //       .login()
-  //       .visit("/")
-  //       .contains("Logout");
-  //   });
-  // });
+    it("should login twice without error", () => {
+      cy
+        .visit("/")
+        .contains("Logout").should('not.exist')
+        .given({ email: 'second@gmail.com' })
+        .login()
+        .visit("/")
+        .contains("Logout");
+    });
+  });
 });

--- a/integrations/cypress/cypress/support/commands/constants.ts
+++ b/integrations/cypress/cypress/support/commands/constants.ts
@@ -1,0 +1,1 @@
+export const SimulationId = 'cypress';

--- a/integrations/cypress/cypress/support/commands/create-simulation.ts
+++ b/integrations/cypress/cypress/support/commands/create-simulation.ts
@@ -13,42 +13,45 @@ export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimu
   return cy.logout().then(() => {
     let client = getClientFromSpec(Cypress.spec.name);
 
+    assert(typeof client?.createSimulation === 'function', 'no client created in createSimulation');
+
     let { debug = false, domain, client_id, ...auth0Options } = options;
 
     assert(typeof domain !== 'undefined', 'domain is a required option');
 
     let port = Number(domain.split(':').slice(-1)[0]);
 
-    assert(typeof client !== 'undefined', 'no client created in createSimulation');
+    log(`creating simulation with options: ${JSON.stringify(options)}`);
 
-    return client.createSimulation("auth0", {
-      options: {
-        ...auth0Options,
-        clientId: client_id,
-      },
-      services: {
-        auth0: {
-          port,
+    return new Cypress.Promise((resolve, reject) => {
+      client.createSimulation("auth0", {
+        options: {
+          ...auth0Options,
+          clientId: client_id,
         },
-      },
-      debug,
-      key: 'cypress'
-    }).then(simulation => {
-      atom.slice(Cypress.spec.name).update(current => {
-        return {
-          ...current,
-          simulation
-        };
+        services: {
+          auth0: {
+            port,
+          },
+        },
+        debug,
+        key: 'cypress'
+      }).then(simulation => {
+        atom.slice(Cypress.spec.name).update(current => {
+          return {
+            ...current,
+            simulation
+          };
+        });
+
+        log(`sumalation created ${JSON.stringify(simulation)}`);
+
+        resolve(simulation);
+      }).catch((e) => {
+        log(`create-simulation failed ${e.message}`);
+
+        reject(e);
       });
-
-      log(`sumalation created ${JSON.stringify(simulation)}`);
-
-      return simulation;
-    }).catch((e) => {
-      log(`create-simulation failed ${e.message}`);
-
-      throw e
-      ;
     });
   });
 };

--- a/integrations/cypress/cypress/support/commands/create-simulation.ts
+++ b/integrations/cypress/cypress/support/commands/create-simulation.ts
@@ -1,6 +1,7 @@
 import { Slice } from '@effection/atom';
 import { CreateSimulation, GetClientFromSpec, TestState } from '../types';
 import { makeCypressLogger } from '../utils/cypress-logger';
+import { SimulationId } from './constants';
 
 export interface MakeCreateSimulationOptions {
   atom: Slice<TestState>;
@@ -12,8 +13,6 @@ const log = makeCypressLogger('simulacrum-create-simulation');
 export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimulationOptions) => (options: CreateSimulation) => {
   return cy.logout().then(() => {
     let client = getClientFromSpec(Cypress.spec.name);
-
-    assert(typeof client?.createSimulation === 'function', 'no client created in createSimulation');
 
     let { debug = false, domain, client_id, ...auth0Options } = options;
 
@@ -35,7 +34,7 @@ export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimu
           },
         },
         debug,
-        key: 'cypress'
+        key: SimulationId
       }).then(simulation => {
         atom.slice(Cypress.spec.name).update(current => {
           return {

--- a/integrations/cypress/cypress/support/commands/create-simulation.ts
+++ b/integrations/cypress/cypress/support/commands/create-simulation.ts
@@ -10,7 +10,7 @@ export interface MakeCreateSimulationOptions {
 const log = makeCypressLogger('simulacrum-create-simulation');
 
 export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimulationOptions) => (options: CreateSimulation) => {
-  return new Cypress.Promise((resolve, reject) => {
+  return cy.logout().then(() => {
     let client = getClientFromSpec(Cypress.spec.name);
 
     let { debug = false, domain, client_id, ...auth0Options } = options;
@@ -21,7 +21,7 @@ export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimu
 
     assert(typeof client !== 'undefined', 'no client created in createSimulation');
 
-    client.createSimulation("auth0", {
+    return client.createSimulation("auth0", {
       options: {
         ...auth0Options,
         clientId: client_id,
@@ -43,11 +43,12 @@ export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimu
 
       log(`sumalation created ${JSON.stringify(simulation)}`);
 
-      resolve(simulation);
+      return simulation;
     }).catch((e) => {
       log(`create-simulation failed ${e.message}`);
 
-      reject(e);
+      throw e
+      ;
     });
   });
 };

--- a/integrations/cypress/cypress/support/commands/given.ts
+++ b/integrations/cypress/cypress/support/commands/given.ts
@@ -13,9 +13,9 @@ const log = makeCypressLogger('simulacrum-given');
 export const makeGiven = ({ atom, getClientFromSpec }: MakeGivenOptions) => (attrs: Partial<Person> = {}) => {
   return new Cypress.Promise((resolve, reject) => {
     let client = getClientFromSpec(Cypress.spec.name);
-    assert(typeof client?.given === 'function', 'no valid client in given');
 
     let simulation = atom.slice(Cypress.spec.name, 'simulation').get();
+
     assert(!!simulation, 'no sumulation in given');
 
     log(`creating person with attrs: ${JSON.stringify(attrs)}`);

--- a/integrations/cypress/cypress/support/commands/given.ts
+++ b/integrations/cypress/cypress/support/commands/given.ts
@@ -13,21 +13,23 @@ const log = makeCypressLogger('simulacrum-given');
 export const makeGiven = ({ atom, getClientFromSpec }: MakeGivenOptions) => (attrs: Partial<Person> = {}) => {
   return new Cypress.Promise((resolve, reject) => {
     let client = getClientFromSpec(Cypress.spec.name);
-    let simulation = atom.slice(Cypress.spec.name, 'simulation').get();
+    assert(typeof client?.given === 'function', 'no valid client in given');
 
+    let simulation = atom.slice(Cypress.spec.name, 'simulation').get();
     assert(!!simulation, 'no sumulation in given');
-    assert(!!client && typeof client.given === 'function', 'no valid client in given');
+
+    log(`creating person with attrs: ${JSON.stringify(attrs)}`);
 
     client.given<Person>(simulation, "person", attrs)
       .then((scenario) => {
+        log(`person created ${JSON.stringify(scenario)}`);
+
         atom.slice(Cypress.spec.name).update(current => {
           return {
             ...current,
             person: scenario.data
           };
         });
-
-        log(`scenario created with ${JSON.stringify(scenario)}`);
 
         resolve(scenario.data);
       })

--- a/integrations/cypress/cypress/support/commands/logout.ts
+++ b/integrations/cypress/cypress/support/commands/logout.ts
@@ -15,10 +15,19 @@ export const makeLogout = ({ atom, getClientFromSpec }: MakeLogoutOptions) => ()
 
     log('in logout');
 
+    if(!client) {
+      log('no client');
+      resolve();
+      return;
+    }
+
     let simulation = atom.slice(Cypress.spec.name, 'simulation').get();
 
-    if(!client || !simulation) {
-      log('no simulation or client');
+    log(JSON.stringify(simulation));
+
+
+    if(!simulation) {
+      log('no simulation');
       resolve();
       return;
     }
@@ -27,7 +36,6 @@ export const makeLogout = ({ atom, getClientFromSpec }: MakeLogoutOptions) => ()
       log('simulation destroyed');
 
       atom.slice(Cypress.spec.name).remove();
-
       resolve();
     }).catch(e => {
       log(`logout failed with ${e.message}`);

--- a/integrations/cypress/cypress/support/commands/logout.ts
+++ b/integrations/cypress/cypress/support/commands/logout.ts
@@ -2,6 +2,7 @@ import { Slice } from '@effection/atom';
 import { Simulation } from '@simulacrum/client';
 import { GetClientFromSpec, TestState } from '../types';
 import { makeCypressLogger } from '../utils/cypress-logger';
+import { SimulationId } from './constants';
 
 export interface MakeLogoutOptions {
   atom: Slice<TestState>;
@@ -16,9 +17,7 @@ export const makeLogout = ({ atom, getClientFromSpec }: MakeLogoutOptions) => ()
 
     let client = getClientFromSpec(Cypress.spec.name);
 
-    assert(typeof client?.createSimulation === 'function', 'no client created in createSimulation');
-
-    client.destroySimulation({ id: 'cypress' } as Simulation).then(() => {
+    client.destroySimulation({ id: SimulationId } as Simulation).then(() => {
       log('simulation destroyed');
 
       atom.slice(Cypress.spec.name).remove();

--- a/integrations/cypress/cypress/support/commands/logout.ts
+++ b/integrations/cypress/cypress/support/commands/logout.ts
@@ -1,4 +1,5 @@
 import { Slice } from '@effection/atom';
+import { Simulation } from '@simulacrum/client';
 import { GetClientFromSpec, TestState } from '../types';
 import { makeCypressLogger } from '../utils/cypress-logger';
 
@@ -11,28 +12,13 @@ const log = makeCypressLogger('simulacrum-logout');
 
 export const makeLogout = ({ atom, getClientFromSpec }: MakeLogoutOptions) => () => {
   return new Cypress.Promise((resolve, reject) => {
-    let client = getClientFromSpec(Cypress.spec.name);
-
     log('in logout');
 
-    if(!client) {
-      log('no client');
-      resolve();
-      return;
-    }
+    let client = getClientFromSpec(Cypress.spec.name);
 
-    let simulation = atom.slice(Cypress.spec.name, 'simulation').get();
+    assert(typeof client?.createSimulation === 'function', 'no client created in createSimulation');
 
-    log(JSON.stringify(simulation));
-
-
-    if(!simulation) {
-      log('no simulation');
-      resolve();
-      return;
-    }
-
-    client.destroySimulation(simulation).then(() => {
+    client.destroySimulation({ id: 'cypress' } as Simulation).then(() => {
       log('simulation destroyed');
 
       atom.slice(Cypress.spec.name).remove();

--- a/integrations/cypress/cypress/support/utils/spec.ts
+++ b/integrations/cypress/cypress/support/utils/spec.ts
@@ -22,5 +22,8 @@ export const makeGetClientFromSpec = ({ atom, port }: MakeGetClientFromSpecOptio
     client = atom.slice(spec, 'client').get();
   }
 
+  // probably not needed but....good to know
+  assert(typeof client?.createSimulation === 'function', 'no client created in getClientFromSpec');
+
   return client;
 };

--- a/integrations/cypress/cypress/support/utils/spec.ts
+++ b/integrations/cypress/cypress/support/utils/spec.ts
@@ -1,19 +1,26 @@
 import { Slice } from '@effection/atom';
 import { Client, createClient } from '@simulacrum/client';
 import { TestState } from '../types';
+import { makeCypressLogger } from './cypress-logger';
 
 export interface MakeGetClientFromSpecOptions {
   atom: Slice<TestState>;
   port: number;
 }
 
+const log = makeCypressLogger('simulacrum-spec');
+
 export const makeGetClientFromSpec = ({ atom, port }: MakeGetClientFromSpecOptions) => function getClientFromSpec (spec: string) {
   let client: Client;
 
-  if(!atom.slice(spec).get()) {
+  if(typeof atom.slice(spec).get()?.client?.createSimulation !== 'function') {
+    log(`creating client for ${spec}`);
     client = createClient(`http://localhost:${port}`);
     atom.set({ [spec]: { client: client } });
+  } else {
+    log(`client already exists for ${spec}`);
+    client = atom.slice(spec, 'client').get();
   }
 
-  return atom.slice(spec, 'client').get();
+  return client;
 };

--- a/integrations/cypress/cypress/support/utils/url.ts
+++ b/integrations/cypress/cypress/support/utils/url.ts
@@ -1,0 +1,6 @@
+
+export function combineURLs(baseURL: string, relativeURL: string): string {
+  return relativeURL
+    ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+    : baseURL;
+}


### PR DESCRIPTION
## Motivation

Prior to this PR, running the cypress plugin in the browser was pretty unusable and would definitely have made this not right for prime time.

Every time a user pressed save or refreshed the browser, the simulation crashed into an unrecoverable state.

## Approach

The fix is to ensure that there is a no existing simulation before creating a new one:

```ts
export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimulationOptions) => (options: CreateSimulation) => {
  return cy.logout().then(() => {
```
## Screenshots



https://user-images.githubusercontent.com/118328/148383468-436eeed7-1d6c-4ff4-a22f-dd315a29f90c.mp4



