### PR TITLE
Optionally output logs from LDAP simulator

### DIFF
--- a/.changes/ldap-logging.md
+++ b/.changes/ldap-logging.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/ldap-simulator": patch
+---
+add `log` option to LDAP simulator options to enabled/disable logging

--- a/packages/ldap/src/index.ts
+++ b/packages/ldap/src/index.ts
@@ -46,7 +46,7 @@ export function createLDAPServer<T extends UserData>(options: LDAPOptions & LDAP
         error: () => undefined,
       };
 
-      let logger = options.log ? console : {
+      let logger = options.log || options.log == null ? console : {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         log: (..._: unknown[]) => {}
       };

--- a/packages/ldap/src/types.ts
+++ b/packages/ldap/src/types.ts
@@ -1,4 +1,5 @@
 export interface LDAPOptions {
+  log?: boolean;
   port?: number;
   baseDN: string;
   bindDn: string;

--- a/packages/ldap/test/ldap.test.ts
+++ b/packages/ldap/test/ldap.test.ts
@@ -69,7 +69,7 @@ describe('Auth0 simulator', () => {
     }
 
     afterEach(() => {
-      ldapClient?.unbind(() => console.log('unbound`'));
+      ldapClient?.unbind();
     });
 
     describe('bind', () => {

--- a/packages/ldap/test/ldap.test.ts
+++ b/packages/ldap/test/ldap.test.ts
@@ -34,6 +34,7 @@ describe('Auth0 simulator', () => {
     beforeEach(function*() {
       simulation = yield client.createSimulation("ldap", {
         options: {
+          log: false,
           baseDN: "ou=users,dc=org.com",
           bindDn: "admin@org.com",
           bindPassword: "password",


### PR DESCRIPTION
## Motivation
The LDAP simulator outputs a lot of useful debug output, however there is no way to silence this output and so when demoing test output, it can be difficult to demonstrate what is signal and what is noise.

## Approach
This adds a `log` flag to the server options, and won't print anything unless that flag is present