### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/extend-github-api-router.md
+++ b/.changes/extend-github-api-router.md
@@ -1,4 +1,0 @@
----
-"@simulacrum/github-api-simulator": minor
----
-Allow extenstion of github api simulator with new endpoints and middleware

--- a/package-lock.json
+++ b/package-lock.json
@@ -12802,7 +12802,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontside/graphgen": "^1.7.0",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.3.0]
+
+- Allow extenstion of github api simulator with new endpoints and middleware
+  - [b065a10](https://github.com/thefrontside/simulacrum/commit/b065a10ad6f5cb53a70453f1e8d3f0065b5e2210) Add changeset on 2023-05-05
+
 ## \[0.2.4]
 
 - Added the description mapping to repositories.

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# @simulacrum/github-api-simulator

## [0.3.0]
- Allow extenstion of github api simulator with new endpoints and middleware
  - [b065a10](https://github.com/thefrontside/simulacrum/commit/b065a10ad6f5cb53a70453f1e8d3f0065b5e2210) Add changeset on 2023-05-05