### PR TITLE
simulation filter may include null, include check

### DIFF
--- a/.changes/more-null-logging-status.md
+++ b/.changes/more-null-logging-status.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/server': patch
+---
+
+The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.

--- a/packages/server/src/operation-context.ts
+++ b/packages/server/src/operation-context.ts
@@ -52,7 +52,7 @@ export function createOperationContext(atom: Slice<ServerState>, scope: Task, ne
 
         simulationsMap.set(simulationId, simulationTask);
 
-        yield slice.filter(({ status }) => status === 'running').expect();
+        yield slice.filter((sim) => sim?.status === 'running').expect();
       });
 
       return slice.get();

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -49,7 +49,7 @@ export const given: Resolver<GivenParameters, ScenarioState> = {
     let scenario = simulation.slice('scenarios').slice(id);
     scenario.set({ id, status: 'new', name: scenarioName, params });
 
-    return scope.run(scenario.filter(({ status }) => status !== 'new').expect());
+    return scope.run(scenario.filter((sim) => sim?.status !== 'new').expect());
   }
 };
 

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -160,7 +160,7 @@ export function createSimulation (slice: Slice<SimulationState>, simulators: Rec
 export function simulation(simulators: Record<string, Simulator>): Effect<SimulationState> {
   return function* (slice) {
     let simulationTask = yield createSimulation(slice, simulators);
-    yield slice.filter(({ status }) => status == "destroying").expect();
+    yield slice.filter((sim) => sim?.status == "destroying").expect();
     yield simulationTask.halt();
     slice.slice("status").set("halted");
   };


### PR DESCRIPTION
## Motivation

The simulation server can return null events on shutdown, and the logger did not consider this. #210 addressed a single instance, but there were three more instances that needed to be addressed.

## Approach

Check for undefined within the filter.
