### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/make-encrypt.md
+++ b/.changes/make-encrypt.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-cypress": minor
----
-Make encrypt typescript and exportable after transpilation

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.4.0]
+
+- Make encrypt typescript and exportable after transpilation
+  - [4446e54](https://github.com/thefrontside/simulacrum/commit/4446e54539f7f75dbaed160a99fb6c77758c67f6) Make encrypt typescript ([#167](https://github.com/thefrontside/simulacrum/pull/167)) on 2022-01-11
+
 ## \[0.3.1]
 
 - Give default values to the cypress environment variables.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/auth0-cypress

## [0.4.0]
- Make encrypt typescript and exportable after transpilation
  - [4446e54](https://github.com/thefrontside/simulacrum/commit/4446e54539f7f75dbaed160a99fb6c77758c67f6) Make encrypt typescript ([#167](https://github.com/thefrontside/simulacrum/pull/167)) on 2022-01-11