### PR TITLE
add event.preventDefault() to login form for submit event

### DIFF
--- a/.changes/auth0-login-form-preventDefault.md
+++ b/.changes/auth0-login-form-preventDefault.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': patch
+---
+
+The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.

--- a/packages/auth0/src/views/login.ts
+++ b/packages/auth0/src/views/login.ts
@@ -53,7 +53,7 @@ export const loginView = ({
               <div class="error bg-red-500 text-white p-3 ${loginFailed ? '' : 'hidden'}">Wrong email or password</div>
 
               <div>
-                <button id="submit" type="form" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                <button id="submit" type="submit" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                   <span class="absolute left-0 inset-y-0 flex items-center pl-3">
                     <svg class="h-5 w-5 text-blue-500 group-hover:text-blue-400" x-description="Heroicon name: solid/lock-closed" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                       <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"></path>
@@ -75,9 +75,10 @@ export const loginView = ({
               responseType: 'token id_token',
             });
             var form = document.querySelector('#the-form');
-            var button = document.querySelector('#sumbit');
 
-            submit.addEventListener('submit', function(e) {
+            form.addEventListener('submit', function(e) {
+              event.preventDefault();
+              event.stopPropagation()
               let params = new URLSearchParams(window.location.search);
 
               var username = document.querySelector('#username');


### PR DESCRIPTION
## Motivation

In https://github.com/thefrontside/simulacrum/pull/231, we switched to the `submit` form event for better form handling expectations (validation, keyboard interactions). We also need to prevent the default form functions which were taking over and prevent the Auth0 functions from running.
