### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/ldap-root-dse.md
+++ b/.changes/ldap-root-dse.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/ldap-simulator": minor
----
-✨Simulated LDAP server now implements the root DSE response https://github.com/thefrontside/simulacrum/pull/193

--- a/package-lock.json
+++ b/package-lock.json
@@ -12702,7 +12702,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.4.0]
+
+- ✨Simulated LDAP server now implements the root DSE response https://github.com/thefrontside/simulacrum/pull/193
+  - [b83367c](https://github.com/thefrontside/simulacrum/commit/b83367c1c45be25e5dd63b99e86bd82b248b51ce) Add changeset on 2022-04-06
+  - [8303448](https://github.com/thefrontside/simulacrum/commit/8303448882db063a11d28c58c9d605aa27a8eae1) Fix changelog entry on 2022-04-07
+
 ## \[0.3.2]
 
 - Add cosmiconfig and zod to @simulacrum/auth0-simulator

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/ldap-simulator

## [0.4.0]
- ✨Simulated LDAP server now implements the root DSE response https://github.com/thefrontside/simulacrum/pull/193
  - [b83367c](https://github.com/thefrontside/simulacrum/commit/b83367c1c45be25e5dd63b99e86bd82b248b51ce) Add changeset on 2022-04-06
  - [8303448](https://github.com/thefrontside/simulacrum/commit/8303448882db063a11d28c58c9d605aa27a8eae1) Fix changelog entry on 2022-04-07