### PR TITLE
Auth0 `/userinfo` `access_token`

### DIFF
--- a/.changes/auth-simulator-userinfo-access_token.md
+++ b/.changes/auth-simulator-userinfo-access_token.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': 'patch'
+---
+
+The auth0 simulator `/userinfo` endpoint will fall back to check for the `access_token` query parameter if the authorization header is not set.

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -241,8 +241,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
         let authorizationHeader = req.headers.authorization;
         token = authorizationHeader?.split(' ')?.[1];
       } else {
-        token = req?.query?.access_token;
-        assert(typeof token === 'string');
+        token = req?.query?.access_token as string;
       }
 
       assert(!!token, 'no authorization header or access_token');

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -236,12 +236,16 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/userinfo']: function(req, res) {
-      let authorizationHeader = req.headers.authorization;
+      let token = null;
+      if (req.headers.authorization) {
+        let authorizationHeader = req.headers.authorization;
+        token = authorizationHeader?.split(' ')?.[1];
+      } else {
+        token = req?.query?.access_token;
+        assert(typeof token === 'string');
+      }
 
-      assert(!!authorizationHeader, 'no authorization header');
-
-      let [, token] = authorizationHeader.split(' ');
-
+      assert(!!token, 'no authorization header or access_token');
       let { sub } = decodeToken(token, { json: true }) as { sub: string };
 
       let user = personQuery((person) => {


### PR DESCRIPTION
## Motivation

When implementing the auth0 simulator in Backstage, we ran into a situation where the authorization header was not set, but the `access_token` was passed as a query parameter. This PR takes it into consideration.

## Approach

Check for the authorization header, then fall back to the query parameter, `access_token`, and throw an assertion error if neither are present on the `/userinfo` endpoint.
