### PR TITLE
Export standalone Auth0 creation function

### DIFF
--- a/.changes/public-auth0-server.md
+++ b/.changes/public-auth0-server.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/auth0-simulator": minor
+---
+export `createAuth0Server` operation for running Auth0 server standalone.

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -1,6 +1,6 @@
 import type { Person , ResourceServiceCreator, Simulator } from '@simulacrum/server';
 import { createServer, consoleLogger, person } from '@simulacrum/server';
-import type { Operation } from 'effection';
+import { Operation } from 'effection';
 import express, { json, urlencoded } from 'express';
 import path from 'path';
 import { getConfig } from './config/get-config';
@@ -17,7 +17,7 @@ export { getConfig } from './config/get-config';
 
 const publicDir = path.join(__dirname, 'views', 'public');
 
-interface Server {
+export interface Server {
   port: number;
 }
 
@@ -72,7 +72,7 @@ const createAuth0Service: ResourceServiceCreator = (slice, options) => ({
   }
 });
 
-function createAuth0Server(options: Auth0ServerOptions): Operation<Server> {
+export function createAuth0Server(options: Auth0ServerOptions): Operation<Server> {
   let { config, serviceURL, store, people, port, debug = true } = options;
   let auth0 = createAuth0Handlers(store, people, serviceURL, config);
   let openid = createOpenIdHandlers(serviceURL);


### PR DESCRIPTION


## Motivation
We want to be able to use the `createAuth0Server` directly so that we don't have to go through the ceremony of starting an entire Simulacrum server.

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

## Approach
This change exports the `Server` interface and the `createAuth0Server()` function.
