### PR TITLE
wait for simulation to be destroyed before creating a new one

### DIFF
--- a/.changes/wait-for-destroying-simulation.md
+++ b/.changes/wait-for-destroying-simulation.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/server": patch
+---
+wait for simulation to be destroyed before creating a new one

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -51,9 +51,7 @@ export const destroySimulation: Resolver<{ id: string }, boolean> = {
   async resolve({ id }, { atom, scope }) {
     let simulation = atom.slice("simulations", id);
     if (simulation.get()) {
-      let status = simulation.get().status;
-
-      if(['halted', 'destroying'].includes(status)) {
+      if(['halted', 'destroying'].includes(simulation.get().status)) {
         return false;
       }
 

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -28,6 +28,10 @@ export const createSimulation: Resolver<CreateSimulationParameters, SimulationSt
 
     let simulation = atom.slice("simulations", id);
 
+    if(simulation.get()?.status === 'running') {
+      await destroySimulation.resolve({ id }, ctx);
+    }
+
     if(['halted', 'destroying'].includes(simulation.get()?.status)) {
       await scope.run(simulation.filter((sim) => typeof sim === 'undefined').expect());
     }

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -51,10 +51,6 @@ export const destroySimulation: Resolver<{ id: string }, boolean> = {
   async resolve({ id }, { atom, scope }) {
     let simulation = atom.slice("simulations", id);
     if (simulation.get()) {
-      if(['halted', 'destroying'].includes(simulation.get().status)) {
-        return false;
-      }
-
       simulation.slice("status").set("destroying");
       await scope.run(simulation.filter(({ status }) => status == "halted").expect());
       simulation.remove();

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -271,4 +271,17 @@ hello world`);
       expect(first).toEqual(second);
     });
   });
+
+  describe('calling createSimulation on a simulation that is being destroyed()', () => {
+    beforeEach(function*() {
+      simulation = yield client.createSimulation("echo", { key: 'sim' });
+    });
+
+    // not the greatest test, does not always fail
+    it('should wait for the simulation to be destroyed before creating a new one', function*() {
+      client.destroySimulation(simulation);
+      simulation = yield client.createSimulation("echo", { key: 'sim' });
+      expect(simulation.status).toEqual('running');
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

While working with the cypress plugin, there are times when `createSimulation` is called with a guaranteed `key` property like `cypress` and a simulation is in the process of being destroyed.

## Approach

Wait until the simulation is `undefined` in the state because we might get a halted state also.

### Alternate Designs

It is quite an expensive process to rebuild a simulation and especially in a hot reloading scenario like running cypress tests in the browser.

If we could recycle a simulation without tearing everything down and recreating it, that might work better.