### PR TITLE
Prep API and README for testing article

### DIFF
--- a/.changes/ldap-readme.md
+++ b/.changes/ldap-readme.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/ldap-simulator": minor
+---
+Add a README to the NPM package as well as an async api around an LDAP server
+resource

--- a/packages/ldap/README.md
+++ b/packages/ldap/README.md
@@ -12,6 +12,7 @@ environment, you can use promise-based API.
 
 ## Plain JavaScript
 
+```js
 import { runLDAPServer } from "@simulacrum/ldap-simulator";
 
 async function run() {
@@ -39,6 +40,7 @@ async function run() {
     await server.close();
   }
 }
+```
 
 ## Effection
 
@@ -46,6 +48,7 @@ However, if you are already using [Effection][effection], the LDAP
 server is available as a [Resource][resource], and so you can use it
 freely in any context:
 
+```js
 import { createLDAPServer } from "@simulacrum/ldap-simulator";
 
 function* run() {
@@ -68,6 +71,7 @@ function* run() {
 
   //... do some stuff
 }
+```
 
 [effection]: https://frontside.com/effection
 [resource]: https://frontside.com/effection/docs/guides/resources

--- a/packages/ldap/README.md
+++ b/packages/ldap/README.md
@@ -1,0 +1,73 @@
+# @simulacrum/ldap-simulator
+
+Simulate an actual LDAP server for testing and development.
+
+Often you are working on software that depends on the presence of an
+LDAP directory. This let's you create an LDAP server in a known state
+that can be used for offline development and testing.
+
+There are two different ways to start an LDAP simulator, but they both involve
+the same set of options. If you are running in a vanilla JavaScript
+environment, you can use promise-based API.
+
+## Plain JavaScript
+
+import { runLDAPServer } from "@simulacrum/ldap-simulator";
+
+async function run() {
+  let server = await runLDAPServer({
+    port: 3890,
+    baseDN: "ou=users,dc=org.com",
+    bindDn: "admin@org.com",
+    bindPassword: "password",
+    groupDN:"ou=groups,dc=org.com",
+    users: [{
+      //required
+      cn: 'Charles Lowell',
+      //optional to bind using this user
+      password: "super-secret-but-not-really",
+      //optional:
+      uid: 'cowboyd',
+
+    }]
+  });
+  console.log(`LDAP server running on ${server.port}`);
+  try {
+    //.... do some stuff;
+  } finally {
+    // don't forget to release the server resources!
+    await server.close();
+  }
+}
+
+## Effection
+
+However, if you are already using [Effection][effection], the LDAP
+server is available as a [Resource][resource], and so you can use it
+freely in any context:
+
+import { createLDAPServer } from "@simulacrum/ldap-simulator";
+
+function* run() {
+  let server = yield runLDAPServer({
+    port: 3890,
+    baseDN: "ou=users,dc=org.com",
+    bindDn: "admin@org.com",
+    bindPassword: "password",
+    groupDN:"ou=groups,dc=org.com",
+    users: [{
+      //required
+      cn: 'Charles Lowell',
+      //optional to bind using this user
+      password: "super-secret-but-not-really",
+      //optional:
+      uid: 'cowboyd',
+
+    }]
+  });
+
+  //... do some stuff
+}
+
+[effection]: https://frontside.com/effection
+[resource]: https://frontside.com/effection/docs/guides/resources


### PR DESCRIPTION
## Motivation
There is an article in the works that references the LDAP simulator as a solution to testing a backstage server. Unfortunately, we don't have a README, and so the [NPM package homepage](https://www.npmjs.com/package/@simulacrum/ldap-simulator/v/0.4.0) looks quite bad.

## Approach
This adds a basic readme and shows how to start an LDAP server from both a vanilla JavaScript context as well from an Effection context. There is a third way, which is via a simulacrum server, but this does not add that since it's a bit more fiddly, likely to change, and not relevant for the content of the blog post.

It also adds the actual vanilla javascript integration since it didn't exist before (it just wraps the resource in a run);