### PR TITLE
/login/callback should pass all wctx

### DIFF
--- a/.changes/auth0-callback-pass-all.md
+++ b/.changes/auth0-callback-pass-all.md
@@ -1,0 +1,5 @@
+---
+'@simulacrum/auth0-simulator': patch
+---
+
+The auth0-simulator `/login/callback` is difficult to inspect. We need the `client_id` passed, but it seems safe to pass the whole `wctx` object as query strings.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/index.js",
   "scripts": {
     "clean": "rimraf *.tsbuildinfo dist",
-    "test": "NODE_EXTRA_CA_CERTS=\"$(mkcert -CAROOT)/rootCA.pem\" mocha -r ts-node/register --timeout 21000 test/**/*.test.ts",
+    "test": "mocha -r ts-node/register --timeout 21000 test/**/*.test.ts",
     "prepack": "tsc --build tsconfig.dist.json && copy-cli \"./src/views/**/*.png\" ./dist/views/",
     "build": "npm run prepack",
     "lint": "eslint src bin test",

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/index.js",
   "scripts": {
     "clean": "rimraf *.tsbuildinfo dist",
-    "test": "mocha -r ts-node/register --timeout 21000 test/**/*.test.ts",
+    "test": "NODE_EXTRA_CA_CERTS=\"$(mkcert -CAROOT)/rootCA.pem\" mocha -r ts-node/register --timeout 21000 test/**/*.test.ts",
     "prepack": "tsc --build tsconfig.dist.json && copy-cli \"./src/views/**/*.png\" ./dist/views/",
     "build": "npm run prepack",
     "lint": "eslint src bin test",

--- a/packages/auth0/test/auth0.test.ts
+++ b/packages/auth0/test/auth0.test.ts
@@ -212,7 +212,7 @@ describe('Auth0 simulator', () => {
       });
     });
 
-    it('should post to /login/callback', function* () {
+    it('should post', function* () {
       let fields = encodeURIComponent(JSON.stringify({
         ...Fields
       }));
@@ -227,6 +227,28 @@ describe('Auth0 simulator', () => {
 
       expect(res.status).toBe(200);
       expect(res.statusText).toBe('OK');
+    });
+
+    it(`should redirect to redirect_uri`, function* () {
+      let fields = encodeURIComponent(JSON.stringify({
+        ...Fields
+      }));
+
+      let res: Response = yield fetch(`https://localhost:4400/login/callback`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: `wctx=${fields}`
+      });
+
+
+
+      expect(res.url.slice(0, Fields.redirect_uri.length)).toBe(
+        Fields.redirect_uri
+      );
+      expect(res.url).toContain(`client_id=${Fields.client_id}`);
+      expect(res.url).toContain(`audience=${encodeURIComponent(Fields.audience)}`);
     });
   });
 


### PR DESCRIPTION
## Motivation

The `/login/callback` is rather hard to inspect. It seems that we do need to pass the `client_id`, but I suspect there are other pieces we need as we extend the simulator. It seems pretty safe to pass the full object.
