### PR TITLE
Don't report server started until listener callback is invoked

### DIFF
--- a/.changes/ldap-await-server-init.md
+++ b/.changes/ldap-await-server-init.md
@@ -1,0 +1,6 @@
+---
+"@simulacrum/ldap-simulator": patch
+---
+
+Don't resolve `createLDAPServer()` until server is known to be accepting
+connections.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  node: circleci/node@4.3.0
+  node: circleci/node@5.1.0
 jobs:
   test:
     docker:

--- a/packages/ldap/src/index.ts
+++ b/packages/ldap/src/index.ts
@@ -139,15 +139,23 @@ filter: ${req.filter.toString()}
         }
       });
 
-      server.listen(port, function () {
-        logger.log(dedent`LDAP test server running on port ${port});
+      yield new Promise<void>((resolve, reject) => {
+        server.listen(port, function (err: Error) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+
+      logger.log(dedent`LDAP test server running on port ${port}
 
 BindDN: bindDn = ${bindDn} cn=${bindDn},${baseDN}
 Bind Password: ${bindPassword}
 
 UserBaseDN:    ${bindDn}
 `);
-      });
 
       yield spawn(function* shutdown() {
         try {


### PR DESCRIPTION
## Motivation

The server resource was being reported as initialized before the server.listen() callback was invoked. This meant that you could have test code that relied on the server running, and awaited server initialization, but the server was not actually up and accepting connections.

## Approach
During server initialization, create a promise that is only ever resolved when the server.listen() callback is invoked.
