### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/server-effect-logging-null.md
+++ b/.changes/server-effect-logging-null.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/server': patch
----
-
-The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.13]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
+  - Bumped due to a bump in @simulacrum/server.
+  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23
+
 ## \[0.1.12]
 
 - add missing @simulacrum/client to auth0 package

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.6.2",
+    "@simulacrum/auth0-simulator": "0.6.3",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.0",
+    "@simulacrum/server": "0.6.1",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.14]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
+  - Bumped due to a bump in @simulacrum/server.
+  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23
+
 ## \[0.0.13]
 
 - add missing @simulacrum/client to auth0 package

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,9 +22,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.6.2",
+    "@simulacrum/auth0-simulator": "0.6.3",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.0",
+    "@simulacrum/server": "0.6.1",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.6.3]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23
+
 ## \[0.6.2]
 
 - add missing @simulacrum/client to auth0 package

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12595,12 +12595,12 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.6.0",
+        "@simulacrum/server": "0.6.1",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12679,7 +12679,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12721,7 +12721,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
@@ -14368,7 +14368,7 @@
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.6.0",
+        "@simulacrum/server": "0.6.1",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.6.3]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
+  - Bumped due to a bump in @simulacrum/server.
+  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23
+
 ## \[0.6.2]
 
 - add missing @simulacrum/client to auth0 package

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@effection/process": "^2.0.1",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.0",
+    "@simulacrum/server": "0.6.1",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.2]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
+  - Bumped due to a bump in @simulacrum/server.
+  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23
+
 ## \[0.5.1]
 
 - fix typo in readme for Effection example

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.1]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
+  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23
+
 ## \[0.6.0]
 
 - Add cosmiconfig and zod to @simulacrum/auth0-simulator

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/server

## [0.6.1]
- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23



# @simulacrum/auth0-simulator

## [0.6.3]
- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
  - Bumped due to a bump in @simulacrum/server.
  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23



# @simulacrum/ldap-simulator

## [0.5.2]
- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
  - Bumped due to a bump in @simulacrum/server.
  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23



# @simulacrum/auth0-cypress

## [0.6.3]
- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.13]
- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
  - Bumped due to a bump in @simulacrum/server.
  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.14]
- The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.
  - Bumped due to a bump in @simulacrum/server.
  - [43bb4cf](https://github.com/thefrontside/simulacrum/commit/43bb4cfde8884595496ecdd27f6c94ceff95765d) simulation filter may include null, include check ([#210](https://github.com/thefrontside/simulacrum/pull/210)) on 2022-08-23