### PR TITLE
Run Unit Tests In CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
       # build root first
       - node/install-packages
       - run: npm run build
+      # run unit tests
+      - run: npm run test
       # integration test requires the example installed
       - node/install-packages:
           app-dir: examples/nextjs/auth0-react


### PR DESCRIPTION
## Motivation

The unit tests don't appear to run in CI on circle-ci. Run these prior to integration tests.
