### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/auth0-callback-pass-all.md
+++ b/.changes/auth0-callback-pass-all.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.

--- a/.changes/auth0-email_verified.md
+++ b/.changes/auth0-email_verified.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.

--- a/.changes/auth0-login-form-preventDefault.md
+++ b/.changes/auth0-login-form-preventDefault.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.

--- a/.changes/auth0-stopgap-debug.md
+++ b/.changes/auth0-stopgap-debug.md
@@ -1,5 +1,0 @@
----
-'@simulacrum/auth0-simulator': patch
----
-
-The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.

--- a/.changes/github-api-simulator.md
+++ b/.changes/github-api-simulator.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/github-api-simulator": minor
----
-create the @simulacrum/github-api-simulator package

--- a/examples/nextjs/auth0-react/CHANGELOG.md
+++ b/examples/nextjs/auth0-react/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## \[0.1.19]
+
+- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
+- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
+- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
+- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30
+
 ## \[0.1.18]
 
 - Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.

--- a/examples/nextjs/auth0-react/package.json
+++ b/examples/nextjs/auth0-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-auth0-react",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -21,7 +21,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.8.2",
+    "@simulacrum/auth0-simulator": "0.8.3",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.6.3",
     "@types/react": "17.0.37",

--- a/examples/nextjs/nextjs-auth0/CHANGELOG.md
+++ b/examples/nextjs/nextjs-auth0/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## \[0.0.20]
+
+- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
+- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
+- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
+- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30
+
 ## \[0.0.19]
 
 - Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.

--- a/examples/nextjs/nextjs-auth0/package.json
+++ b/examples/nextjs/nextjs-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum-examples/nextjs-with-nextjs-auth0",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "scripts": {
     "standup": "npm run sim & npm run dev",
@@ -22,7 +22,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@simulacrum/auth0-simulator": "0.8.2",
+    "@simulacrum/auth0-simulator": "0.8.3",
     "@simulacrum/client": "0.5.4",
     "@simulacrum/server": "0.6.3",
     "@types/react": "17.0.37",

--- a/integrations/cypress/CHANGELOG.md
+++ b/integrations/cypress/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## \[0.6.9]
+
+- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
+- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
+- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
+- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
+  - Bumped due to a bump in @simulacrum/auth0-simulator.
+  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30
+
 ## \[0.6.8]
 
 - Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-cypress",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Cypress simulacrum commands",
   "main": "dist/support/index.js",
   "types": "dist/support/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12718,7 +12718,7 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@effection/process": "^2.0.1",
@@ -12802,7 +12802,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontside/graphgen": "^1.7.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## \[0.8.3]
+
+- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
+  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
+- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
+  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
+- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
+  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
+- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
+  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30
+
 ## \[0.8.2]
 
 - Added specific support for the `grant_type` `client_credentials` which is required for machine-to-machine tokens. This grant_type specifically does not run the rules. The `scope` option now accepts an array of objects to specify specific scopes for specific clients.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## \[0.2.0]
+
+- create the @simulacrum/github-api-simulator package
+  - [0eb4ebf](https://github.com/thefrontside/simulacrum/commit/0eb4ebf7d24b1e06cbba2ccc9f9e247f55b52e60) add changeset on 2022-11-30

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",
@@ -19,7 +19,7 @@
     "lint": "eslint src",
     "prepack": "npm run build",
     "build:cjs": "tsc -b tsconfig.dist.json",
-    "build:esm": "tsc -b tsconfig.esm.json", 
+    "build:esm": "tsc -b tsconfig.esm.json",
     "build": "npm run generate && npm run build:cjs && npm run build:esm && copyfiles -f src/schema/schema.docs*.graphql dist/schema",
     "start": "PORT=3300 nodemon",
     "watch": "NODE_ENV=development npm run concurrently \"tsc -b --watch\" \"npm run generate:watch\"",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/auth0-simulator

## [0.8.3]
- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30



# @simulacrum/auth0-cypress

## [0.6.9]
- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30



# @simulacrum/github-api-simulator

## [0.2.0]
- create the @simulacrum/github-api-simulator package
  - [0eb4ebf](https://github.com/thefrontside/simulacrum/commit/0eb4ebf7d24b1e06cbba2ccc9f9e247f55b52e60) add changeset on 2022-11-30



# @simulacrum-examples/nextjs-with-auth0-react

## [0.1.19]
- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30



# @simulacrum-examples/nextjs-with-nextjs-auth0

## [0.0.20]
- The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [6b18117](https://github.com/thefrontside/simulacrum/commit/6b18117093e650713fe00d5b0614ba085186db9f) /login/callback should pass all wctx ([#241](https://github.com/thefrontside/simulacrum/pull/241)) on 2022-11-30
- The auth0-simulator userData does not consider the Auth0 email verification functionality. Set it to `true` as a default to enable minimal functionality.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [547ef7f](https://github.com/thefrontside/simulacrum/commit/547ef7f3a9f7d99023078ff18307bed2b30223af) default auth0 simulator userData email_verified to true on 2022-11-29
- The login form needs `event.preventDefault()` to allow the Auth0 library functions to run instead of default form functionality.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [046f49f](https://github.com/thefrontside/simulacrum/commit/046f49f3603a7865f3e62c84d81851637971f97f) add event.preventDefault() to login form for submit event on 2022-11-29
- The auth0-simulator uses a logger that was refactored and broke the middleware logging. As a stopgap to the required, involved refactor, log out based on the debug flag.
  - Bumped due to a bump in @simulacrum/auth0-simulator.
  - [67e2f7f](https://github.com/thefrontside/simulacrum/commit/67e2f7f18d90a2fa53f2f216291ee770aab60440) add stopgap debug in auth0-simulator ([#237](https://github.com/thefrontside/simulacrum/pull/237)) on 2022-11-30