### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/github-api-repo-name-undefined.md
+++ b/.changes/github-api-repo-name-undefined.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:bug
----
-
-A `repository` query would fail due to a destructured `name`. This fixes the reference and adds an additional check for matching `nameWithOwner`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12802,7 +12802,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontside/graphgen": "^1.8.1",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.3.2]
+
+### Bug Fixes
+
+- [`1040a8f`](https://github.com/thefrontside/simulacrum/commit/1040a8f11d9534eebaa1620c0bd9b8b884291d53)([#263](https://github.com/thefrontside/simulacrum/pull/263)) A `repository` query would fail due to a destructured `name`. This fixes the reference and adds an additional check for matching `nameWithOwner`.
+
 ## \[0.3.1]
 
 ### Dependencies

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/github-api-simulator

## [0.3.2]
### Bug Fixes

- [`1040a8f`](https://github.com/thefrontside/simulacrum/commit/1040a8f11d9534eebaa1620c0bd9b8b884291d53)([#263](https://github.com/thefrontside/simulacrum/pull/263)) A `repository` query would fail due to a destructured `name`. This fixes the reference and adds an additional check for matching `nameWithOwner`.