### PR TITLE
Added new tags and description for simulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Modern applications have modern dependencies. Whether they run on the server or 
 
 Simulacrum removes these constraints from your process by allowing you to simulate external dependencies with a very high degree of reality.
 
+## Existing Simulators
+
+* [auth0](packages/auth0) - [@simulacrum/auth0-simulator](https://www.npmjs.com/package/@simulacrum/auth0-simulator)
+* [ldap](packages/ldap) - [@simulacrum/ldap-simulator](https://www.npmjs.com/package/@simulacrum/ldap-simulator)
+
 ## Usage
 
 Simulacrum is based on a client server architecture. The server can hold any number of simulations which you can create and control via the client. The following examples use JavaScript, but under the hood it is just connects over HTTP and so can be used from any language.

--- a/packages/auth0/README.md
+++ b/packages/auth0/README.md
@@ -1,5 +1,7 @@
 # Auth0 simulator
 
+Read about this simulator on our blog: [Simplified Local Development and Testing with Auth0 Simulation](https://frontside.com/blog/2022-01-13-auth0-simulator/).
+
 ## Table of Contents
 
 - [Auth0 simulator](#auth0-simulator)
@@ -100,7 +102,6 @@ npm install @simulacrum/auth0-simulator
 ```
 
 The following examples are written in Typescript, but using Typescript is not a requirement. The Auth0 simulator creates a server with a graphql interface. This means that your interactions with the server can be written in any language or framework that can communicate over http / graphql.
-
 
 ```ts
 import { main } from "effection";

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -26,6 +26,7 @@
     "emulation",
     "authentication",
     "auth0",
+    "mock",
     "mocking",
     "stubbing",
     "integration testing"

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@simulacrum/auth0-simulator",
   "version": "0.4.1",
-  "description": "Simulate Auth0",
+  "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
   "scripts": {
@@ -25,7 +25,10 @@
     "simulation",
     "emulation",
     "authentication",
-    "auth0"
+    "auth0",
+    "mocking",
+    "stubbing",
+    "integration testing"
   ],
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -17,6 +17,7 @@
     "simulation",
     "LDAP",
     "emulation",
+    "mock",
     "mocking",
     "stubbing",
     "integration testing"

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@simulacrum/ldap-simulator",
   "version": "0.2.2",
-  "description": "Simulate an LDAP server",
+  "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
   "scripts": {
@@ -16,7 +16,10 @@
   "keywords": [
     "simulation",
     "LDAP",
-    "emulation"
+    "emulation",
+    "mocking",
+    "stubbing",
+    "integration testing"
   ],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Motivation

I was linking to NPM packages for a Reddit post and found that our packages don't have good descriptions and don't have tags that would make them show up.

## Approach

I'm adding tags like this,

```json
    "mock",
    "mocking",
    "stubbing",
    "integration testing"
```

Also improving description for simulators and linking to simulators from README.md. Add a link to the blog post in Auth0 simulator.

BTW, I don't like these tags but we want people to be able to find them.

