### PR TITLE
consider client_id and audience in auth0 sim request

### DIFF
--- a/.changes/auth0-token-with-req-audience.md
+++ b/.changes/auth0-token-with-req-audience.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': patch
+---
+
+The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -75,16 +75,21 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/login']: function(req, res) {
-      let { redirect_uri } = req.query as QueryParams;
-
-      assert(!!clientID, `no clientID assigned`);
+      let {
+        client_id: query_client_id,
+        audience: query_audience,
+        redirect_uri,
+      } = req.query as QueryParams;
+      let response_client_id = query_client_id || clientID;
+      let response_audience = query_audience || audience;
+      assert(!!response_client_id, `no clientID assigned`);
 
       let html = loginView({
         domain: serviceURL().host,
         scope,
         redirectUri: redirect_uri,
-        clientID,
-        audience,
+        clientID: response_client_id,
+        audience: response_audience,
         loginFailed: false
       });
 
@@ -152,12 +157,18 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
       let nonce: string | undefined;
       let username: string;
       let password: string | undefined;
+      let response_client_id: string;
+      let response_audience: string;
 
       if (grant_type === 'password') {
         username = req.body.username;
         password = req.body.password;
+        response_client_id = req?.body?.client_id as string || clientID;
+        response_audience = req?.body?.audience as string|| audience;
       } else {
         assert(typeof code !== 'undefined', 'no code in /oauth/token');
+        response_client_id = clientID;
+        response_audience = audience;
 
         [nonce, username] = decode(code).split(":");
       }
@@ -184,7 +195,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
         return;
       }
 
-      assert(!!clientID, 'no clientID in options');
+      assert(!!response_client_id, 'no clientID in options');
 
       let idTokenData: IdTokenData = {
         alg: "RS256",
@@ -193,7 +204,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
         exp: expiresAt(),
         iat: epochTime(),
         email: username,
-        aud: clientID,
+        aud: response_client_id,
         sub: user.id,
       };
 
@@ -209,14 +220,14 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
         picture: req?.body?.picture,
         identities: req?.body?.identities,
       } as RuleUser;
-      let context = { clientID, accessToken: { scope }, idToken: idTokenData };
+      let context = { clientID: response_client_id, accessToken: { scope }, idToken: idTokenData };
 
       await rulesRunner(userData, context);
 
       let idToken = createJsonWebToken({ ...userData, ...context.idToken });
 
       let accessToken: AccessTokenPayload = {
-        aud: audience,
+        aud: response_audience,
         sub: idTokenData.sub,
         iat: epochTime(),
         iss: idTokenData.iss,

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -75,21 +75,17 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/login']: function(req, res) {
-      let {
-        client_id: query_client_id,
-        audience: query_audience,
-        redirect_uri,
-      } = req.query as QueryParams;
-      let response_client_id = query_client_id || clientID;
-      let response_audience = query_audience || audience;
-      assert(!!response_client_id, `no clientID assigned`);
+      let query = req.query as QueryParams;
+      let responseClientId = query.client_id ?? clientID;
+      let responseAudience = query.audience ?? audience;
+      assert(!!responseClientId, `no clientID assigned`);
 
       let html = loginView({
         domain: serviceURL().host,
         scope,
-        redirectUri: redirect_uri,
-        clientID: response_client_id,
-        audience: response_audience,
+        redirectUri: query.redirect_uri,
+        clientID: responseClientId,
+        audience: responseAudience,
         loginFailed: false
       });
 

--- a/packages/auth0/src/handlers/login-redirect.ts
+++ b/packages/auth0/src/handlers/login-redirect.ts
@@ -6,6 +6,7 @@ export const createLoginRedirectHandler = (options: Auth0Configuration): Request
   function loginRedirect (req: Request, res: Response) {
     let {
       client_id,
+      audience,
       redirect_uri,
       scope,
       state,
@@ -21,7 +22,7 @@ export const createLoginRedirectHandler = (options: Auth0Configuration): Request
       `/login?${stringify({
         state,
         redirect_uri,
-        client: client_id,
+        client: client_id || options.clientID,
         protocol: "oauth2",
         scope,
         response_type,
@@ -30,7 +31,7 @@ export const createLoginRedirectHandler = (options: Auth0Configuration): Request
         code_challenge,
         code_challenge_method,
         auth0Client,
-        audience: options.audience,
+        audience: audience || options.audience,
       })}`
     );
   };

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -308,7 +308,6 @@ describe('Auth0 simulator', () => {
       });
     });
 
-
     it('should return a 401 responsive with invalid credentials', function* () {
       let [nonce] = decode(code).split(":");
 
@@ -326,6 +325,44 @@ describe('Auth0 simulator', () => {
       });
 
       expect(res.status).toBe(401);
+    });
+
+    describe('grant_type=password', () => {
+      let idToken: IdToken;
+      let accessToken: AccessToken;
+      beforeEach(function * () {
+        let res: Response = yield fetch(`${authUrl}/oauth/token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            ...Fields,
+            grant_type: 'password',
+            username: person.data.email,
+            password: person.data.password,
+            // these are different than the simulator defined values
+            // to confirming we can auth and create tokens with the passed values
+            client_id: 'test-id-to-confirm-it-uses-this',
+            audience: 'https://thefrontside.auth0.com/api/v0/',
+          })
+        });
+
+        expect(res.ok).toBe(true);
+
+        let json = yield res.json();
+
+        idToken = jwt.decode(json.id_token, { complete: true }) as IdToken;
+        accessToken = jwt.decode(json.access_token, { complete: true }) as AccessToken;
+      });
+
+      it('id_token should contain client_id as aud', function* () {
+        expect(idToken.payload.aud).toBe('test-id-to-confirm-it-uses-this');
+      });
+
+      it('access_token should contain audience as aud', function* () {
+        expect(accessToken.payload.aud).toBe("https://thefrontside.auth0.com/api/v0/");
+      });
     });
   });
 


### PR DESCRIPTION
## Motivation

The auth0-simulator responses should consider the values passed as part of the `req` rather than using the specifically defined clientId and audience in the simulator. This allows the simulator to work with many clients, and can be important in the rules logic.

## Approach

Using the req values but falling back to the simulator defined values to prevent breaking changes.
