### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/public-auth0-server.md
+++ b/.changes/public-auth0-server.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor
----
-export `createAuth0Server` operation for running Auth0 server standalone.

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.1.16]
+
+- export `createAuth0Server` operation for running Auth0 server standalone.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01
+
 ## \[0.1.15]
 
 - The auth0 simulator `/userinfo` endpoint will fall back to check for the `access_token` query parameter if the authorization header is not set.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.7.1",
+    "@simulacrum/auth0-simulator": "0.8.0",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.6.2",
     "@types/react": "17.0.37",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.0.17]
+
+- export `createAuth0Server` operation for running Auth0 server standalone.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01
+
 ## \[0.0.16]
 
 - The auth0 simulator `/userinfo` endpoint will fall back to check for the `access_token` query parameter if the authorization header is not set.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,7 +22,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.7.1",
+    "@simulacrum/auth0-simulator": "0.8.0",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.6.2",
     "@types/react": "17.0.37",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.6.6]
+
+- export `createAuth0Server` operation for running Auth0 server standalone.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01
+
 ## \[0.6.5]
 
 - The auth0 simulator `/userinfo` endpoint will fall back to check for the `access_token` query parameter if the authorization header is not set.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12595,7 +12595,7 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.8.0]
+
+- export `createAuth0Server` operation for running Auth0 server standalone.
+  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01
+
 ## \[0.7.1]
 
 - The auth0 simulator `/userinfo` endpoint will fall back to check for the `access_token` query parameter if the authorization header is not set.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/auth0-simulator

## [0.8.0]
- export `createAuth0Server` operation for running Auth0 server standalone.
  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01



# @simulacrum/auth0-cypress

## [0.6.6]
- export `createAuth0Server` operation for running Auth0 server standalone.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.16]
- export `createAuth0Server` operation for running Auth0 server standalone.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.17]
- export `createAuth0Server` operation for running Auth0 server standalone.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [cd2f869](https://github.com/thefrontside/simulacrum/commit/cd2f8695ef8f4d4088a7fd37a8383fb7cc0d8c49) Export standalone Auth0 creation function on 2022-11-01