### PR TITLE
Decouple Auth0 server from simulacrum

### DIFF
--- a/.changes/auth0-standalone.md
+++ b/.changes/auth0-standalone.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/auth0-simulator": minor
+---
+now exports a `createAuth0Server` operation which can be used directly without
+starting a Simulacrum server

--- a/packages/auth0/src/config/get-config.ts
+++ b/packages/auth0/src/config/get-config.ts
@@ -1,19 +1,6 @@
 import { cosmiconfigSync } from 'cosmiconfig';
-import type { Auth0Configuration, Options, Schema } from '../types';
+import type { Auth0Configuration, Schema } from '../types';
 import { configurationSchema } from '../types';
-
-function omit<T, K extends keyof T>(obj: T, ...keys: K[]): Omit<T, K> {
-  let copy = {} as T;
-
-  let remaining = (Object.keys(obj) as K[])
-                      .flatMap(c => keys.includes(c) === false ? [c] : []);
-
-  for(let k of remaining) {
-    copy[k] = obj[k];
-  }
-
-  return copy;
-}
 
 const DefaultAuth0Port = 4400;
 
@@ -42,13 +29,13 @@ function getPort({ domain, port }: Auth0Configuration): number {
 // This higher order function would only be used for testing and
 // allows different cosmiconfig instances to be used for testing
 export function getConfigCreator(explorer: Explorer) {
-  return function getConfig(options?: Options): Auth0Configuration {
+  return function getConfig(options?: Partial<Auth0Configuration>): Auth0Configuration {
     let searchResult = explorer.search();
 
     let config: Schema =
       searchResult === null ? DefaultArgs : searchResult.config;
 
-    let strippedOptions = !!options ? omit(options, 'store', 'services') : {};
+    let strippedOptions = options ?? {};
 
     let configuration = { ...DefaultArgs, ...config, ...strippedOptions } as Auth0Configuration;
 
@@ -63,4 +50,3 @@ export function getConfigCreator(explorer: Explorer) {
 const explorer = cosmiconfigSync("auth0Simulator");
 
 export const getConfig = getConfigCreator(explorer);
-

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -1,4 +1,4 @@
-import type { Middleware, Person } from '@simulacrum/server';
+import type { Person } from '@simulacrum/server';
 import type { AccessTokenPayload, Auth0Configuration, IdTokenData, QueryParams, ResponseModes } from '../types';
 import type { RequestHandler } from 'express';
 import { createLoginRedirectHandler } from './login-redirect';

--- a/packages/auth0/src/handlers/get-service-url.ts
+++ b/packages/auth0/src/handlers/get-service-url.ts
@@ -1,8 +1,8 @@
-import type { Options } from '../types';
 import { assert } from 'assert-ts';
+import type { SimulationState } from '@simulacrum/server';
 
-export const getServiceUrl = (options: Options): URL => {
-  let service = options.services.get().find(({ name }) => name === 'auth0' );
+export const getServiceUrl = (options: SimulationState): URL => {
+  let service = options.services.find(({ name }) => name === 'auth0' );
 
   assert(!!service, `did not find auth0 service in set of running services`);
 

--- a/packages/auth0/src/handlers/login-redirect.ts
+++ b/packages/auth0/src/handlers/login-redirect.ts
@@ -1,9 +1,9 @@
 import type { Request, Response } from 'express';
-import type { Options, QueryParams } from '../types';
+import type { Auth0Configuration, QueryParams } from '../types';
 import { stringify } from "querystring";
 import type { Middleware } from '@simulacrum/server';
 
-export const createLoginRedirectHandler = (options: Options): Middleware =>
+export const createLoginRedirectHandler = (options: Auth0Configuration): Middleware =>
   function* loginRedirect (req: Request, res: Response) {
     let {
       client_id,

--- a/packages/auth0/src/handlers/login-redirect.ts
+++ b/packages/auth0/src/handlers/login-redirect.ts
@@ -1,10 +1,9 @@
-import type { Request, Response } from 'express';
+import type { Request, Response, RequestHandler } from 'express';
 import type { Auth0Configuration, QueryParams } from '../types';
 import { stringify } from "querystring";
-import type { Middleware } from '@simulacrum/server';
 
-export const createLoginRedirectHandler = (options: Auth0Configuration): Middleware =>
-  function* loginRedirect (req: Request, res: Response) {
+export const createLoginRedirectHandler = (options: Auth0Configuration): RequestHandler =>
+  function loginRedirect (req: Request, res: Response) {
     let {
       client_id,
       redirect_uri,

--- a/packages/auth0/src/handlers/openid-handlers.ts
+++ b/packages/auth0/src/handlers/openid-handlers.ts
@@ -1,7 +1,5 @@
 import type { HttpHandler } from '@simulacrum/server';
-import type { Options } from 'src/types';
 import { JWKS } from '../auth/constants';
-import { getServiceUrl } from './get-service-url';
 import { removeTrailingSlash } from './url';
 
 type Routes =
@@ -18,14 +16,14 @@ export interface OpenIdConfiguration {
   jwks_uri: string;
 }
 
-export const createOpenIdHandlers = (options: Options): Record<OpenIdRoutes, HttpHandler> => {
+export const createOpenIdHandlers = (serviceURL: () => URL): Record<OpenIdRoutes, HttpHandler> => {
   return {
     ['/.well-known/jwks.json']: function* (_, res) {
       res.json(JWKS);
     },
 
     ['/.well-known/openid-configuration']: function* (_, res) {
-      let url = removeTrailingSlash(getServiceUrl(options).toString());
+      let url = removeTrailingSlash(serviceURL().toString());
 
       res.json({
         issuer: `${url}/`,

--- a/packages/auth0/src/handlers/openid-handlers.ts
+++ b/packages/auth0/src/handlers/openid-handlers.ts
@@ -1,4 +1,4 @@
-import type { HttpHandler } from '@simulacrum/server';
+import type { RequestHandler } from 'express';
 import { JWKS } from '../auth/constants';
 import { removeTrailingSlash } from './url';
 
@@ -16,13 +16,13 @@ export interface OpenIdConfiguration {
   jwks_uri: string;
 }
 
-export const createOpenIdHandlers = (serviceURL: () => URL): Record<OpenIdRoutes, HttpHandler> => {
+export const createOpenIdHandlers = (serviceURL: () => URL): Record<OpenIdRoutes, RequestHandler> => {
   return {
-    ['/.well-known/jwks.json']: function* (_, res) {
+    ['/.well-known/jwks.json']: function(_, res) {
       res.json(JWKS);
     },
 
-    ['/.well-known/openid-configuration']: function* (_, res) {
+    ['/.well-known/openid-configuration']: function(_, res) {
       let url = removeTrailingSlash(serviceURL().toString());
 
       res.json({

--- a/packages/auth0/src/handlers/web-message.ts
+++ b/packages/auth0/src/handlers/web-message.ts
@@ -1,11 +1,11 @@
-import type { Middleware } from '@simulacrum/server';
+import type { RequestHandler } from 'express';
 import { assert } from 'assert-ts';
 import { encode } from 'base64-url';
 import type { QueryParams } from 'src/types';
 import { webMessage } from '../views/web-message';
 
-export const createWebMessageHandler = (): Middleware =>
-  function* (req, res) {
+export const createWebMessageHandler = (): RequestHandler =>
+  function(req, res) {
     assert(!!req.session, "no session");
 
     let username = req.session.username;

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -42,6 +42,7 @@ const createAuth0Service: ResourceServiceCreator = (slice, options) => ({
     let serviceURL = () => getServiceUrl(slice.get());
 
     let auth0Store = slice.slice('store').slice('auth0');
+    auth0Store.set({});
 
     let store: Auth0Store = {
       get: (nonce) => auth0Store.slice(nonce).get() as AuthSession,
@@ -57,8 +58,6 @@ const createAuth0Service: ResourceServiceCreator = (slice, options) => ({
       }
     };
 
-    console.dir({ options })
-
     let server: Server = yield createAuth0Server({
       debug,
       config,
@@ -67,8 +66,6 @@ const createAuth0Service: ResourceServiceCreator = (slice, options) => ({
       people,
       port
     });
-
-    console.dir({ server })
 
     return {
       port: server.port,

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -1,71 +1,131 @@
-import type { Simulator, LegacyServiceCreator } from '@simulacrum/server';
-import type { Options } from './types';
-import { consoleLogger } from '@simulacrum/server';
-import { createHttpApp } from '@simulacrum/server';
-import { urlencoded, json } from 'express';
-import { createAuth0Handlers } from './handlers/auth0-handlers';
-import { person } from '@simulacrum/server';
-import { createSession } from './middleware/session';
+import type { AddressInfo } from 'net';
+import type { Person } from '@simulacrum/server';
+import { createAppServer, consoleLogger, person, ResourceServiceCreator, Simulator } from '@simulacrum/server';
+import type { Operation } from 'effection';
+import { once, spawn } from 'effection';
+import express, { json, urlencoded } from 'express';
 import path from 'path';
-import express from 'express';
+import { getConfig } from './config/get-config';
+import type { Auth0Store, AuthSession } from './handlers/auth0-handlers';
+import { createAuth0Handlers } from './handlers/auth0-handlers';
+import { getServiceUrl } from './handlers/get-service-url';
+import { createOpenIdHandlers } from './handlers/openid-handlers';
 import { createCors } from './middleware/create-cors';
 import { noCache } from './middleware/no-cache';
-import { createOpenIdHandlers } from './handlers/openid-handlers';
-import { getConfig } from './config/get-config';
+import { createSession } from './middleware/session';
+import type { Auth0Configuration } from './types';
 
 export { getConfig } from './config/get-config';
 
 const publicDir = path.join(__dirname, 'views', 'public');
 
-type Auth0Handlers = ReturnType<typeof createAuth0Handlers> & ReturnType<typeof createOpenIdHandlers>;
+interface Server {
+  port: number;
+}
 
-const createAuth0Service = (handlers: Auth0Handlers, { port, debug }: { port: number, debug: boolean }): LegacyServiceCreator => {
-  let app = createHttpApp()
-    .use(express.static(publicDir))
-    .use(createSession())
-    .use(createCors())
-    .use(noCache())
-    .use(json())
-    .use(urlencoded({ extended: true }))
-    .get('/heartbeat', handlers['/heartbeat'])
-    .get('/authorize', handlers['/authorize'])
-    .get('/login', handlers['/login'])
-    .get('/u/login', handlers['/usernamepassword/login'])
-    .post('/usernamepassword/login', handlers['/usernamepassword/login'])
-    .post('/login/callback', handlers['/login/callback'])
-    .post('/oauth/token', handlers['/oauth/token'])
-    .get('/userinfo', handlers['/userinfo'])
-    .get('/v2/logout', handlers['/v2/logout'])
-    .get('/.well-known/jwks.json', handlers['/.well-known/jwks.json'])
-    .get('/.well-known/openid-configuration', handlers['/.well-known/openid-configuration']);
+export interface Auth0ServerOptions {
+  config: Auth0Configuration;
+  store: Auth0Store;
+  people: Iterable<Person>;
+  serviceURL: () => URL;
+  port?: number;
+  debug?: boolean;
+}
 
-  if(debug) {
-    app = app.use(consoleLogger);
+const createAuth0Service: ResourceServiceCreator = (slice, options) => ({
+  name: 'Auth0Service',
+  *init() {
+    let debug = !!slice.slice('debug').get();
+    let { port } = options;
+    let config = getConfig(slice.slice('options').slice('options').get());
+
+    let serviceURL = () => getServiceUrl(slice.get());
+
+    let auth0Store = slice.slice('store').slice('auth0');
+
+    let store: Auth0Store = {
+      get: (nonce) => auth0Store.slice(nonce).get() as AuthSession,
+      set: (nonce, session) => auth0Store.slice(nonce).set(session),
+    };
+
+    let people: Iterable<Person> = {
+      *[Symbol.iterator]() {
+        let values = Object.values(slice.slice('store').slice('people').get() ?? {});
+        for (let person of values) {
+          yield person as Person;
+        }
+      }
+    };
+
+    let server: Server = yield createAuth0Server({
+      debug,
+      config,
+      store,
+      serviceURL,
+      people,
+      port
+    });
+
+    return {
+      port: server.port,
+      protocol: 'https',
+    };
   }
+});
+
+function createAuth0Server(options: Auth0ServerOptions): Operation<Server> {
+  let { config, serviceURL, store, people, port, debug = true } = options;
+  let auth0 = createAuth0Handlers(store, people, serviceURL, config);
+  let openid = createOpenIdHandlers(serviceURL);
 
   return {
-    protocol: 'https',
-    app,
-    port
-  } as const;
-};
+    name: 'Auth0Server',
+    *init() {
+      let app = express()
+        .use(express.static(publicDir))
+        .use(createSession())
+        .use(createCors())
+        .use(noCache())
+        .use(json())
+        .use(urlencoded({ extended: true }))
+        .get('/heartbeat', auth0['/heartbeat'])
+        .get('/authorize', auth0['/authorize'])
+        .get('/login', auth0['/login'])
+        .get('/u/login', auth0['/usernamepassword/login'])
+        .post('/usernamepassword/login', auth0['/usernamepassword/login'])
+        .post('/login/callback', auth0['/login/callback'])
+        .post('/oauth/token', auth0['/oauth/token'])
+        .get('/userinfo', auth0['/userinfo'])
+        .get('/v2/logout', auth0['/v2/logout'])
+        .get('/.well-known/jwks.json', openid['/.well-known/jwks.json'])
+        .get('/.well-known/openid-configuration', openid['/.well-known/openid-configuration']);
 
-export const auth0: Simulator<Options> = (slice, options) => {
-  let store = slice.slice('store');
-  let services = slice.slice('services');
-  let debug = !!slice.slice('debug').get();
+      if (debug) {
+        app.use(consoleLogger);
+      }
 
-  let config = getConfig(options);
+      let server = createAppServer(app, { protocol: 'https', port });
 
-  let handlersOptions = { ...config, store, services };
+      server.listen();
 
-  let auth0Handlers = createAuth0Handlers(handlersOptions);
-  let openIdHandlers = createOpenIdHandlers(handlersOptions);
+      yield spawn(function*() {
+        throw yield once(server, 'error');
+      });
 
-  let serviceOptions = { debug, port: config.port };
+      yield once(server, 'listening');
 
+      let address = server.address() as AddressInfo;
+
+      return {
+        port: address.port
+      };
+    }
+  };
+}
+
+export const auth0: Simulator = () => {
   return {
-    services: { auth0: createAuth0Service({ ...auth0Handlers, ...openIdHandlers }, serviceOptions) },
+    services: { auth0: createAuth0Service },
     scenarios: {
       /**
        * Here we just export the internal `person` scenario so that it can be

--- a/packages/auth0/src/types.ts
+++ b/packages/auth0/src/types.ts
@@ -1,5 +1,3 @@
-import type { SimulationState, Store } from '@simulacrum/server';
-import type { Slice } from '@effection/atom';
 import { z } from 'zod';
 
 // TODO: better validation
@@ -23,12 +21,6 @@ type ReadonlyFields = 'audience' | 'clientID' | 'scope' | 'port';
 
 export type Auth0Configuration = Required<Pick<Schema, ReadonlyFields>>
                                  & Omit<Schema, ReadonlyFields>;
-
-export type Options = Auth0Configuration & {
-  store: Store;
-  services: Slice<SimulationState['services']>;
-}
-
 export type ResponseModes = 'query' | 'web_message';
 
 export type QueryParams = {

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -74,6 +74,11 @@ describe('Auth0 simulator', () => {
         frontendUrl = simulation.services[1].url;
       });
 
+      it('has a heartbeat', function*() {
+        let res: Response = yield fetch(`${auth0Url}/heartbeat`);
+        expect(res.ok).toBe(true);
+      });
+
       it('should authorize', function *() {
         let res: Response = yield fetch(`${auth0Url}/authorize?${stringify({
           client_id: "1234",
@@ -141,15 +146,8 @@ describe('Auth0 simulator', () => {
     let url: string;
 
     beforeEach(function* () {
-      simulation = yield client.createSimulation("auth0", {
-        services: {
-          auth0: {
-            port: 4400,
-          }
-        }
-      });
+      simulation = yield client.createSimulation("auth0");
       url = simulation.services[0].url;
-      console.dir({ url });
 
       person = yield client.given(simulation, "person");
     });
@@ -182,7 +180,6 @@ describe('Auth0 simulator', () => {
           password: 'no-way',
         })
       });
-      console.dir({ res });
 
       expect(res.status).toBe(400);
     });

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -141,13 +141,20 @@ describe('Auth0 simulator', () => {
     let url: string;
 
     beforeEach(function* () {
-      simulation = yield client.createSimulation("auth0");
+      simulation = yield client.createSimulation("auth0", {
+        services: {
+          auth0: {
+            port: 4400,
+          }
+        }
+      });
       url = simulation.services[0].url;
+      console.dir({ url });
 
       person = yield client.given(simulation, "person");
     });
 
-    it('should login with valid credentials', function*(){
+    it('should login with valid credentials', function*() {
       let res: Response = yield fetch(`${url}/usernamepassword/login`, {
         method: 'POST',
         headers: {
@@ -175,6 +182,7 @@ describe('Auth0 simulator', () => {
           password: 'no-way',
         })
       });
+      console.dir({ res });
 
       expect(res.status).toBe(400);
     });

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -20,7 +20,7 @@ export interface ServerOptions {
   protocol: LegacyServiceCreator['protocol'];
 }
 
-const createAppServer = (app: Application, options: ServerOptions) => {
+export const createAppServer = (app: Application, options: ServerOptions) => {
   switch(options.protocol) {
     case 'http':
       return createHttpServer(app);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -20,7 +20,7 @@ export interface ServerOptions {
   protocol: LegacyServiceCreator['protocol'];
 }
 
-export const createAppServer = (app: Application, options: ServerOptions) => {
+const createAppServer = (app: Application, options: ServerOptions) => {
   switch(options.protocol) {
     case 'http':
       return createHttpServer(app);


### PR DESCRIPTION
## Motivation
Sometimes you want the freedom to just embed an Auth0 server directly into Node without having to pay the overhead of managing a simulacrum process. This pattern is already in play with the LDAP server, and it actually greatly simplifies the simulacrum server code itself. Instead of defining endpoints and then having simulacrum create the server, we just say "hey, start a server, and just let me know what the port and protocol are".

## Approach
This enables us to use the same simulator in both the simulacrum environment and also in any Node environment of our choosing by applying the same strategy to the Auth0 service as to the LDAP Service. The low level server accepts its list of people as an iterable, and any other information it may need from the environment. For example, rather than using the `Slice` of the simulation directly, it uses an adapter class similar to the `Map` API. That way it is easy to satify and adapt to.

Once this is complete, we can delete the LegacyResourceCreator interface and any code that requires it.