### PR TITLE
✨Add ability to extend the Github API Router with custom middleware

### DIFF
--- a/.changes/extend-github-api-router.md
+++ b/.changes/extend-github-api-router.md
@@ -1,0 +1,4 @@
+---
+"@simulacrum/github-api-simulator": minor
+---
+Allow extenstion of github api simulator with new endpoints and middleware

--- a/packages/github-api/src/service/standaloneServer.ts
+++ b/packages/github-api/src/service/standaloneServer.ts
@@ -7,6 +7,15 @@ import type { SimulatedData } from './types';
 
 export interface ServerOptions extends SimulatedData {
   port?: number;
+
+  /**
+   * Extend the capabilities of the Express Router simulating the GithHub API
+   * with custom middlewares, and custom endpoints.
+   *
+   * @param ext an extenstion function that accepts the Express Router to make
+   * changes to it
+   */
+  extend?(router: express.Router): void;
 }
 
 export async function startStandaloneServer({
@@ -14,6 +23,7 @@ export async function startStandaloneServer({
   users,
   githubRepositories,
   githubOrganizations,
+  extend,
 }: ServerOptions): Promise<Server> {
   let router = Router();
 
@@ -27,6 +37,10 @@ export async function startStandaloneServer({
     '/graphql',
     createHandler({ users, githubRepositories, githubOrganizations }),
   );
+
+  if (extend) {
+    extend(router);
+  }
 
   let app = express().use(cors()).use(router);
 


### PR DESCRIPTION
## Motivation

Our implementation of the GitHub API is incomplete which is not suprising given that it is huge. However this poses a problem for someone using the API simulator. What if the API is missing something that they need? Their options are to submit a PR to this repo, or to just start the things they need on another port. This is doable, but it means that they have to manage two servers, and also that the simulation does not appear to be hosted at the same origin. That's an unecessary burden. We need a way to extend a simulator with new endpoints (and possibly new middlewares) without requiring an upstream change to this repository.

## Approach

This takes the simplest approach that could possibly work. It adds an "extension" property to the `ServerOptions` interface. It's just a function that, if present, will be invoked with the express router so that it can do whatever it wants to it.