### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/add-cosmiconfig.md
+++ b/.changes/add-cosmiconfig.md
@@ -1,6 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor
-"@simulacrum/auth0-cypress": minor
-"@simulacrum/server": minor
----
-Add cosmiconfig and zod to @simulacrum/auth0-simulator

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.10]
+
+- Add cosmiconfig and zod to @simulacrum/auth0-simulator
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01
+
 ## \[0.1.9]
 
 - Make the iat field epoch time.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.5.1",
+    "@simulacrum/auth0-simulator": "0.6.0",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.5.1",
+    "@simulacrum/server": "0.6.0",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.11]
+
+- Add cosmiconfig and zod to @simulacrum/auth0-simulator
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01
+
 ## \[0.0.10]
 
 - Make the iat field epoch time.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,9 +22,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.5.1",
+    "@simulacrum/auth0-simulator": "0.6.0",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.5.1",
+    "@simulacrum/server": "0.6.0",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.0]
+
+- Add cosmiconfig and zod to @simulacrum/auth0-simulator
+  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01
+
 ## \[0.5.2]
 
 - Make the iat field epoch time.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12620,11 +12620,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
-        "@simulacrum/server": "0.5.1",
+        "@simulacrum/server": "0.6.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12702,7 +12702,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12744,7 +12744,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
@@ -14401,7 +14401,7 @@
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.5.1",
+        "@simulacrum/server": "0.6.0",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.0]
+
+- Add cosmiconfig and zod to @simulacrum/auth0-simulator
+  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01
+
 ## \[0.5.1]
 
 - Make the iat field epoch time.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
     "@effection/process": "^2.0.1",
-    "@simulacrum/server": "0.5.1",
+    "@simulacrum/server": "0.6.0",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.3.2]
+
+- Add cosmiconfig and zod to @simulacrum/auth0-simulator
+  - Bumped due to a bump in @simulacrum/server.
+  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01
+
 ## \[0.3.1]
 
 - add `log` option to LDAP simulator options to enabled/disable logging

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.0]
+
+- Add cosmiconfig and zod to @simulacrum/auth0-simulator
+  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01
+
 ## \[0.5.1]
 
 - apply @typescript/consistent-types

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/server

## [0.6.0]
- Add cosmiconfig and zod to @simulacrum/auth0-simulator
  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01



# @simulacrum/auth0-simulator

## [0.6.0]
- Add cosmiconfig and zod to @simulacrum/auth0-simulator
  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01



# @simulacrum/ldap-simulator

## [0.3.2]
- Add cosmiconfig and zod to @simulacrum/auth0-simulator
  - Bumped due to a bump in @simulacrum/server.
  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01



# @simulacrum/auth0-cypress

## [0.6.0]
- Add cosmiconfig and zod to @simulacrum/auth0-simulator
  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.10]
- Add cosmiconfig and zod to @simulacrum/auth0-simulator
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.11]
- Add cosmiconfig and zod to @simulacrum/auth0-simulator
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [3dfacdc](https://github.com/thefrontside/simulacrum/commit/3dfacdcf84ca55a7f965dd297675245efb794f69) Add Cosmiconfig and zod to @simulacrum/auth0-config ([#190](https://github.com/thefrontside/simulacrum/pull/190)) on 2022-04-01