### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/auth0-standalone.md
+++ b/.changes/auth0-standalone.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor
----
-now exports a `createAuth0Server` operation which can be used directly without
-starting a Simulacrum server

--- a/.changes/more-null-logging-status.md
+++ b/.changes/more-null-logging-status.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/server': patch
----
-
-The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.1.14]
+
+- now exports a `createAuth0Server` operation which can be used directly without
+  starting a Simulacrum server
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01
+
 ## \[0.1.13]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.6.3",
+    "@simulacrum/auth0-simulator": "0.7.0",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.1",
+    "@simulacrum/server": "0.6.2",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.0.15]
+
+- now exports a `createAuth0Server` operation which can be used directly without
+  starting a Simulacrum server
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01
+
 ## \[0.0.14]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,9 +22,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.6.3",
+    "@simulacrum/auth0-simulator": "0.7.0",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.1",
+    "@simulacrum/server": "0.6.2",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.6.4]
+
+- now exports a `createAuth0Server` operation which can be used directly without
+  starting a Simulacrum server
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01
+
 ## \[0.6.3]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12595,12 +12595,12 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.6.1",
+        "@simulacrum/server": "0.6.2",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12679,7 +12679,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12721,7 +12721,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
@@ -14368,7 +14368,7 @@
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.6.1",
+        "@simulacrum/server": "0.6.2",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.7.0]
+
+- now exports a `createAuth0Server` operation which can be used directly without
+  starting a Simulacrum server
+  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01
+
 ## \[0.6.3]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@effection/process": "^2.0.1",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.1",
+    "@simulacrum/server": "0.6.2",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.3]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.
+  - Bumped due to a bump in @simulacrum/server.
+  - [7a3b87a](https://github.com/thefrontside/simulacrum/commit/7a3b87aeea69128f9dff04d6a99a52b5d58d08fa) simulation filter may include null, include check on 2022-09-19
+
 ## \[0.5.2]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.2]
+
+- The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.
+  - [7a3b87a](https://github.com/thefrontside/simulacrum/commit/7a3b87aeea69128f9dff04d6a99a52b5d58d08fa) simulation filter may include null, include check on 2022-09-19
+
 ## \[0.6.1]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. Check for undefined within the filter.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/server

## [0.6.2]
- The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.
  - [7a3b87a](https://github.com/thefrontside/simulacrum/commit/7a3b87aeea69128f9dff04d6a99a52b5d58d08fa) simulation filter may include null, include check on 2022-09-19



# @simulacrum/auth0-simulator

## [0.7.0]
- now exports a `createAuth0Server` operation which can be used directly without
starting a Simulacrum server
  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01



# @simulacrum/ldap-simulator

## [0.5.3]
- The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.
  - Bumped due to a bump in @simulacrum/server.
  - [7a3b87a](https://github.com/thefrontside/simulacrum/commit/7a3b87aeea69128f9dff04d6a99a52b5d58d08fa) simulation filter may include null, include check on 2022-09-19



# @simulacrum/auth0-cypress

## [0.6.4]
- now exports a `createAuth0Server` operation which can be used directly without
starting a Simulacrum server
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.14]
- now exports a `createAuth0Server` operation which can be used directly without
starting a Simulacrum server
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.15]
- now exports a `createAuth0Server` operation which can be used directly without
starting a Simulacrum server
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [875def0](https://github.com/thefrontside/simulacrum/commit/875def0277a9c6d6d1f5ea05d8dbffcfcc65d1a2) Add change entry on 2022-10-01