### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/client.md
+++ b/.changes/client.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-
-add missing @simulacrum/client to auth0 package

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.12]
+
+- add missing @simulacrum/client to auth0 package
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20
+
 ## \[0.1.11]
 
 - Add cosmiconfig as a dependency to the auth0-simulator

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.6.1",
+    "@simulacrum/auth0-simulator": "0.6.2",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.6.0",
     "@types/react": "17.0.37",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.13]
+
+- add missing @simulacrum/client to auth0 package
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20
+
 ## \[0.0.12]
 
 - Add cosmiconfig as a dependency to the auth0-simulator

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,7 +22,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.6.1",
+    "@simulacrum/auth0-simulator": "0.6.2",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.6.0",
     "@types/react": "17.0.37",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.6.2]
+
+- add missing @simulacrum/client to auth0 package
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20
+
 ## \[0.6.1]
 
 - Add cosmiconfig as a dependency to the auth0-simulator

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12595,10 +12595,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
+        "@simulacrum/client": "0.5.4",
         "@simulacrum/server": "0.6.0",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.2]
+
+- add missing @simulacrum/client to auth0 package
+  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20
+
 ## \[0.6.1]
 
 - Add cosmiconfig as a dependency to the auth0-simulator

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/auth0-simulator

## [0.6.2]
- add missing @simulacrum/client to auth0 package
  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20



# @simulacrum/auth0-cypress

## [0.6.2]
- add missing @simulacrum/client to auth0 package
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.12]
- add missing @simulacrum/client to auth0 package
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.13]
- add missing @simulacrum/client to auth0 package
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6b0c7d1](https://github.com/thefrontside/simulacrum/commit/6b0c7d1cdca0f19455b5e9017216520bcae06ff2) add missing @simulacrum/client to auth0 package ([#205](https://github.com/thefrontside/simulacrum/pull/205)) on 2022-04-20