### PR TITLE
Implement Root DSE search for LDAP Simulator

### DIFF
--- a/.changes/ldap-root-dse.md
+++ b/.changes/ldap-root-dse.md
@@ -1,4 +1,4 @@
 ---
-@simulacrum/ldap-simulator: minor
+"@simulacrum/ldap-simulator": minor
 ---
 ✨Simulated LDAP server now implements the root DSE response https://github.com/thefrontside/simulacrum/pull/193

--- a/.changes/ldap-root-dse.md
+++ b/.changes/ldap-root-dse.md
@@ -1,0 +1,4 @@
+---
+@simulacrum/ldap-simulator: minor
+---
+✨Simulated LDAP server now implements the root DSE response https://github.com/thefrontside/simulacrum/pull/193

--- a/packages/ldap/src/index.ts
+++ b/packages/ldap/src/index.ts
@@ -54,7 +54,7 @@ export function createLDAPServer<T extends UserData>(options: LDAPOptions & LDAP
 
       let server = createServer({ log: silence });
 
-
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       server.search("", function (req: any, res: any, next: any) {
         logger.log(dedent`--- Root DSE ---
 scope:  ${req.scope}

--- a/packages/ldap/src/index.ts
+++ b/packages/ldap/src/index.ts
@@ -53,6 +53,22 @@ export function createLDAPServer<T extends UserData>(options: LDAPOptions & LDAP
 
 
       let server = createServer({ log: silence });
+
+
+      server.search("", function (req: any, res: any, next: any) {
+        logger.log(dedent`--- Root DSE ---
+scope:  ${req.scope}
+`);
+        res.send({
+          "dn":"",
+          "attributes":{
+            "vendorName": "Frontside, Inc."
+          },
+        });
+        res.end();
+        return next();
+      });
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       server.search(baseDN, function (req: any, res: any, next: any) {
         logger.log(dedent`--- User Search ---

--- a/packages/ldap/test/helpers.ts
+++ b/packages/ldap/test/helpers.ts
@@ -5,7 +5,8 @@ import { createClient } from '@simulacrum/client';
 import type { Server, ServerOptions } from '@simulacrum/server';
 import { createSimulationServer } from '@simulacrum/server';
 export type { Client, Simulation } from '@simulacrum/client';
-import { createClient as createLDAPJSClient, SearchEntryObject, SearchOptions } from 'ldapjs';
+import type { SearchEntryObject, SearchOptions } from 'ldapjs';
+import { createClient as createLDAPJSClient } from 'ldapjs';
 
 export function createTestServer(options: ServerOptions): Operation<Client> {
   return {
@@ -30,6 +31,7 @@ export interface LDAP {
 }
 
 export interface LDAPCommands {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   search(base: string, options?: SearchOptions): Stream<SearchEntryObject & Record<string, any>, void>;
 }
 
@@ -47,7 +49,7 @@ export function createLDAPClient(url: string): LDAP {
           yield ensure(() => new Promise<void>((resolve, reject) => {
             client.unbind(err => {
               if (err) {
-                reject(err)
+                reject(err);
               } else {
                 resolve();
               }
@@ -62,7 +64,7 @@ export function createLDAPClient(url: string): LDAP {
                 resolve(value);
               }
             });
-          })
+          });
 
 
           return {
@@ -73,23 +75,23 @@ export function createLDAPClient(url: string): LDAP {
                     if (err) {
                       reject(err);
                     } else {
-                      resolve(res)
+                      resolve(res);
                     }
-                  })
+                  });
                 });
 
                 yield spawn(function*() {
                   throw yield once(response, 'error');
                 });
 
-                yield spawn(on<SearchEntryObject>(response, 'searchEntry').forEach(publish))
+                yield spawn(on<SearchEntryObject>(response, 'searchEntry').forEach(publish));
 
                 yield once(response, 'end');
               });
             }
-          }
+          };
         },
-      }
+      };
     }
   };
 }

--- a/packages/ldap/test/ldap.test.ts
+++ b/packages/ldap/test/ldap.test.ts
@@ -128,6 +128,15 @@ describe('LDAP simulator', () => {
 
         expect(result).toBeUndefined();
       });
+
+      it('has a root DSE', function*() {
+        let result = yield commands.search("").first();
+        expect(result).toMatchObject({
+          attributes: [{
+            type: "vendorName",
+          }]
+        });
+      });
     });
   });
 });

--- a/packages/ldap/test/ldap.test.ts
+++ b/packages/ldap/test/ldap.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from '@effection/mocha';
 import expect from 'expect';
-import { Client, createLDAPClient, LDAP, LDAPCommands, Simulation } from './helpers';
+import type { Client, LDAP, LDAPCommands, Simulation } from './helpers';
+import { createLDAPClient } from './helpers';
 import { createTestServer } from './helpers';
 import { ldap } from '../src';
 import { NoSuchObjectError } from 'ldapjs';


### PR DESCRIPTION
> Depends on #192 

## Motivation
Every LDAP Server must have a [Root DSE][1] to provide metadata about itself. This allows clients to distinguish between particular vendors. Among others, Backstage uses the root dse to determine if it is talking to Microsoft Active Directory and customize its behavior accordingly.

## Approach
This adds the root DSE search which is just an "empty" entry with the zero leng string as its DN.

[1]: https://ldap.com/dit-and-the-ldap-root-dse/