### PR TITLE
Simplify the LDAP schema

### DIFF
--- a/.changes/align-ldap-schema.md
+++ b/.changes/align-ldap-schema.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/ldap-simulator": minor
+---
+feed ldap server uuid, cn directly to the low-level server api

--- a/packages/ldap/test/ldap.test.ts
+++ b/packages/ldap/test/ldap.test.ts
@@ -70,7 +70,7 @@ describe('LDAP simulator', () => {
 
       it('should not bind with invalid credentials', function* () {
         yield client.given(simulation, "person", {
-          email: "admin@org.com",
+          cn: "admin@org.com",
           password: "password"
         });
 


### PR DESCRIPTION
## Motivation
There are some difficulties integrating the LDAP simulator in with the Backstage processors and providers. The `UserData` that feeds the LDAP server is required to have an `id` attribute and an `email` attribute, both of which are not part of any common ldap schema. Furthermore, it does not send common user attributes as part of a search result. So, for example, Backstage (as well as most common LDAP clients), when connecting to an OpenLDAP server, will be looking for both the `entryDN` virtual attribute and the `entryUUID` attribute. Backstage, for example, uses `entryUUID` as the value of the all-important `metadata.name` Entity field.

## Approach

This aligns the `user data` with the minimum number of attributes. Since `cn` is used to authenticate, we use `cn` in the user data api (also, the LDAP convention for the email field is `mail` anyway, and not `email`). This also makes send the the `dn` back to the client more straightforward since the `dn` is comprised of the `cn`,`baseDN`.

Note that this is a breaking change, and will require user data to be mapped differently for currently running these simulators.

### Possible Drawbacks or Risks

There is actually quite a bit of variance in the attribute naming conventions that LDAP servers use, and so there really isn't a "one-size fits all". For example, there really is no guarantee that `entryUUID` is an attribute. I think we can mitigate this by specifying a "vendor" flag to show 


## Learning

There are some good resources for learning LDAP... not something that I'm good at yet, but I was able to come up to basic, basic speed with the following resources:

* https://ldap.com
* https://ldapwiki.com
and to a lesser extent, 
* https://openldap.org

In the future, it would be nice if we could run an actual open LDAP server embedded in-process using WASM.