### PR TITLE
Improve LDAP-simulator types

### DIFF
--- a/.changes/ldap-types.md
+++ b/.changes/ldap-types.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/ldap-simulator": minor
+---
+improve ldap types

--- a/package-lock.json
+++ b/package-lock.json
@@ -2371,9 +2371,9 @@
       "dev": true
     },
     "node_modules/@types/ldapjs": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.1.tgz",
-      "integrity": "sha512-rctCsjTBpG86j352gd6BfFevpcG2Rvh2K6t3BLO3VJMe6JSGDI5rovA+8O/rxL5PbXz0UFBdDu7wv/1hA/0GjA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.2.tgz",
+      "integrity": "sha512-U5HdnwIZ5uZa+f3usxdqgyfNmOROxOxXvQdQtsu6sKo8fte5vej9br2csHxPvXreAbAO1bs8/rdEzvCLpi67nQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -12714,7 +12714,7 @@
         "ldap-simulator": "bin/index.js"
       },
       "devDependencies": {
-        "@types/ldapjs": "^2.2.1",
+        "@types/ldapjs": "^2.2.2",
         "@types/seedrandom": "^3.0.1",
         "typescript": "^4.4.3"
       }
@@ -14464,7 +14464,7 @@
       "version": "file:packages/ldap",
       "requires": {
         "@simulacrum/server": "^0.4.0",
-        "@types/ldapjs": "^2.2.1",
+        "@types/ldapjs": "^2.2.2",
         "@types/seedrandom": "^3.0.1",
         "get-port": "5.1.1",
         "ldapjs": "^2.3.1",
@@ -14695,9 +14695,9 @@
       "dev": true
     },
     "@types/ldapjs": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.1.tgz",
-      "integrity": "sha512-rctCsjTBpG86j352gd6BfFevpcG2Rvh2K6t3BLO3VJMe6JSGDI5rovA+8O/rxL5PbXz0UFBdDu7wv/1hA/0GjA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.2.tgz",
+      "integrity": "sha512-U5HdnwIZ5uZa+f3usxdqgyfNmOROxOxXvQdQtsu6sKo8fte5vej9br2csHxPvXreAbAO1bs8/rdEzvCLpi67nQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -31,7 +31,7 @@
     "@simulacrum/server": "^0.4.0"
   },
   "devDependencies": {
-    "@types/ldapjs": "^2.2.1",
+    "@types/ldapjs": "^2.2.2",
     "@types/seedrandom": "^3.0.1",
     "typescript": "^4.4.3"
   }

--- a/packages/ldap/src/types.ts
+++ b/packages/ldap/src/types.ts
@@ -1,3 +1,42 @@
+declare module 'ldapjs' {
+  interface RDNS {
+    attrs: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [key: string]: any;
+    }
+  }
+  interface DN {
+    rdns: RDNS[];
+  }
+  export interface SearchRequest {
+    dn: DN;
+  }
+
+  export interface LDAPResult {
+    // 0 is success
+    end(status?: number): void;
+  }
+
+  export interface SearchResponse extends LDAPResult {
+    send(entry: SearchEntry | SearchReference, noFiltering?: boolean): void;
+  }
+
+  export interface CompareRequest {
+    entry: SearchEntry;
+    attribute: Attribute;
+    value: string | Buffer;
+    dn: DN;
+  }
+
+  export type CompareResponse = LDAPResult;
+  export type BindResponse = LDAPResult;
+
+  export interface BindRequest {
+    credentials: string;
+    dn: DN
+  }
+}
+
 export interface LDAPOptions {
   log?: boolean;
   port?: number;
@@ -5,4 +44,18 @@ export interface LDAPOptions {
   bindDn: string;
   groupDN: string
   bindPassword: string;
+}
+
+export interface UserData {
+  uuid: string;
+  cn: string;
+  password: string;
+}
+
+export interface LDAPStoreOptions<T extends UserData> {
+  users: Iterable<T>;
+}
+
+export interface Port {
+  port: number;
 }


### PR DESCRIPTION
## Motivation

There are currently far too many `any` types in the ldap-simulator.  The `@types/ldapjs` is pretty incomplete and uses a lot of `any` itself.

## Approach

Use declaration merging to add some type safety around the missing bits

```ts
declare module 'ldapjs' {
    // etc.
}
```
