### PR TITLE
add the description mapping to Github API simulator

### DIFF
--- a/.changes/github-api-simulator-repo-description.md
+++ b/.changes/github-api-simulator-repo-description.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch
+---
+
+Added the description mapping to repositories.

--- a/packages/github-api/src/service/repositories.ts
+++ b/packages/github-api/src/service/repositories.ts
@@ -13,6 +13,7 @@ export function requestRepositories(
 export function requestRepository(repository: GithubRepository) {
   return {
     name: repository.name,
+    description: repository.description,
     isArchived: repository.isArchived,
     nameWithOwner: repository.nameWithOwner,
     repositoryTopics: {


### PR DESCRIPTION
## Motivation

The description was not being mapped in the Github API simulator repository mapping.

## Approach

Added it to the mapping; having had tested the change downstream from the `node_modules`.
