### PR TITLE
update github action dependencies to avoid breakage from upcoming deprecation removal

### DIFF
--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -6,9 +6,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for use of git history
+      - uses: volta-cli/action@v4
+      # this is required when running the ./.scripts/checkIfPublished.mjs
+      - name: Install Node.js dependencies
+        run: npm ci
       - name: covector status
         uses: jbolda/covector/packages/action@covector-v0.9
         id: covector

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -15,15 +15,15 @@ jobs:
       successfulPublish: ${{ steps.covector.outputs.successfulPublish }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for use of git history
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14
           registry-url: "https://registry.npmjs.org"
-      - run: npm install --global npm@7.10.0
-      - run: npm install
+      - uses: volta-cli/action@v4
+      - name: Install Node.js dependencies
+        run: npm ci
       - name: git config
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
-
+      - uses: actions/checkout@v3
+      - uses: volta-cli/action@v4
       - name: Install Node.js dependencies
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "npm": ">=9"
   },
   "volta": {
-    "node": "18.12.0",
-    "npm": "9.1.2"
+    "node": "18.16.0",
+    "npm": "9.6.7"
   },
   "devDependencies": {
     "@effection/fetch": "^2.0.1",


### PR DESCRIPTION
## Motivation

We had a handful of Github Action steps that were out of date, and were using deprecated versions of node and Github Action APIs. The status check also required `node_modules` installed so we added this.
