### PR TITLE
bump graphgen to 1.8.1

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -7,6 +7,12 @@
       "publish": "npm publish --access public"
     }
   },
+  "changeTags": {
+    "feat": "New Features",
+    "enhance": "Enhancements",
+    "bug": "Bug Fixes",
+    "deps": "Dependencies"
+  },
   "packages": {
     "@simulacrum/client": {
       "path": "./packages/client",
@@ -35,9 +41,7 @@
     "@simulacrum/auth0-cypress": {
       "path": "./integrations/cypress",
       "manager": "javascript",
-      "dependencies": [
-        "@simulacrum/auth0-simulator"
-      ],
+      "dependencies": ["@simulacrum/auth0-simulator"],
       "prepublish": ["npm install", "npm run build"]
     },
     "@simulacrum/github-api-simulator": {

--- a/.changes/graphgen-1.8.1.md
+++ b/.changes/graphgen-1.8.1.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch:deps
+---
+
+Bump the version of graphgen to 1.8.1 to support the latest type signature expected from the factory that is passed to the server.

--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           fetch-depth: 0 # required for use of git history
       - name: covector status
-        uses: jbolda/covector/packages/action@covector-v0.5
+        uses: jbolda/covector/packages/action@covector-v0.9
         id: covector
         with:
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -29,7 +29,7 @@ jobs:
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
       - name: covector version or publish (publish when no change files present)
-        uses: jbolda/covector/packages/action@covector-v0.5
+        uses: jbolda/covector/packages/action@covector-v0.9
         id: covector
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@frontside/graphgen": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@frontside/graphgen/-/graphgen-1.7.0.tgz",
-      "integrity": "sha512-KE4IXH+CyzSyVT7+37vd4ysK0JkEuuw1Ex8LGx7q8mr4MEyAsSWTkO6BPrWsuJNka4hhDaev78SePMTBkb+TOA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@frontside/graphgen/-/graphgen-1.8.1.tgz",
+      "integrity": "sha512-YtKGMEWWPI+AcqJkuElZBjmmtQ/Tf2mXVz3dkgjSRNabtPFBvt/apPTcxzLdgem/ONZpbRx6tibScRWAI+TanA==",
       "dependencies": {
         "alea": "1.0.1",
         "glob-to-regexp": "0.4.1",
@@ -12805,7 +12805,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@frontside/graphgen": "^1.7.0",
+        "@frontside/graphgen": "^1.8.1",
         "@graphql-yoga/node": "^2.13.13",
         "assert-ts": "^0.3.4",
         "cors": "^2.8.5",
@@ -14000,9 +14000,9 @@
       }
     },
     "@frontside/graphgen": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@frontside/graphgen/-/graphgen-1.7.0.tgz",
-      "integrity": "sha512-KE4IXH+CyzSyVT7+37vd4ysK0JkEuuw1Ex8LGx7q8mr4MEyAsSWTkO6BPrWsuJNka4hhDaev78SePMTBkb+TOA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@frontside/graphgen/-/graphgen-1.8.1.tgz",
+      "integrity": "sha512-YtKGMEWWPI+AcqJkuElZBjmmtQ/Tf2mXVz3dkgjSRNabtPFBvt/apPTcxzLdgem/ONZpbRx6tibScRWAI+TanA==",
       "requires": {
         "alea": "1.0.1",
         "glob-to-regexp": "0.4.1",
@@ -16186,7 +16186,7 @@
     "@simulacrum/github-api-simulator": {
       "version": "file:packages/github-api",
       "requires": {
-        "@frontside/graphgen": "^1.7.0",
+        "@frontside/graphgen": "^1.8.1",
         "@graphql-codegen/add": "^3.1.1",
         "@graphql-codegen/cli": "^2.6.2",
         "@graphql-codegen/graphql-modules-preset": "^2.3.8",

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -29,7 +29,7 @@
     "test": "echo not.....yet"
   },
   "dependencies": {
-    "@frontside/graphgen": "^1.7.0",
+    "@frontside/graphgen": "^1.8.1",
     "@graphql-yoga/node": "^2.13.13",
     "assert-ts": "^0.3.4",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Motivation

The type signature of graphgen has been updated which affects the type of `factory` passed to the Github API simulator.

## Approach

Bump the version of graphgen to the latest.
