### PR TITLE
Github API simulator fields isArchived and defaultBranchRef

### DIFF
--- a/.changes/gh-api-isarchived-defaultbranch.md
+++ b/.changes/gh-api-isarchived-defaultbranch.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch
+---
+
+Adding the isArchived and defaultBranchRef as options to return in the query.

--- a/packages/github-api/src/service/resolvers.ts
+++ b/packages/github-api/src/service/resolvers.ts
@@ -81,6 +81,10 @@ export function createResolvers({
           url: repo.url,
           description: repo.description,
           visibility: repo.visibility,
+          isArchived: repo.isArchived,
+          defaultBranchRef: {
+              name: repo.defaultBranchRef.name
+          },
           languages: {
             nodes: repo.languages.map(l => ({
               name: l,


### PR DESCRIPTION
## Motivation

We have `isArchived` and `defaultBranchRef` missing.

## Approach

Simply adding them.
