### PR TITLE
Use LDAP client as a resource in tests

### DIFF
--- a/packages/ldap/test/helpers.ts
+++ b/packages/ldap/test/helpers.ts
@@ -41,6 +41,9 @@ export function createLDAPClient(url: string): LDAP {
         *init() {
           let client = createLDAPJSClient({ url });
 
+          // The mere attempt to `bind()` requires an `unbind()`,
+          // so we have to put our ensure block first because
+          // it must be called even in the event that `bind()` fails.
           yield ensure(() => new Promise<void>((resolve, reject) => {
             client.unbind(err => {
               if (err) {

--- a/packages/ldap/test/helpers.ts
+++ b/packages/ldap/test/helpers.ts
@@ -79,8 +79,7 @@ export function createLDAPClient(url: string): LDAP {
                 });
 
                 yield spawn(function*() {
-                  let error = yield once(response, 'error');
-                  throw error;
+                  throw yield once(response, 'error');
                 });
 
                 yield spawn(on<SearchEntryObject>(response, 'searchEntry').forEach(publish))

--- a/packages/ldap/test/helpers.ts
+++ b/packages/ldap/test/helpers.ts
@@ -1,18 +1,19 @@
-import type { Task, Resource } from 'effection';
+import type { Task, Stream, Operation } from 'effection';
+import { createStream, ensure, on, once, spawn } from 'effection';
 import type { Client } from '@simulacrum/client';
 import { createClient } from '@simulacrum/client';
 import type { Server, ServerOptions } from '@simulacrum/server';
 import { createSimulationServer } from '@simulacrum/server';
-
 export type { Client, Simulation } from '@simulacrum/client';
+import { createClient as createLDAPJSClient, SearchEntryObject, SearchOptions } from 'ldapjs';
 
-export function createTestServer(options: ServerOptions): Resource<Client> {
+export function createTestServer(options: ServerOptions): Operation<Client> {
   return {
     *init(scope: Task) {
       let server: Server = yield createSimulationServer(options);
       let { port } = server.address;
       let client = createClient(`http://localhost:${port}`);
-      scope.run(function*() {
+      yield scope.spawn(function*() {
         try {
           yield;
         } finally {
@@ -20,6 +21,75 @@ export function createTestServer(options: ServerOptions): Resource<Client> {
         }
       });
       return client;
+    }
+  };
+}
+
+export interface LDAP {
+  bind(dn: string, secret: string): Operation<LDAPCommands>;
+}
+
+export interface LDAPCommands {
+  search(base: string, options?: SearchOptions): Stream<SearchEntryObject & Record<string, any>, void>;
+}
+
+export function createLDAPClient(url: string): LDAP {
+  return {
+    bind(dn, secret) {
+      return {
+        name: 'LDAPCommands',
+        *init() {
+          let client = createLDAPJSClient({ url });
+
+          yield ensure(function*() {
+            yield new Promise<void>((resolve, reject) => {
+              client.unbind(err => {
+                if (err) {
+                  reject(err)
+                } else {
+                  resolve();
+                }
+              })
+            });
+          });
+
+          yield new Promise((resolve, reject) => {
+            client.bind(dn, secret, (err, value) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve(value);
+              }
+            });
+          })
+
+
+          return {
+            search(base, options = {}) {
+              return createStream(function*(publish) {
+                let response = yield new Promise((resolve, reject) => {
+                  client.search(base, options, (err, res) => {
+                    if (err) {
+                      reject(err);
+                    } else {
+                      resolve(res)
+                    }
+                  })
+                });
+
+                yield spawn(function*() {
+                  let error = yield once(response, 'error');
+                  throw error;
+                });
+
+                yield spawn(on<SearchEntryObject>(response, 'searchEntry').forEach(publish))
+
+                yield once(response, 'end');
+              });
+            }
+          }
+        },
+      }
     }
   };
 }

--- a/packages/ldap/test/helpers.ts
+++ b/packages/ldap/test/helpers.ts
@@ -41,17 +41,15 @@ export function createLDAPClient(url: string): LDAP {
         *init() {
           let client = createLDAPJSClient({ url });
 
-          yield ensure(function*() {
-            yield new Promise<void>((resolve, reject) => {
-              client.unbind(err => {
-                if (err) {
-                  reject(err)
-                } else {
-                  resolve();
-                }
-              })
+          yield ensure(() => new Promise<void>((resolve, reject) => {
+            client.unbind(err => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve();
+              }
             });
-          });
+          }));
 
           yield new Promise((resolve, reject) => {
             client.bind(dn, secret, (err, value) => {


### PR DESCRIPTION
## Motivation
As part of [adding the root DSE handler](https://github.com/thefrontside/simulacrum/pull/193) to the ldap simulator, I found that my bindings were getting out of sync because the after each hook was not attached to the appropriate scope. Since this is Effection, and we can use resources that automatically teardown after every test, let's make this implicit, that way our tests can be more flexible.

## Approach
This takes out the raw usage of the LDAP client, and wraps it in a resource. Specifically, in order to get to the ldap client, you must first `bind()` and then you can execute commands such as `search`. `search()` itself has been implemented as a stream which makes working with it a lot nicer.