### PR TITLE
default auth0 simulator userData email_verified to true

### DIFF
--- a/.changes/auth0-email_verified.md
+++ b/.changes/auth0-email_verified.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': patch
+---
+
+The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.

--- a/packages/auth0/src/handlers/oauth-handlers.ts
+++ b/packages/auth0/src/handlers/oauth-handlers.ts
@@ -91,6 +91,7 @@ export const getIdToken = ({
   let userData: RuleUser = {
     name: body?.name,
     email: body?.email,
+    email_verified: true,
     user_id: body?.id,
     nickname: body?.nickname,
     picture: body?.picture,


### PR DESCRIPTION
## Motivation

The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
