### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/apply-consistent-types.md
+++ b/.changes/apply-consistent-types.md
@@ -1,9 +1,0 @@
----
-"@simulacrum/server": patch
-"@simulacrum/client": patch
-"@simulacrum/ui": patch
-"@simulacrum/auth0-simulator": patch
-"@simulacrum/ldap-simulator": patch
-"@simulacrum/auth0-cypress": patch
----
-apply @typescript/consistent-types

--- a/.changes/fix-access-token.md
+++ b/.changes/fix-access-token.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor
----
-Apply rules changes to the accessToken

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.8]
+
+- apply @typescript/consistent-types
+  - Bumped due to a bump in @simulacrum/server.
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.1.7]
 
 - Simplify createSimulation and destroySimulation by removing them from the effects.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.4.1",
-    "@simulacrum/client": "0.5.3",
-    "@simulacrum/server": "0.5.0",
+    "@simulacrum/auth0-simulator": "0.5.0",
+    "@simulacrum/client": "0.5.4",
+    "@simulacrum/server": "0.5.1",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.9]
+
+- apply @typescript/consistent-types
+  - Bumped due to a bump in @simulacrum/server.
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.0.8]
 
 - Simplify createSimulation and destroySimulation by removing them from the effects.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.4.1",
-    "@simulacrum/client": "0.5.3",
-    "@simulacrum/server": "0.5.0",
+    "@simulacrum/auth0-simulator": "0.5.0",
+    "@simulacrum/client": "0.5.4",
+    "@simulacrum/server": "0.5.1",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.1]
+
+- apply @typescript/consistent-types
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.5.0]
 
 - have specific cypress commands for specific auth0 javascript sdks.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12601,11 +12601,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
-        "@simulacrum/server": "0.5.0",
+        "@simulacrum/server": "0.5.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12625,7 +12625,7 @@
         "@frontside/eslint-config": "^3.1.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.3",
+        "@simulacrum/client": "0.5.4",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -12660,7 +12660,7 @@
     },
     "packages/client": {
       "name": "@simulacrum/client",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "effection": "^2.0.1",
@@ -12682,7 +12682,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12724,12 +12724,12 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
         "@effection/process": "^2.0.1",
-        "@simulacrum/ui": "0.3.1",
+        "@simulacrum/ui": "0.3.2",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "cors": "^2.8.5",
@@ -12749,7 +12749,7 @@
         "@frontside/eslint-config": "^3.1.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.3",
+        "@simulacrum/client": "0.5.4",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/mocha": "^8.2.1",
@@ -12771,7 +12771,7 @@
     },
     "packages/ui": {
       "name": "@simulacrum/ui",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "integrity": "sha1-8gohJNeFWtQCRHoGPJCE/SR0NwY=",
       "license": "ISC",
       "devDependencies": {
@@ -14380,8 +14380,8 @@
         "@frontside/eslint-config": "^3.1.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.3",
-        "@simulacrum/server": "0.5.0",
+        "@simulacrum/client": "0.5.4",
+        "@simulacrum/server": "0.5.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",
@@ -14485,8 +14485,8 @@
         "@frontside/eslint-config": "^3.1.0",
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
-        "@simulacrum/client": "0.5.3",
-        "@simulacrum/ui": "0.3.1",
+        "@simulacrum/client": "0.5.4",
+        "@simulacrum/ui": "0.3.2",
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.11",
         "@types/faker": "^5.1.7",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.5.0]
+
+- apply @typescript/consistent-types
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+- Apply rules changes to the accessToken
+  - [ad51c3a](https://github.com/thefrontside/simulacrum/commit/ad51c3af6f74aad72b00e3ea71fc01042a6287c5) Rules tests ([#183](https://github.com/thefrontside/simulacrum/pull/183)) on 2022-03-14
+
 ## \[0.4.1]
 
 - Simplify createSimulation and destroySimulation by removing them from the effects.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
     "@effection/process": "^2.0.1",
-    "@simulacrum/server": "0.5.0",
+    "@simulacrum/server": "0.5.1",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",
@@ -56,7 +56,7 @@
     "@frontside/eslint-config": "^3.1.0",
     "@frontside/tsconfig": "^3.0.0",
     "@frontside/typescript": "^3.0.0",
-    "@simulacrum/client": "0.5.3",
+    "@simulacrum/client": "0.5.4",
     "@types/base64-url": "^2.2.0",
     "@types/cookie-session": "^2.0.42",
     "@types/dedent": "^0.7.0",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.4]
+
+- apply @typescript/consistent-types
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.5.3]
 
 - Update eslint-config and typescript versions

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/client",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "connect to simulacrum servers and manipulate them via the control API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.2.3]
+
+- apply @typescript/consistent-types
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.2.2]
 
 - Simplify createSimulation and destroySimulation by removing them from the effects.

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.1]
+
+- apply @typescript/consistent-types
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.5.0]
 
 - Simplify createSimulation and destroySimulation by removing them from the effects.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   "dependencies": {
     "@effection/atom": "^2.0.1",
     "@effection/process": "^2.0.1",
-    "@simulacrum/ui": "0.3.1",
+    "@simulacrum/ui": "0.3.2",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "cors": "^2.8.5",
@@ -49,7 +49,7 @@
     "@frontside/eslint-config": "^3.1.0",
     "@frontside/tsconfig": "^3.0.0",
     "@frontside/typescript": "^3.0.0",
-    "@simulacrum/client": "0.5.3",
+    "@simulacrum/client": "0.5.4",
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/mocha": "^8.2.1",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.3.2]
+
+- apply @typescript/consistent-types
+  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
+
 ## \[0.3.1]
 
 - Update eslint-config and typescript versions

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A web UI to work with a Simulacrum Server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/client

## [0.5.4]
- apply @typescript/consistent-types
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22



# @simulacrum/server

## [0.5.1]
- apply @typescript/consistent-types
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22



# @simulacrum/auth0-simulator

## [0.5.0]
- apply @typescript/consistent-types
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22
- Apply rules changes to the accessToken
  - [ad51c3a](https://github.com/thefrontside/simulacrum/commit/ad51c3af6f74aad72b00e3ea71fc01042a6287c5) Rules tests ([#183](https://github.com/thefrontside/simulacrum/pull/183)) on 2022-03-14



# @simulacrum/ui

## [0.3.2]
- apply @typescript/consistent-types
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22



# @simulacrum/ldap-simulator

## [0.2.3]
- apply @typescript/consistent-types
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22



# @simulacrum/auth0-cypress

## [0.5.1]
- apply @typescript/consistent-types
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.8]
- apply @typescript/consistent-types
  - Bumped due to a bump in @simulacrum/server.
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.9]
- apply @typescript/consistent-types
  - Bumped due to a bump in @simulacrum/server.
  - [746a2ab](https://github.com/thefrontside/simulacrum/commit/746a2ab46333ff836808dd4d1bf8e98f2a20afae) Eslint consitent types ([#181](https://github.com/thefrontside/simulacrum/pull/181)) on 2022-02-22