### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/world-factory-types.md
+++ b/.changes/world-factory-types.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch
----
-export World and Factory types

--- a/package-lock.json
+++ b/package-lock.json
@@ -12802,7 +12802,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontside/graphgen": "^1.7.0",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.2.2]
+
+- export World and Factory types
+  - [1c70396](https://github.com/thefrontside/simulacrum/commit/1c703967c972f9a363727607becd29c1c7b9992e) export World and Factory types ([#245](https://github.com/thefrontside/simulacrum/pull/245)) on 2022-12-01
+
 ## \[0.2.1]
 
 - Fix path resolution to github api schema

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/github-api-simulator

## [0.2.2]
- export World and Factory types
  - [1c70396](https://github.com/thefrontside/simulacrum/commit/1c703967c972f9a363727607becd29c1c7b9992e) export World and Factory types ([#245](https://github.com/thefrontside/simulacrum/pull/245)) on 2022-12-01