### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/graphgen-1.8.1.md
+++ b/.changes/graphgen-1.8.1.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:deps
----
-
-Bump the version of graphgen to 1.8.1 to support the latest type signature expected from the factory that is passed to the server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12802,7 +12802,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontside/graphgen": "^1.8.1",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.3.1]
+
+### Dependencies
+
+- [`70eedc3`](https://github.com/thefrontside/simulacrum/commit/70eedc311329078b65fd57afd9112dceeed0319e)([#260](https://github.com/thefrontside/simulacrum/pull/260)) Bump the version of graphgen to 1.8.1 to support the latest type signature expected from the factory that is passed to the server.
+
 ## \[0.3.0]
 
 - Allow extenstion of github api simulator with new endpoints and middleware

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/github-api-simulator

## [0.3.1]
### Dependencies

- [`70eedc3`](https://github.com/thefrontside/simulacrum/commit/70eedc311329078b65fd57afd9112dceeed0319e)([#260](https://github.com/thefrontside/simulacrum/pull/260)) Bump the version of graphgen to 1.8.1 to support the latest type signature expected from the factory that is passed to the server.