### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/make-iat-epoch-time.md
+++ b/.changes/make-iat-epoch-time.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-Make the iat field epoch time.

--- a/.changes/standalone-ldap-resource.md
+++ b/.changes/standalone-ldap-resource.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/ldap-simulator": minor
----
-add low-level `createLDAPServer()` resource that lets you embed an LDAP server
-into any Effection program as an resource.

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.9]
+
+- Make the iat field epoch time.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15
+
 ## \[0.1.8]
 
 - apply @typescript/consistent-types

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.5.0",
+    "@simulacrum/auth0-simulator": "0.5.1",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.5.1",
     "@types/react": "17.0.37",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.10]
+
+- Make the iat field epoch time.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15
+
 ## \[0.0.9]
 
 - apply @typescript/consistent-types

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "sim": "node ./simulator-server.mjs",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.5.0",
+    "@simulacrum/auth0-simulator": "0.5.1",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.5.1",
     "@types/react": "17.0.37",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.2]
+
+- Make the iat field epoch time.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15
+
 ## \[0.5.1]
 
 - apply @typescript/consistent-types

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12601,7 +12601,7 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
@@ -12682,7 +12682,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.1]
+
+- Make the iat field epoch time.
+  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15
+
 ## \[0.5.0]
 
 - apply @typescript/consistent-types

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.3.0]
+
+- add low-level `createLDAPServer()` resource that lets you embed an LDAP server
+  into any Effection program as an resource.
+  - [a470277](https://github.com/thefrontside/simulacrum/commit/a47027705cb8976dc97f5b274a3582b8c665dadb) Allow LDAP server to be standalone a resource on 2022-03-15
+
 ## \[0.2.3]
 
 - apply @typescript/consistent-types

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/auth0-simulator

## [0.5.1]
- Make the iat field epoch time.
  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15



# @simulacrum/ldap-simulator

## [0.3.0]
- add low-level `createLDAPServer()` resource that lets you embed an LDAP server
into any Effection program as an resource.
  - [a470277](https://github.com/thefrontside/simulacrum/commit/a47027705cb8976dc97f5b274a3582b8c665dadb) Allow LDAP server to be standalone a resource on 2022-03-15



# @simulacrum/auth0-cypress

## [0.5.2]
- Make the iat field epoch time.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.9]
- Make the iat field epoch time.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.10]
- Make the iat field epoch time.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6e08689](https://github.com/thefrontside/simulacrum/commit/6e086899eaf085d1e12e2c8edfea56139d8b705b) make iat field epoch time ([#187](https://github.com/thefrontside/simulacrum/pull/187)) on 2022-03-15