### PR TITLE
create defaults for auth0-cypress environment variables

### DIFF
--- a/.changes/cypress-env-defaults.md
+++ b/.changes/cypress-env-defaults.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-cypress": patch
+---
+Give default values to the cypress environment variables.

--- a/examples/nextjs/auth0-react/package-lock.json
+++ b/examples/nextjs/auth0-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum-examples/nextjs-with-auth0-react",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "workspaces": [
         "../../../packages/*"
       ],
@@ -18,9 +18,9 @@
         "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@simulacrum/auth0-simulator": "0.3.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/auth0-simulator": "0.4.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/server": "0.4.1",
         "@types/react": "17.0.37",
         "eslint": "7.30.0",
         "eslint-config-next": "11.0.1",
@@ -29,11 +29,11 @@
     },
     "../../../packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/server": "0.4.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -53,7 +53,7 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
+        "@simulacrum/client": "0.5.3",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -72,7 +72,7 @@
     },
     "../../../packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "effection": "^2.0.1",
@@ -88,7 +88,7 @@
     },
     "../../../packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -107,12 +107,12 @@
     },
     "../../../packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
         "@effection/process": "^2.0.1",
-        "@simulacrum/ui": "0.3.0",
+        "@simulacrum/ui": "0.3.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
@@ -132,7 +132,7 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
+        "@simulacrum/client": "0.5.3",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -148,7 +148,7 @@
     },
     "../../../packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "ISC",
       "devDependencies": {
         "@frontside/eslint-config": "^3.0.0",
@@ -7365,8 +7365,8 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/server": "0.4.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -7425,8 +7425,8 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/ui": "0.3.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/ui": "0.3.1",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",

--- a/examples/nextjs/nextjs-auth0/package-lock.json
+++ b/examples/nextjs/nextjs-auth0/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "workspaces": [
         "../../../packages/*"
       ],
@@ -19,9 +19,9 @@
         "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@simulacrum/auth0-simulator": "0.3.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/auth0-simulator": "0.4.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/server": "0.4.1",
         "@types/react": "17.0.37",
         "eslint": "7.30.0",
         "eslint-config-next": "11.0.1",
@@ -30,11 +30,11 @@
     },
     "../../../packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/server": "0.4.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -54,7 +54,7 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
+        "@simulacrum/client": "0.5.3",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -73,7 +73,7 @@
     },
     "../../../packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "effection": "^2.0.1",
@@ -89,7 +89,7 @@
     },
     "../../../packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -108,12 +108,12 @@
     },
     "../../../packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
         "@effection/process": "^2.0.1",
-        "@simulacrum/ui": "0.3.0",
+        "@simulacrum/ui": "0.3.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
@@ -133,7 +133,7 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
+        "@simulacrum/client": "0.5.3",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -149,7 +149,7 @@
     },
     "../../../packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "ISC",
       "devDependencies": {
         "@frontside/eslint-config": "^3.0.0",
@@ -7856,8 +7856,8 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/server": "0.4.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/server": "0.4.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -7916,8 +7916,8 @@
         "@frontside/eslint-config": "^3.0.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.2",
-        "@simulacrum/ui": "0.3.0",
+        "@simulacrum/client": "0.5.3",
+        "@simulacrum/ui": "0.3.1",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",

--- a/integrations/cypress/cypress/plugins/index.js
+++ b/integrations/cypress/cypress/plugins/index.js
@@ -1,33 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { encrypt } = require('../../encrypt');
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-const hkdf = require('futoin-hkdf');
-const { JWK, JWE } = require('jose');
-
-const BYTE_LENGTH = 32;
-const ENCRYPTION_INFO = 'JWE CEK';
-const options = { hash: 'SHA-256' };
-
-const deriveKey = (secret) => hkdf(secret, BYTE_LENGTH, { info: ENCRYPTION_INFO, ...options });
-
-function encrypt(arg) {
-  let { secret, ...thingToEncrypt } = arg;
-  let key = JWK.asKey(deriveKey(secret));
-  let epochNow = (Date.now() / 1000) | 0;
-  return Promise.resolve(JWE.encrypt(
-      JSON.stringify(thingToEncrypt),
-      key,
-      {
-        alg: 'dir',
-        enc: 'A256GCM',
-        uat: epochNow,
-        iat: epochNow,
-        exp: epochNow + 7 * 24 * 60 * 60
-      }
-  ));
-}
-
-module.exports = (on, config) => {
+module.exports = (on) => {
   on('task', { encrypt });
 };

--- a/integrations/cypress/cypress/support/auth/index.ts
+++ b/integrations/cypress/cypress/support/auth/index.ts
@@ -1,18 +1,20 @@
 import type { AuthorizeOptions, AuthOptions } from 'auth0-js';
 import { WebAuth } from 'auth0-js';
+import { getConfig } from '../utils/config';
 
 const Auth0ConfigDefaults: Pick<AuthorizeOptions, 'connection' | 'scope'> = {
   connection: 'Username-Password-Authentication',
   scope: 'openid profile email',
 };
 
+const { audience, clientID, domain, scope } = getConfig();
 
 const Auth0Config: AuthOptions = {
   ...Auth0ConfigDefaults,
-  audience: Cypress.env('audience'),
-  clientID: Cypress.env('client_id'),
-  domain: Cypress.env('domain'),
-  scope: Cypress.env('scope'),
+  audience,
+  clientID,
+  domain,
+  scope,
 };
 
 export const auth = new WebAuth(Auth0Config);

--- a/integrations/cypress/cypress/support/commands/get-user-tokens.ts
+++ b/integrations/cypress/cypress/support/commands/get-user-tokens.ts
@@ -2,15 +2,17 @@ import { Person } from '../types';
 import { auth } from '../auth';
 import { DefaultDirectoryLoginOptions } from 'auth0-js';
 import { makeCypressLogger } from '../utils/cypress-logger';
+import { getConfig } from '../utils/config';
 
 const log = makeCypressLogger('simulacrum-get-user-tokens');
 
 Cypress.Commands.add('getUserTokens', (person: Person) => {
   let { email, password } = person;
+  let { audience, scope } = getConfig();
 
-  let auth0ClientSecret = Cypress.env('auth0ClientSecret');
+  let { clientSecret } = getConfig();
 
-  assert([email, password, auth0ClientSecret].every(Boolean), 'email, auth0ClientSecret and password are required');
+  assert([email, password, clientSecret].every(Boolean), 'email, auth0ClientSecret and password are required');
 
   log(`about to attempt login with email: ${email}`);
 
@@ -18,9 +20,9 @@ Cypress.Commands.add('getUserTokens', (person: Person) => {
     auth.client.loginWithDefaultDirectory({
       username: email,
       password,
-      audience: Cypress.env('audience'),
-      scope: Cypress.env('scope'),
-      client_secret: auth0ClientSecret,
+      audience,
+      scope,
+      client_secret: clientSecret,
     } as DefaultDirectoryLoginOptions, (err, response) => {
       if (err) {
         console.error(err);

--- a/integrations/cypress/cypress/support/commands/login.ts
+++ b/integrations/cypress/cypress/support/commands/login.ts
@@ -50,8 +50,6 @@ export const makeLogin = ({ atom }: MakeLoginOptions) => () => {
             cy.task<string>('encrypt', payload).then((encryptedSession) => {
               log('successfully encrypted session');
 
-              console.dir({ encryptedSession });
-
               cy.setCookie(sessionCookieName, encryptedSession);
             });
           });

--- a/integrations/cypress/cypress/support/commands/login.ts
+++ b/integrations/cypress/cypress/support/commands/login.ts
@@ -2,6 +2,7 @@ import { Slice } from '@effection/atom';
 import { TestState } from '../types';
 import { assert } from 'assert-ts';
 import { makeCypressLogger } from '../utils/cypress-logger';
+import { getConfig } from '../utils/config';
 
 export interface MakeLoginOptions {
   atom: Slice<TestState>;
@@ -10,13 +11,12 @@ export interface MakeLoginOptions {
 const log = makeCypressLogger('simulacrum-login');
 
 export const makeLogin = ({ atom }: MakeLoginOptions) => () => {
-
-  let sessionCookieName = Cypress.env('auth0SessionCookieName');
+  let { sessionCookieName, cookieSecret, audience } = getConfig();
 
   try {
     cy.getCookie(sessionCookieName).then((cookieValue) => {
       if (cookieValue) {
-        log('Skip logging in again if session already exists');
+        log('Skip logging in again, session already exists');
         return true;
       } else {
         cy.clearCookies();
@@ -37,7 +37,8 @@ export const makeLogin = ({ atom }: MakeLoginOptions) => () => {
             assert(typeof expiresIn !== 'undefined', 'no expiresIn in login');
 
             let payload = {
-              secret: Cypress.env('auth0CookieSecret'),
+              secret: cookieSecret,
+              audience,
               user,
               idToken,
               accessToken,
@@ -48,6 +49,8 @@ export const makeLogin = ({ atom }: MakeLoginOptions) => () => {
 
             cy.task<string>('encrypt', payload).then((encryptedSession) => {
               log('successfully encrypted session');
+
+              console.dir({ encryptedSession });
 
               cy.setCookie(sessionCookieName, encryptedSession);
             });

--- a/integrations/cypress/cypress/support/utils/config.ts
+++ b/integrations/cypress/cypress/support/utils/config.ts
@@ -1,0 +1,32 @@
+interface Config {
+  sessionCookieName: string;
+  cookieSecret: string;
+  audience: string;
+  connection: string;
+  scope: string;
+  clientSecret: string;
+  clientID: string;
+  domain: string;
+}
+
+export function getConfig(): Config {
+  let sessionCookieName = Cypress.env('auth0SessionCookieName') ?? 'appSession';
+  let cookieSecret = Cypress.env('auth0CookieSecret') ?? 'COOKIE_SECRET';
+  let audience = Cypress.env('audience');
+  let connection = Cypress.env('connection') ?? 'Username-Password-Authentication';
+  let scope = Cypress.env('scope') ?? 'openid profile email offline_access';
+  let clientSecret = Cypress.env('auth0ClientSecret') ?? 'YOUR_AUTH0_CLIENT_SECRET';
+  let clientID = Cypress.env('client_id') ?? 'YOUR_AUTH0_CLIENT_ID';
+  let domain = Cypress.env('domain') ?? 'localhost:4400';
+
+  return {
+    sessionCookieName,
+    cookieSecret,
+    audience,
+    connection,
+    scope,
+    clientSecret,
+    clientID,
+    domain
+  };
+}

--- a/integrations/cypress/cypress/support/utils/whitelist-cookies.ts
+++ b/integrations/cypress/cypress/support/utils/whitelist-cookies.ts
@@ -1,5 +1,7 @@
+import { getConfig } from './config';
+
 Cypress.Cookies.defaults({
   preserve: [
-    Cypress.env('auth0SessionCookieName')
+    getConfig().sessionCookieName,
   ],
 });

--- a/integrations/cypress/encrypt.js
+++ b/integrations/cypress/encrypt.js
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 const hkdf = require('futoin-hkdf');
 const { JWK, JWE } = require('jose');
 

--- a/integrations/cypress/encrypt.js
+++ b/integrations/cypress/encrypt.js
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const hkdf = require('futoin-hkdf');
+const { JWK, JWE } = require('jose');
+
+const BYTE_LENGTH = 32;
+const ENCRYPTION_INFO = 'JWE CEK';
+const options = { hash: 'SHA-256' };
+
+const deriveKey = (secret) => hkdf(secret, BYTE_LENGTH, { info: ENCRYPTION_INFO, ...options });
+
+module.exports.encrypt = function encrypt(arg) {
+  let { secret, ...thingToEncrypt } = arg;
+  let key = JWK.asKey(deriveKey(secret));
+  let epochNow = (Date.now() / 1000) | 0;
+  return Promise.resolve(JWE.encrypt(
+      JSON.stringify(thingToEncrypt),
+      key,
+      {
+        alg: 'dir',
+        enc: 'A256GCM',
+        uat: epochNow,
+        iat: epochNow,
+        exp: epochNow + 7 * 24 * 60 * 60
+      }
+  ));
+};

--- a/integrations/cypress/package-lock.json
+++ b/integrations/cypress/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum/auth0-cypress",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "2.0.1",

--- a/packages/ldap/src/start.ts
+++ b/packages/ldap/src/start.ts
@@ -48,7 +48,7 @@ main(function*() {
 
  let client = createClient(url);
 
- let simulation = yield client.createSimulation("ldap", {
+ yield client.createSimulation("ldap", {
     options: {
       baseDN: "ou=users,dc=org.com",
       bindDn: "admin@org.com",
@@ -61,8 +61,6 @@ main(function*() {
       }
     }
   });
-
-  console.dir({ simulation }, { depth: 33 });
 
   yield;
 });


### PR DESCRIPTION
## Motivation

When testing the @simulacrum/auth0-cypress package against a `create-react-app` package, it requires the `auth0ClientSecret` and `auth0CookieSecret` variables to be set in the `cypress.env.json` file.

They are not relevant when dealing with a SPA that renders in the client and is not calling an api that subsequently calls auth0.

## Approach

Centralise how the config is loaded and supply default values for the server side specific environment variables.