### PR TITLE
fix github api repository query name undefined

### DIFF
--- a/.changes/github-api-repo-name-undefined.md
+++ b/.changes/github-api-repo-name-undefined.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch:bug
+---
+
+A `repository` query would fail due to a destructured `name`. This fixes the reference and adds an additional check for matching `nameWithOwner`.

--- a/packages/github-api/src/service/resolvers.ts
+++ b/packages/github-api/src/service/resolvers.ts
@@ -65,9 +65,11 @@ export function createResolvers({
           };
         });
       },
-      repository({ name }: { owner: string; name: string }) {
+      repository(_, { owner, name }: { owner: string; name: string }) {
         let repo = [...githubRepositories].find(
-          r => r.name.toLowerCase() === name,
+          (r) =>
+            r.name.toLowerCase() === name &&
+            r.nameWithOwner.toLowerCase() === `${owner}/${name}`.toLowerCase()
         );
 
         assert(!!repo, `no repository found for ${name}`);


### PR DESCRIPTION
## Motivation

A `repository` query would fail due to a destructured `name`. This fixes the reference and adds an additional check for matching `nameWithOwner`.

## Approach

The first arg is the request context. The variables required are within the second arg passed to the repository query. Make this adjustment, and also use the `owner` field for improved matching.
