### PR TITLE
Make all clientId variables use clientID casing

### DIFF
--- a/.changes/sort-out-client-id.md
+++ b/.changes/sort-out-client-id.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-cypress": patch
+---
+Make all clientId variables use clientID casing

--- a/examples/nextjs/auth0-react/simulator-server.mjs
+++ b/examples/nextjs/auth0-react/simulator-server.mjs
@@ -22,7 +22,7 @@ main(function* () {
     options: {
       audience: "https://your-audience/",
       scope: "openid profile email offline_access",
-      clientId: "YOUR_AUTH0_CLIENT_ID",
+      clientID: "YOUR_AUTH0_CLIENT_ID",
     },
     services: {
       auth0: {

--- a/examples/nextjs/nextjs-auth0/simulator-server.mjs
+++ b/examples/nextjs/nextjs-auth0/simulator-server.mjs
@@ -22,7 +22,7 @@ main(function* () {
     options: {
       audience: "https://your-audience/",
       scope: "openid profile email offline_access",
-      clientId: "YOUR_AUTH0_CLIENT_ID",
+      clientID: "YOUR_AUTH0_CLIENT_ID",
     },
     services: {
       auth0: {

--- a/integrations/cypress/README.md
+++ b/integrations/cypress/README.md
@@ -64,7 +64,7 @@ An example [cypress environment file](./cypress.env.json) is in the root of this
 {
   "audience": "https://thefrontside.auth0.com/api/v1/",
   "domain": "localhost:4400",
-  "clientId": "YOUR_AUTH0_CLIENT_ID",
+  "clientID": "YOUR_AUTH0_CLIENT_ID",
   "connection": "Username-Password-Authentication",
   "scope": "openid profile email offline_access"
 }

--- a/integrations/cypress/cypress.env.json
+++ b/integrations/cypress/cypress.env.json
@@ -1,7 +1,7 @@
 {
   "audience": "https://your-audience/",
   "domain": "localhost:4400",
-  "client_id": "YOUR_AUTH0_CLIENT_ID",
+  "clientID": "YOUR_AUTH0_CLIENT_ID",
   "connection": "Username-Password-Authentication",
   "scope": "openid profile email offline_access",
   "auth0SessionCookieName": "appSession",

--- a/integrations/cypress/cypress/support/commands/create-simulation.ts
+++ b/integrations/cypress/cypress/support/commands/create-simulation.ts
@@ -14,11 +14,12 @@ export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimu
   return cy.logout().then(() => {
     let client = getClientFromSpec(Cypress.spec.name);
 
-    let { debug = false, domain, client_id, ...auth0Options } = options;
+    let { debug = false, ...auth0Options } = options;
 
-    assert(typeof domain !== 'undefined', 'domain is a required option');
+    assert(typeof auth0Options.domain !== 'undefined', 'domain is a required option');
+    assert(typeof auth0Options.clientID !== 'undefined', 'clientID is a required option');
 
-    let port = Number(domain.split(':').slice(-1)[0]);
+    let port = Number(auth0Options.domain.split(':').slice(-1)[0]);
 
     log(`creating simulation with options: ${JSON.stringify(options)}`);
 
@@ -26,7 +27,6 @@ export const makeCreateSimulation = ({ atom, getClientFromSpec }: MakeCreateSimu
       client.createSimulation("auth0", {
         options: {
           ...auth0Options,
-          clientId: client_id,
         },
         services: {
           auth0: {

--- a/integrations/cypress/cypress/support/types.ts
+++ b/integrations/cypress/cypress/support/types.ts
@@ -7,7 +7,7 @@ export type TestState = Record<string, {
   person?: Person
 }>;
 
-export type CreateSimulation = Omit<AuthOptions, 'clientID'> & { debug?: boolean, client_id?: string };
+export type CreateSimulation = AuthOptions & { debug?: boolean };
 
 export interface Token {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/integrations/cypress/cypress/support/utils/config.ts
+++ b/integrations/cypress/cypress/support/utils/config.ts
@@ -16,7 +16,7 @@ export function getConfig(): Config {
   let connection = Cypress.env('connection') ?? 'Username-Password-Authentication';
   let scope = Cypress.env('scope') ?? 'openid profile email offline_access';
   let clientSecret = Cypress.env('auth0ClientSecret') ?? 'YOUR_AUTH0_CLIENT_SECRET';
-  let clientID = Cypress.env('client_id') ?? 'YOUR_AUTH0_CLIENT_ID';
+  let clientID = Cypress.env('clientID') ?? 'YOUR_AUTH0_CLIENT_ID';
   let domain = Cypress.env('domain') ?? 'localhost:4400';
 
   return {

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -47,7 +47,7 @@
     "test": "npm run test:auth0-react:headless && npm run test:nextjs-auth0:headless",
     "build": "npm run prepack",
     "prepack": "tsc --build tsconfig.dist.json",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"cypress/**/*.ts\""
   },
   "dependencies": {
     "@effection/atom": "2.0.1",

--- a/packages/auth0/README.md
+++ b/packages/auth0/README.md
@@ -44,7 +44,7 @@ mutation CreateSimulation {
     options:{
       audience: "[your audience]",
       scope: "[your scope]",
-      clientId: "[your client-id]"
+      clientID: "[your client-id]"
     },
     services:{
       auth0:{
@@ -71,7 +71,7 @@ Use the values returned from the query to update your configuration in the clien
 ```json
 {
   "domain": "localhost:4400",
-  "clientId": "00000000000000000000000000000000",
+  "clientID": "00000000000000000000000000000000",
   "audience": "https://your-audience/"
 }
 ```
@@ -128,7 +128,7 @@ main(function* () {
     options: {
       audience: "[your audience]",
       scope: "[your scope]",
-      clientId: "[your client-id]",
+      clientID: "[your client-id]",
     },
     services: {
       auth0: {
@@ -183,7 +183,7 @@ async function setupClient({ url }) {
     options: {
       audience: "https://your-audience/",
       scope: "openid profile email offline_access",
-      clientId: "YOUR_AUTH0_CLIENT_ID",
+      clientID: "YOUR_AUTH0_CLIENT_ID",
     },
     services: {
       auth0: {
@@ -213,7 +213,7 @@ let simulation = yield client.createSimulation("auth0", {
   options: {
     audience: "[your audience]",
     scope: "[your scope]",
-    clientId: "[your client-id]",
+    clientID: "[your client-id]",
     rulesDirectory: "test/rules",
   },
   services: {

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -48,7 +48,7 @@ const createPersonQuery = (store: Store) => (predicate: Predicate<Person>) => {
 };
 
 export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandler> => {
-  let { audience, scope, store, clientId, rulesDirectory } = options;
+  let { audience, scope, store, clientID, rulesDirectory } = options;
   let personQuery = createPersonQuery(store);
   let rulesRunner = createRulesRunner(rulesDirectory);
 
@@ -88,13 +88,13 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
 
       let url = getServiceUrl(options);
 
-      assert(!!clientId, `no clientId assigned`);
+      assert(!!clientID, `no clientID assigned`);
 
       let html = loginView({
         domain: url.host,
         scope,
         redirectUri: redirect_uri,
-        clientId,
+        clientID,
         audience,
         loginFailed: false
       });
@@ -118,13 +118,13 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
 
         let url = getServiceUrlFromOptions(options);
 
-        assert(!!clientId, `no clientId assigned`);
+        assert(!!clientID, `no clientID assigned`);
 
         let html = loginView({
           domain: url.host,
           scope,
           redirectUri: redirect_uri,
-          clientId,
+          clientID,
           audience,
           loginFailed: true
         });
@@ -211,7 +211,7 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
         exp: expiresAt(),
         iat: Date.now(),
         email: username,
-        aud: clientId,
+        aud: clientID,
         sub: user.id,
       };
 
@@ -219,14 +219,14 @@ export const createAuth0Handlers = (options: Options): Record<Routes, HttpHandle
         idTokenData.nonce = nonce;
       }
 
-      assert(!!clientId, 'no clientId in options');
+      assert(!!clientID, 'no clientID in options');
 
       let accessToken = {
         scope,
       };
 
       let userData = {} as RuleUser;
-      let context = { clientID: clientId, accessToken, idToken: idTokenData };
+      let context = { clientID, accessToken, idToken: idTokenData };
 
       rulesRunner(userData, context);
 

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -15,7 +15,7 @@ import { createOpenIdHandlers } from './handlers/openid-handlers';
 const publicDir = path.join(__dirname, 'views', 'public');
 
 const DefaultOptions = {
-  clientId: '00000000000000000000000000000000',
+  clientID: '00000000000000000000000000000000',
   audience: 'https://thefrontside.auth0.com/api/v1/',
   scope: "openid profile email offline_access",
 };

--- a/packages/auth0/src/start.ts
+++ b/packages/auth0/src/start.ts
@@ -26,7 +26,7 @@ main(function*() {
       options:{
         audience: "[your audience]",
         scope: "[your scope]",
-        clientId: "[your client-id]"
+        clientID: "[your client-id]"
       },
       services:{
         auth0:{

--- a/packages/auth0/src/types.ts
+++ b/packages/auth0/src/types.ts
@@ -5,7 +5,7 @@ export interface Options {
   scope: string;
   port?: number;
   audience: string;
-  clientId: string;
+  clientID: string;
   store: Store;
   services: Slice<SimulationState['services']>;
   rulesDirectory?: string;

--- a/packages/auth0/src/views/login.ts
+++ b/packages/auth0/src/views/login.ts
@@ -4,7 +4,7 @@ interface LoginViewProps {
   domain: string;
   scope: string;
   redirectUri: string;
-  clientId: string;
+  clientID: string;
   audience: string;
   loginFailed: boolean;
 }
@@ -13,7 +13,7 @@ export const loginView = ({
   domain,
   scope,
   redirectUri,
-  clientId,
+  clientID,
   audience,
   loginFailed = false
 }: LoginViewProps): string => {
@@ -67,7 +67,7 @@ export const loginView = ({
           document.addEventListener('DOMContentLoaded', function(){
             var webAuth = new window.auth0.default.WebAuth({
               domain: '${domain}',
-              clientID: '${clientId}',
+              clientID: '${clientID}',
               redirectUri: '${redirectUri}',
               audience: '${audience}',
               responseType: 'token id_token',


### PR DESCRIPTION
## Motivation

`clientID` is an auth0 option but in the simulacrum codebase, it is a mixture of `clientId` and `clientID` leading to some subtle bugs which are not helped with the loose typing around simulator options.

## Approach

Make all `clientId` variables use the `clientID` casing.

