### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/auth0-providers.md
+++ b/.changes/auth0-providers.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-cypress": minor
----
-have specific cypress commands for specific auth0 javascript sdks.

--- a/.changes/simplify-create-simulation.md
+++ b/.changes/simplify-create-simulation.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/server": minor
----
-Simplify createSimulation and destroySimulation by removing them from the effects.

--- a/.changes/sort-out-client-id.md
+++ b/.changes/sort-out-client-id.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-cypress": patch
----
-Make all clientId variables use clientID casing

--- a/.changes/wait-for-destroying-simulation.md
+++ b/.changes/wait-for-destroying-simulation.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/server": patch
----
-wait for simulation to be destroyed before creating a new one

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.1.7]
+
+- Simplify createSimulation and destroySimulation by removing them from the effects.
+  - Bumped due to a bump in @simulacrum/server.
+  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
+- wait for simulation to be destroyed before creating a new one
+  - Bumped due to a bump in @simulacrum/server.
+  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18
+
 ## \[0.1.6]
 
 - Enable @simulacrum/auth0-cypress to run against nextjs-auth0.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.4.0",
+    "@simulacrum/auth0-simulator": "0.4.1",
     "@simulacrum/client": "0.5.3",
-    "@simulacrum/server": "0.4.1",
+    "@simulacrum/server": "0.5.0",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.0.8]
+
+- Simplify createSimulation and destroySimulation by removing them from the effects.
+  - Bumped due to a bump in @simulacrum/server.
+  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
+- wait for simulation to be destroyed before creating a new one
+  - Bumped due to a bump in @simulacrum/server.
+  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18
+
 ## \[0.0.7]
 
 - Enable @simulacrum/auth0-cypress to run against nextjs-auth0.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.4.0",
+    "@simulacrum/auth0-simulator": "0.4.1",
     "@simulacrum/client": "0.5.3",
-    "@simulacrum/server": "0.4.1",
+    "@simulacrum/server": "0.5.0",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.5.0]
+
+- have specific cypress commands for specific auth0 javascript sdks.
+  - [175a0f4](https://github.com/thefrontside/simulacrum/commit/175a0f47357f682c470c6df47ae3d3be92687f0e) Auth0 cypress provider ([#172](https://github.com/thefrontside/simulacrum/pull/172)) on 2022-01-19
+- Make all clientId variables use clientID casing
+  - [5863e14](https://github.com/thefrontside/simulacrum/commit/5863e14d35166cbfce7c87d1acc96e3a2137ea3d) Make all clientId variables use clientID casing ([#173](https://github.com/thefrontside/simulacrum/pull/173)) on 2022-01-17
+
 ## \[0.4.0]
 
 - Make encrypt typescript and exportable after transpilation

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12612,11 +12612,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
-        "@simulacrum/server": "0.4.1",
+        "@simulacrum/server": "0.5.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12693,7 +12693,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12712,7 +12712,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
@@ -14379,7 +14379,7 @@
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
         "@simulacrum/client": "0.5.3",
-        "@simulacrum/server": "0.4.1",
+        "@simulacrum/server": "0.5.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.4.1]
+
+- Simplify createSimulation and destroySimulation by removing them from the effects.
+  - Bumped due to a bump in @simulacrum/server.
+  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
+- wait for simulation to be destroyed before creating a new one
+  - Bumped due to a bump in @simulacrum/server.
+  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18
+
 ## \[0.4.0]
 
 - Enable @simulacrum/auth0-cypress to run against nextjs-auth0.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Simulate Auth0",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
     "@effection/process": "^2.0.1",
-    "@simulacrum/server": "0.4.1",
+    "@simulacrum/server": "0.5.0",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.2.2]
+
+- Simplify createSimulation and destroySimulation by removing them from the effects.
+  - Bumped due to a bump in @simulacrum/server.
+  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
+- wait for simulation to be destroyed before creating a new one
+  - Bumped due to a bump in @simulacrum/server.
+  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18
+
 ## \[0.2.1]
 
 - Update eslint-config and typescript versions

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Simulate an LDAP server",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.5.0]
+
+- Simplify createSimulation and destroySimulation by removing them from the effects.
+  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
+- wait for simulation to be destroyed before creating a new one
+  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18
+
 ## \[0.4.1]
 
 - Update eslint-config and typescript versions

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/server

## [0.5.0]
- Simplify createSimulation and destroySimulation by removing them from the effects.
  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
- wait for simulation to be destroyed before creating a new one
  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18



# @simulacrum/auth0-simulator

## [0.4.1]
- Simplify createSimulation and destroySimulation by removing them from the effects.
  - Bumped due to a bump in @simulacrum/server.
  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
- wait for simulation to be destroyed before creating a new one
  - Bumped due to a bump in @simulacrum/server.
  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18



# @simulacrum/ldap-simulator

## [0.2.2]
- Simplify createSimulation and destroySimulation by removing them from the effects.
  - Bumped due to a bump in @simulacrum/server.
  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
- wait for simulation to be destroyed before creating a new one
  - Bumped due to a bump in @simulacrum/server.
  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18



# @simulacrum/auth0-cypress

## [0.5.0]
- have specific cypress commands for specific auth0 javascript sdks.
  - [175a0f4](https://github.com/thefrontside/simulacrum/commit/175a0f47357f682c470c6df47ae3d3be92687f0e) Auth0 cypress provider ([#172](https://github.com/thefrontside/simulacrum/pull/172)) on 2022-01-19
- Make all clientId variables use clientID casing
  - [5863e14](https://github.com/thefrontside/simulacrum/commit/5863e14d35166cbfce7c87d1acc96e3a2137ea3d) Make all clientId variables use clientID casing ([#173](https://github.com/thefrontside/simulacrum/pull/173)) on 2022-01-17



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.7]
- Simplify createSimulation and destroySimulation by removing them from the effects.
  - Bumped due to a bump in @simulacrum/server.
  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
- wait for simulation to be destroyed before creating a new one
  - Bumped due to a bump in @simulacrum/server.
  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.8]
- Simplify createSimulation and destroySimulation by removing them from the effects.
  - Bumped due to a bump in @simulacrum/server.
  - [04d5aaf](https://github.com/thefrontside/simulacrum/commit/04d5aaf0077d744badd8739936aad328156d64e2) Simplify createSimulation and destroySimulation ([#174](https://github.com/thefrontside/simulacrum/pull/174)) on 2022-01-19
- wait for simulation to be destroyed before creating a new one
  - Bumped due to a bump in @simulacrum/server.
  - [b1412da](https://github.com/thefrontside/simulacrum/commit/b1412daa2d7846ec4c8eefeea2dfbf94e19b7261) wait for simulation to be destroyed before creating a new one ([#171](https://github.com/thefrontside/simulacrum/pull/171)) on 2022-01-18