### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/auth0-client_credentials-gty.md
+++ b/.changes/auth0-client_credentials-gty.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.

--- a/.changes/auth0-form-submit.md
+++ b/.changes/auth0-form-submit.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).

--- a/.changes/auth0-token-with-req-audience.md
+++ b/.changes/auth0-token-with-req-audience.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.

--- a/.changes/person-simulator-set-id.md
+++ b/.changes/person-simulator-set-id.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/server': patch
----
-
-When creating a person with the person simulator, we now allow passing in a specific `id` to use.

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## \[0.1.18]
+
+- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
+  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
+- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
+- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16
+
 ## \[0.1.17]
 
 - Async rules were not properly processing and would run as a race condition mutating the `user` and `context` objects. This would mean part of the rule might be applied. This adds some additional wrappers in the rule running to properly handle and `await` on async code.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,9 +21,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.8.1",
+    "@simulacrum/auth0-simulator": "0.8.2",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.2",
+    "@simulacrum/server": "0.6.3",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## \[0.0.19]
+
+- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
+  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
+- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
+- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16
+
 ## \[0.0.18]
 
 - Async rules were not properly processing and would run as a race condition mutating the `user` and `context` objects. This would mean part of the rule might be applied. This adds some additional wrappers in the rule running to properly handle and `await` on async code.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,9 +22,9 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.8.1",
+    "@simulacrum/auth0-simulator": "0.8.2",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.2",
+    "@simulacrum/server": "0.6.3",
     "@types/react": "17.0.37",
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## \[0.6.8]
+
+- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
+  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
+- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
+- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16
+
 ## \[0.6.7]
 
 - Async rules were not properly processing and would run as a race condition mutating the `user` and `context` objects. This would mean part of the rule might be applied. This adds some additional wrappers in the rule running to properly handle and `await` on async code.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12595,12 +12595,12 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.6.2",
+        "@simulacrum/server": "0.6.3",
         "@types/faker": "^5.1.7",
         "assert-ts": "^0.3.2",
         "base64-url": "^2.3.3",
@@ -12679,7 +12679,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",
@@ -12721,7 +12721,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@effection/atom": "^2.0.1",
@@ -14368,7 +14368,7 @@
         "@frontside/tsconfig": "^3.0.0",
         "@frontside/typescript": "^3.0.0",
         "@simulacrum/client": "0.5.4",
-        "@simulacrum/server": "0.6.2",
+        "@simulacrum/server": "0.6.3",
         "@types/base64-url": "^2.2.0",
         "@types/cookie-session": "^2.0.42",
         "@types/dedent": "^0.7.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.8.2]
+
+- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
+  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
+  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
+- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
+  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
+- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
+  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16
+
 ## \[0.8.1]
 
 - Async rules were not properly processing and would run as a race condition mutating the `user` and `context` objects. This would mean part of the rule might be applied. This adds some additional wrappers in the rule running to properly handle and `await` on async code.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@effection/process": "^2.0.1",
     "@simulacrum/client": "0.5.4",
-    "@simulacrum/server": "0.6.2",
+    "@simulacrum/server": "0.6.3",
     "@types/faker": "^5.1.7",
     "assert-ts": "^0.3.2",
     "base64-url": "^2.3.3",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.4]
+
+- When creating a person with the person simulator, we now allow passing in a specific `id` to use.
+  - Bumped due to a bump in @simulacrum/server.
+  - [6793a27](https://github.com/thefrontside/simulacrum/commit/6793a2743ed57c79670ca95842e0202bfa5db359) change file on 2022-11-16
+
 ## \[0.5.3]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.6.3]
+
+- When creating a person with the person simulator, we now allow passing in a specific `id` to use.
+  - [6793a27](https://github.com/thefrontside/simulacrum/commit/6793a2743ed57c79670ca95842e0202bfa5db359) change file on 2022-11-16
+
 ## \[0.6.2]
 
 - The simulation server can return null events on shutdown, and the logger did not consider this. The previous patch fixed a single instance. This addresses the remaining three instances by checking for undefined within the filter.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A server containing simulation state, and the control API to manipulate it",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/server

## [0.6.3]
- When creating a person with the person simulator, we now allow passing in a specific `id` to use.
  - [6793a27](https://github.com/thefrontside/simulacrum/commit/6793a2743ed57c79670ca95842e0202bfa5db359) change file on 2022-11-16



# @simulacrum/auth0-simulator

## [0.8.2]
- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16



# @simulacrum/ldap-simulator

## [0.5.4]
- When creating a person with the person simulator, we now allow passing in a specific `id` to use.
  - Bumped due to a bump in @simulacrum/server.
  - [6793a27](https://github.com/thefrontside/simulacrum/commit/6793a2743ed57c79670ca95842e0202bfa5db359) change file on 2022-11-16



# @simulacrum/auth0-cypress

## [0.6.8]
- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.18]
- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.19]
- Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [4ffde63](https://github.com/thefrontside/simulacrum/commit/4ffde63842c0984f7bf5d6b3bd0f3d98ad938799) support client_credentials grant_type on 2022-11-17
  - [9bb1b43](https://github.com/thefrontside/simulacrum/commit/9bb1b43bb80332e5357123550d72eef8681ae416) update change file with note about scope adjustments on 2022-11-23
- Tweaks the login form so the button is a true form submission button. This allows the form to input validate, and enables all form submission options (enter primarily the addition).
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [fa4a9e2](https://github.com/thefrontside/simulacrum/commit/fa4a9e27f72b6609419ee93d3c55b620a5feb6bc) auth0 submit as form button on 2022-11-21
- The simulator should consider the audience and client_id passed in the request. The values may be important for logic in user defined rules, and is used in validating the token, e.g. in `auth0-react`.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [86cd7d0](https://github.com/thefrontside/simulacrum/commit/86cd7d06d5747c81d31a241726999955425a8e65) consider client_id and audience in auth0 sim request on 2022-11-16