### PR TITLE
Use package.json exports to export encrypt to stop cypress global var…

### DIFF
--- a/.changes/use-exports-for-encrypt.md
+++ b/.changes/use-exports-for-encrypt.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-cypress": minor
+---
+Use package.json exports to export encrypt to stop cypress global variable errors

--- a/.changes/use-exports-for-encrypt.md
+++ b/.changes/use-exports-for-encrypt.md
@@ -1,4 +1,4 @@
 ---
-"@simulacrum/auth0-cypress": minor
+"@simulacrum/auth0-cypress": patch
 ---
-Use package.json exports to export encrypt to stop cypress global variable errors
+Use package.json exports to export encrypt and stop cypress global variable errors

--- a/integrations/cypress/README.md
+++ b/integrations/cypress/README.md
@@ -36,7 +36,7 @@ We need to register an encrypt [cypress task](https://docs.cypress.io/api/comman
 ```js
 // cypress/plugins/index.js
 
-import { encrypt } from '../support/utils/encrypt';
+import { encrypt } from '@simulacrum/auth0-cypress';
 
 export default (on) => {
   on('task', { encrypt });

--- a/integrations/cypress/cypress/support/utils/encrypt.ts
+++ b/integrations/cypress/cypress/support/utils/encrypt.ts
@@ -1,6 +1,6 @@
+import type { EncryptPayload } from '../types';
 import hkdf from 'futoin-hkdf';
 import { EncryptJWT, JWTPayload } from 'jose';
-import { EncryptPayload } from '../types';
 
 const BYTE_LENGTH = 32;
 const ENCRYPTION_INFO = 'JWE CEK';

--- a/integrations/cypress/package-lock.json
+++ b/integrations/cypress/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@simulacrum/auth0-cypress",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "2.0.1",

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -7,6 +7,23 @@
   "repository": "https://github.com/thefrontside/simulacrum.git",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
+  "exports": {
+    ".": {
+      "import": "./dist/support/index.js",
+      "require": "./dist/support/index.js"
+    },
+    "./encrypt": {
+      "import": "./dist/support/utils/encrypt.js",
+      "require": "./dist/support/utils/encrypt.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/support/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist/**/*",
     "cypress/**/*",


### PR DESCRIPTION
## Motivation

I ran into a problem because I needed to export a function so that users of the plugin can create a [cypress task](https://docs.cypress.io/api/commands/task).  It, unfortunately,  needs to be a cypress task and the user will have to import it from `@simulacrum/auth0-cypress`.

```ts
import { encrypt } from '@simulacrum/auth0-cypress';

export default (on) => {
  on('task', { encrypt });
};
```

The problem is, the `import { encrypt } from  '@simulacrum/auth0-cypress' ` then calls code that references the global `Cypress` object in the `support/commands/index.ts` file before it is operational:

e.g.

```ts
Cypress.Commands.add('createSimulation', 
```

Which causes an error.

## Approach

Use the new package.json exports to ensure the encrypt.js file can be imported without loading everything:

```ts
  "exports": {
    ".": {
      "import": "./dist/support/index.js",
      "require": "./dist/support/index.js"
    },
    "./encrypt": {
      "import": "./dist/support/utils/encrypt.js",
      "require": "./dist/support/utils/encrypt.js"
    }
  },
```

### Alternate Designs

revert `encrypt.js` to a javascript file that lies outside of the `src` directory and the import becomes

`import { encrypt } from '@simulacrum/auth0-cypress/encrypt';`

### Possible Drawbacks or Risks

We need at least node 14 for package.json exports