### PR TITLE
simulation filter may include null, include check

### DIFF
--- a/.changes/server-effect-logging-null.md
+++ b/.changes/server-effect-logging-null.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/server': patch
+---
+
+The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/packages/server/src/effects/logging.ts
+++ b/packages/server/src/effects/logging.ts
@@ -15,7 +15,7 @@ export function createLogger(slice: Slice<ServerState>): Operation<void> {
         yield task.halt();
         if (shouldLogErrors) {
           task = yield spawn(map(slice.slice("simulations"), function*(simulation) {
-            yield simulation.filter(({ status }) => status === 'failed').forEach(state => {
+            yield simulation.filter(sim => sim?.status === 'failed').forEach(state => {
               assert(state.status === 'failed');
               console.error(state.error);
             });


### PR DESCRIPTION
## Motivation

The simulation server can return null events on shutdown, and the logger did not consider this.

## Approach

Check for undefined within the filter.
