### PR TITLE
support client_credentials grant_type

### DIFF
--- a/.changes/auth0-client_credentials-gty.md
+++ b/.changes/auth0-client_credentials-gty.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': patch
+---
+
+Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules.

--- a/.changes/auth0-client_credentials-gty.md
+++ b/.changes/auth0-client_credentials-gty.md
@@ -2,4 +2,4 @@
 '@simulacrum/auth0-simulator': patch
 ---
 
-Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules.
+Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.

--- a/packages/auth0/README.md
+++ b/packages/auth0/README.md
@@ -229,6 +229,8 @@ let simulation = yield client.createSimulation("auth0", {
 
 The `options` field supports the [auth0 configuration fields](https://auth0.com/docs/quickstart/spa/vanillajs#configure-auth0). The option fields should match the fields in the client application that is calling the auth0 server.
 
+The `scope` also accepts an array of objects containing `clientID`, `scope` and optionally `audience` to enable dynamic scopes from a single simulator. This should allow multiple clients to all use the same simulator. Additionally, setting the `clientID: "default"` will enable a default fallback scope so every client does not need to be included.
+
 An optional [`rulesDirectory` field](#rules) can specify a directory of [auth0 rules](https://auth0.com/docs/rules) code files, more on this [below](#rules).
 
 ### Services

--- a/packages/auth0/src/error-handling-middleware.ts
+++ b/packages/auth0/src/error-handling-middleware.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export function defaultErrorHandler(error: Error, _req: Request, res: Response, next: NextFunction) {
+  if (res.headersSent) {
+    return next(error);
+  }
+
+  let assertCondition = 'Assert condition failed: ';
+
+  if (error?.message?.startsWith(assertCondition)) {
+    let errorCode = 500;
+    let errorResponse = error.message;
+
+    if (error.message.includes('::')) {
+      let errorMessage = error.message.slice(assertCondition.length);
+      errorCode = parseInt(errorMessage.slice(0, 3));
+      errorResponse = errorMessage.slice(5);
+    }
+
+    res.status(errorCode).send(errorResponse);
+  } else {
+    console.error(error);
+    res
+      .status(500)
+      .json({
+        error: {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        },
+      });
+  }
+}

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -136,7 +136,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
       res.status(302).redirect(routerUrl);
     },
 
-    ['/oauth/token']: async function (req, res) {
+    ['/oauth/token']: async function (req, res, next) {
       try {
         let iss = serviceURL().toString();
 
@@ -162,28 +162,8 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
           expires_in: 86400,
           token_type: "Bearer",
         });
-      } catch (error: any) {
-        let assertCondition = 'Assert condition failed: ';
-        if (error?.message?.startsWith(assertCondition)) {
-          let errorMessage = error.message.slice(assertCondition.length);
-          let errorCode =
-            errorMessage.slice(3, 5) === '::'
-              ? parseInt(errorMessage.slice(0, 3))
-              : 500;
-          let errorResponse = errorMessage.slice(5);
-          res.status(errorCode).send(errorResponse);
-        } else {
-          console.error(error)
-          res
-            .status(500)
-            .json({
-              error: {
-                name: error.name,
-                message: error.message,
-                stack: error.stack,
-              },
-            });
-        }
+      } catch (error) {
+        next(error);
       }
     },
 

--- a/packages/auth0/src/handlers/oauth-handlers.ts
+++ b/packages/auth0/src/handlers/oauth-handlers.ts
@@ -1,0 +1,180 @@
+import { assert } from 'assert-ts';
+import { decode as decodeBase64 } from 'base64-url';
+import { epochTime, expiresAt } from '../auth/date';
+import { createJsonWebToken } from '../auth/jwt';
+import { createRulesRunner } from '../rules/rules-runner';
+import { deriveScope, createPersonQuery } from './utils';
+
+import type { Request } from 'express';
+import type { Person } from '@simulacrum/server';
+import type { RuleContext, RuleUser } from '../rules/types';
+import type {
+  ScopeConfig,
+  AccessTokenPayload,
+  GrantType,
+  IdTokenData,
+} from '../types';
+
+export const createTokens = async ({
+  body,
+  iss,
+  clientID,
+  audience,
+  rulesDirectory,
+  people,
+  scope: scopeConfig,
+}: {
+  body: Request['body'];
+  iss: string;
+  clientID: string;
+  audience: string;
+  rulesDirectory: string | undefined;
+  people: Iterable<Person>;
+  scope: ScopeConfig;
+}) => {
+  let { grant_type }: { grant_type: GrantType } = body;
+  let scope = deriveScope({ scopeConfig, clientID, audience });
+
+  let accessToken = getBaseAccessToken({ iss, grant_type, scope, audience });
+  if (grant_type === 'client_credentials') {
+    return { access_token: createJsonWebToken(accessToken) };
+  } else {
+    let { user, nonce } = verifyUserExistsInStore({
+      people,
+      body,
+      grant_type,
+    });
+    let { idTokenData, userData } = getIdToken({
+      body,
+      iss,
+      user,
+      clientID,
+      nonce,
+    });
+
+    let context: RuleContext<Partial<AccessTokenPayload>, IdTokenData> = {
+      clientID,
+      accessToken: { scope, sub: idTokenData.sub },
+      idToken: idTokenData,
+    };
+
+    let rulesRunner = createRulesRunner(rulesDirectory);
+    // the rules mutate the values
+    await rulesRunner(userData, context);
+
+    return {
+      access_token: createJsonWebToken({
+        ...accessToken,
+        ...context.accessToken,
+      }),
+      id_token: createJsonWebToken({
+        ...userData,
+        ...context.idToken,
+      }),
+    };
+  }
+};
+
+export const getIdToken = ({
+  body,
+  iss,
+  user,
+  clientID,
+  nonce,
+}: {
+  body: Request['body'];
+  iss: string;
+  user: Person;
+  clientID: string;
+  nonce: string | undefined;
+}) => {
+  let userData: RuleUser = {
+    name: body?.name,
+    email: body?.email,
+    user_id: body?.id,
+    nickname: body?.nickname,
+    picture: body?.picture,
+    identities: body?.identities,
+  };
+
+  assert(!!user.email, '500::User in store requires an email');
+  let idTokenData: IdTokenData = {
+    alg: 'RS256',
+    typ: 'JWT',
+    iss,
+    exp: expiresAt(),
+    iat: epochTime(),
+    email: user.email,
+    aud: clientID,
+    sub: user.id,
+  };
+
+  if (typeof nonce !== 'undefined') {
+    idTokenData.nonce = nonce;
+  }
+
+  return { userData, idTokenData };
+};
+
+export const getBaseAccessToken = ({
+  iss,
+  grant_type,
+  scope,
+  audience,
+}: {
+  iss: string;
+  grant_type: string;
+  scope: string;
+  audience: string;
+}): Partial<AccessTokenPayload> => ({
+  iss,
+  exp: expiresAt(),
+  iat: epochTime(),
+  aud: audience,
+  gty: grant_type,
+  scope,
+});
+
+const verifyUserExistsInStore = ({
+  people,
+  body,
+  grant_type,
+}: {
+  people: Iterable<Person>;
+  body: Request['body'];
+  grant_type: string;
+}) => {
+  let { code } = body;
+  let personQuery = createPersonQuery(people);
+  let nonce: string | undefined;
+  let username: string;
+  let password: string | undefined;
+
+  if (grant_type === 'password') {
+    username = body.username;
+    password = body.password;
+  } else {
+    // specifically grant_type === 'authorization_code'
+    // but naively using it to handle other cases at the moment
+    assert(typeof code !== 'undefined', '400::no code in /oauth/token');
+    [nonce, username] = decodeBase64(code).split(':');
+  }
+
+  assert(!!username, `400::no nonce in store for ${code}`);
+
+  let user: Person | undefined = personQuery((person) => {
+    assert(!!person.email, `500::no email defined on person scenario`);
+
+    let valid = person.email.toLowerCase() === username.toLowerCase();
+
+    if (typeof password === 'undefined') {
+      return valid;
+    } else {
+      return valid && password === person.password;
+    }
+  });
+
+  assert(!!user, '401::Unauthorized');
+
+  return { user, nonce };
+};

--- a/packages/auth0/src/handlers/utils.ts
+++ b/packages/auth0/src/handlers/utils.ts
@@ -19,6 +19,9 @@ export const deriveScope = ({
   audience: string;
 }) => {
   if (typeof scopeConfig === 'string') return scopeConfig;
+  let defaultScope = scopeConfig.find(
+    (application) => application.clientID === 'default'
+  );
 
   assert(!!clientID, `500::Did not have a clientID to derive the scope`);
 
@@ -36,6 +39,10 @@ export const deriveScope = ({
       ignoreAudience === undefined,
       `500::Found application matching clientID, ${ignoreAudience?.clientID}, but incorrect audience, configured: ${ignoreAudience?.audience} :: passed: ${audience}`
     );
+  }
+
+  if (!application && defaultScope) {
+    application = defaultScope;
   }
 
   assert(

--- a/packages/auth0/src/handlers/utils.ts
+++ b/packages/auth0/src/handlers/utils.ts
@@ -1,0 +1,52 @@
+import { assert } from 'assert-ts';
+import type { Person } from '@simulacrum/server';
+import type { ScopeConfig } from '../types';
+
+type Predicate<T> = (this: void, value: T, index: number, obj: T[]) => boolean;
+
+export const createPersonQuery =
+  (people: Iterable<Person>) => (predicate: Predicate<Person>) => {
+    return [...people].find(predicate);
+  };
+
+export const deriveScope = ({
+  scopeConfig,
+  clientID,
+  audience,
+}: {
+  scopeConfig: ScopeConfig;
+  clientID: string;
+  audience: string;
+}) => {
+  if (typeof scopeConfig === 'string') return scopeConfig;
+
+  assert(!!clientID, `500::Did not have a clientID to derive the scope`);
+
+  let application = scopeConfig.find(
+    (application) =>
+      application.clientID === clientID &&
+      (application.audience ? application.audience === audience : true)
+  );
+
+  if (!application) {
+    let ignoreAudience = scopeConfig.find(
+      (application) => application.clientID === clientID
+    );
+    assert(
+      ignoreAudience === undefined,
+      `500::Found application matching clientID, ${ignoreAudience?.clientID}, but incorrect audience, configured: ${ignoreAudience?.audience} :: passed: ${audience}`
+    );
+  }
+
+  assert(
+    !!application,
+    `500::Could not find application with clientID: ${clientID}`
+  );
+
+  assert(
+    !!application.scope,
+    `500::${application.clientID} is expected to have a scope`
+  );
+
+  return application.scope;
+};

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -1,9 +1,10 @@
 import type { Person , ResourceServiceCreator, Simulator } from '@simulacrum/server';
 import { createServer, consoleLogger, person } from '@simulacrum/server';
-import { Operation } from 'effection';
+import type { Operation } from 'effection';
 import express, { json, urlencoded } from 'express';
 import path from 'path';
 import { getConfig } from './config/get-config';
+import { defaultErrorHandler } from './error-handling-middleware';
 import type { Auth0Store, AuthSession } from './handlers/auth0-handlers';
 import { createAuth0Handlers } from './handlers/auth0-handlers';
 import { getServiceUrl } from './handlers/get-service-url';
@@ -102,6 +103,9 @@ export function createAuth0Server(options: Auth0ServerOptions): Operation<Server
       if (debug) {
         app.use(consoleLogger);
       }
+
+      // needs to be the last middleware added
+      app.use(defaultErrorHandler);
 
       let server = yield createServer(app, { protocol: 'https', port });
 

--- a/packages/auth0/src/rules/types.ts
+++ b/packages/auth0/src/rules/types.ts
@@ -13,15 +13,23 @@ export interface RuleUser {
   given_name?: string | undefined;
   family_name?: string | undefined;
   name?: string | undefined;
+  identities: IdentityProvider[] | undefined;
 }
 
-export interface RuleContext<A, I> {
-  clientID: string
-  accessToken: {
-    scope: string | string[]
-  } & A
+type IdentityProvider = {
+  provider: string;
+  user_id: string;
+  connection: string;
+  isSocial: boolean;
+};
 
-  idToken: I
+export interface RuleContext<A, I> {
+  clientID: string;
+  accessToken: {
+    scope: string | string[];
+  } & A;
+
+  idToken: I;
 }
 
 export interface Rule {

--- a/packages/auth0/src/types.ts
+++ b/packages/auth0/src/types.ts
@@ -2,11 +2,23 @@ import { z } from 'zod';
 
 // TODO: better validation
 export const configurationSchema = z.object({
-  port: z.optional(z.number().gt(2999, "port must be greater than 2999").lt(10000, "must be less than 10000")),
+  port: z.optional(
+    z
+      .number()
+      .gt(2999, 'port must be greater than 2999')
+      .lt(10000, 'must be less than 10000')
+  ),
   domain: z.optional(z.string().min(1, 'domain is required')),
-  audience:  z.optional(z.string().min(1, "audience is required")),
-  clientID: z.optional(z.string().max(32, "must be 32 characters long")),
-  scope: z.string().min(1, "scope is required"),
+  audience: z.optional(z.string().min(1, 'audience is required')),
+  clientID: z.optional(z.string().max(32, 'must be 32 characters long')),
+  scope: z.union([
+      z.string().min(1, 'scope is required'),
+      z.array(z.object({
+        clientID: z.string().max(32, 'must be 32 characters long'),
+        audience: z.optional(z.string().min(1, 'audience is required')),
+        scope: z.string().min(1, 'scope is required'),
+      }))
+    ]),
   clientSecret: z.optional(z.string()),
   rulesDirectory: z.optional(z.string()),
   auth0SessionCookieName: z.optional(z.string()),
@@ -18,6 +30,14 @@ export const configurationSchema = z.object({
 export type Schema = z.infer<typeof configurationSchema>;
 
 type ReadonlyFields = 'audience' | 'clientID' | 'scope' | 'port';
+
+// grant_type list as defined by auth0
+// https://auth0.com/docs/get-started/applications/application-grant-types#spec-conforming-grants
+export type GrantType = 'password' | 'client_credentials' | 'authorization_code';
+
+export type ScopeConfig =
+  | string
+  | { audience?: string; clientID: string; scope: string }[];
 
 export type Auth0Configuration = Required<Pick<Schema, ReadonlyFields>>
                                  & Omit<Schema, ReadonlyFields>;

--- a/packages/auth0/src/views/login.ts
+++ b/packages/auth0/src/views/login.ts
@@ -1,8 +1,10 @@
+import type { ScopeConfig } from '../types';
+import { deriveScope } from '../handlers/utils';
 const html = String.raw;
 
 interface LoginViewProps {
   domain: string;
-  scope: string;
+  scope: ScopeConfig;
   redirectUri: string;
   clientID: string;
   audience: string;
@@ -11,7 +13,7 @@ interface LoginViewProps {
 
 export const loginView = ({
   domain,
-  scope,
+  scope: scopeConfig,
   redirectUri,
   clientID,
   audience,
@@ -86,7 +88,7 @@ export const loginView = ({
                   username: username.value,
                   password: password.value,
                   realm: 'Username-Password-Authentication',
-                  scope: '${scope}',
+                  scope: '${deriveScope({ scopeConfig, clientID, audience })}',
                   nonce: params.get('nonce'),
                   state: params.get('state')
                 },

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -364,6 +364,73 @@ describe('Auth0 simulator', () => {
         expect(accessToken.payload.aud).toBe("https://thefrontside.auth0.com/api/v0/");
       });
     });
+
+    describe('grant_type=client_credentials', () => {
+      let accessToken: AccessToken;
+      beforeEach(function * () {
+        let res: Response = yield fetch(`${authUrl}/oauth/token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            ...Fields,
+            grant_type: 'client_credentials',
+            // these are different than the simulator defined values
+            // to confirming we can auth and create tokens with the passed values
+            client_id: 'test-id-to-confirm-it-uses-this',
+            audience: 'https://thefrontside.auth0.com/api/v0/',
+          })
+        });
+
+        expect(res.ok).toBe(true);
+
+        let json = yield res.json();
+
+        accessToken = jwt.decode(json.access_token, { complete: true }) as AccessToken;
+      });
+
+      it('access_token should contain audience as aud', function* () {
+        expect(accessToken.payload.aud).toBe("https://thefrontside.auth0.com/api/v0/");
+      });
+    });
+
+    describe('grant_type=authorization_code', () => {
+      let idToken: IdToken;
+      let accessToken: AccessToken;
+      beforeEach(function * () {
+        let res: Response = yield fetch(`${authUrl}/oauth/token`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            ...Fields,
+            code,
+            grant_type: 'authorization_code',
+            // these are different than the simulator defined values
+            // to confirming we can auth and create tokens with the passed values
+            client_id: 'test-id-to-confirm-it-uses-this',
+            audience: 'https://thefrontside.auth0.com/api/v0/',
+          })
+        });
+
+        expect(res.ok).toBe(true);
+
+        let json = yield res.json();
+
+        idToken = jwt.decode(json.id_token, { complete: true }) as IdToken;
+        accessToken = jwt.decode(json.access_token, { complete: true }) as AccessToken;
+      });
+
+      it('id_token should contain client_id as aud', function* () {
+        expect(idToken.payload.aud).toBe('test-id-to-confirm-it-uses-this');
+      });
+
+      it('access_token should contain audience as aud', function* () {
+        expect(accessToken.payload.aud).toBe("https://thefrontside.auth0.com/api/v0/");
+      });
+    });
   });
 
   describe('/v2/logout', () => {

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -664,8 +664,6 @@ describe('Auth0 simulator', () => {
       });
 
       it('neither token specified', function* () {
-        let errorLogs = '';
-        console.error = (message) => (errorLogs += message);
         let simulation: Simulation = yield client.createSimulation('auth0');
 
         auth0Url = simulation.services[0].url;
@@ -694,9 +692,11 @@ describe('Auth0 simulator', () => {
           },
         });
 
+        let responseText = yield res.text();
+
         expect(
-          errorLogs.startsWith(
-            'Error: Assert condition failed: no authorization header or access_token'
+          responseText.startsWith(
+            'Assert condition failed: no authorization header or access_token'
           )
         ).toBe(true);
         expect(res.status).toBe(500);


### PR DESCRIPTION
## Motivation

Add specific support for additional `grant_type`s. This was required to enable m2m token use. Note, this flow does not appear to run the rules, so the return logic is slightly adjusted to suit.
