### PR TITLE
allow setting the user.id in person simulator

### DIFF
--- a/.changes/person-simulator-set-id.md
+++ b/.changes/person-simulator-set-id.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/server': patch
+---
+
+When creating a person with the person simulator, we now allow passing in a specific `id` to use.

--- a/packages/server/src/simulators/person.ts
+++ b/packages/server/src/simulators/person.ts
@@ -19,11 +19,11 @@ export interface Person {
   picture?: string;
 }
 
-export type OptionalParams<T extends { id: string }> = Partial<Omit<T, 'id'>>;
+export type OptionalParams<T extends { id: string }> = Partial<T>;
 
 export function person(store: Store, faker: Faker, params: OptionalParams<Person> = {}): Operation<Person> {
   return function*() {
-    let id = v4();
+    let id = params.id ?? v4();
     let slice = records(store).slice(id);
 
     let name = params.name ?? faker.name.findName();

--- a/packages/server/test/person.test.ts
+++ b/packages/server/test/person.test.ts
@@ -44,5 +44,18 @@ describe('person simulator', () => {
         expect(person.data.name).toEqual("Bob Dobalina");
       });
     });
+
+    describe('given a person with a specified id', () => {
+      let person: Scenario<{ id: string }>;
+      beforeEach(function* () {
+        person = yield client.given(simulation, 'person', {
+          id: 'auth0|aoh1-09jdal-j13lkasd',
+        });
+      });
+
+      it('creates the person with that name', function* () {
+        expect(person.data.id.slice(0, 5)).toBe('auth0');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Motivation

There are cases where, in auth0, we are adding to the token context based on the user id. To help in simulating this situation, allow the `id` to be passed in as a parameter. This could result in conflicts, but I think it is on the them.

## Approach

The `id` as a parameter.
