### PR TITLE
add stopgap debug in auth0-simulator

### DIFF
--- a/.changes/auth0-stopgap-debug.md
+++ b/.changes/auth0-stopgap-debug.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': patch
+---
+
+The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -29,7 +29,7 @@ export interface Auth0Store {
   set(nonce: string, session: AuthSession): void;
 }
 
-export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>, serviceURL: () => URL, options: Auth0Configuration): Record<Routes, RequestHandler> => {
+export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>, serviceURL: () => URL, options: Auth0Configuration, debug: boolean): Record<Routes, RequestHandler> => {
   let { audience, scope, clientID, rulesDirectory } = options;
   let personQuery = createPersonQuery(people);
 
@@ -44,6 +44,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/authorize']: function(req, res, next) {
+      if (debug) console.dir({ '/authorize': { body: req.body, query: req.query, session: req.session } });
       let currentUser = req.query.currentUser as string | undefined;
 
       assert(!!req.session, "no session");
@@ -65,6 +66,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/login']: function(req, res) {
+      if (debug) console.dir({ '/login': { body: req.body, query: req.query } });
       let query = req.query as QueryParams;
       let responseClientId = query.client_id ?? clientID;
       let responseAudience = query.audience ?? audience;
@@ -85,6 +87,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/usernamepassword/login']: function(req, res) {
+      if (debug) console.dir({ '/usernamepassword/login': { body: req.body, query: req.query } });
       let { username, nonce, password } = req.body;
 
       assert(!!username, 'no username in /usernamepassword/login');
@@ -122,6 +125,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
 
     ['/login/callback']: function(req, res) {
       let wctx = JSON.parse(req.body.wctx);
+      if (debug) console.dir({ '/login/callback': { body: req.body, query: req.query, wctx } });
 
       let { redirect_uri, state, nonce } = wctx;
 
@@ -137,6 +141,7 @@ export const createAuth0Handlers = (store: Auth0Store, people: Iterable<Person>,
     },
 
     ['/oauth/token']: async function (req, res, next) {
+      if (debug) console.dir({ '/oauth/token': { body: req.body, query: req.query } });
       try {
         let iss = serviceURL().toString();
 

--- a/packages/auth0/src/index.ts
+++ b/packages/auth0/src/index.ts
@@ -75,7 +75,7 @@ const createAuth0Service: ResourceServiceCreator = (slice, options) => ({
 
 export function createAuth0Server(options: Auth0ServerOptions): Operation<Server> {
   let { config, serviceURL, store, people, port, debug = true } = options;
-  let auth0 = createAuth0Handlers(store, people, serviceURL, config);
+  let auth0 = createAuth0Handlers(store, people, serviceURL, config, debug);
   let openid = createOpenIdHandlers(serviceURL);
 
   return {


### PR DESCRIPTION
## Motivation

The middleware for debug logging is not working and requires a refactor. As a stopgap, adding a handful of `console.dir()` in the meantime.
