### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/github-api-repositoryOwner-resolver.md
+++ b/.changes/github-api-repositoryOwner-resolver.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": minor
----
-
-Adds the `repositoryOwner` resolver.

--- a/.changes/ldap-await-server-init.md
+++ b/.changes/ldap-await-server-init.md
@@ -1,6 +1,0 @@
----
-"@simulacrum/ldap-simulator": patch
----
-
-Don't resolve `createLDAPServer()` until server is known to be accepting
-connections.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12802,7 +12802,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@frontside/graphgen": "^1.8.1",
@@ -12842,7 +12842,7 @@
     },
     "packages/ldap": {
       "name": "@simulacrum/ldap-simulator",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "ISC",
       "dependencies": {
         "@simulacrum/server": "^0.4.0",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## \[0.4.0]
+
+- [`955dd7f`](https://github.com/thefrontside/simulacrum/commit/955dd7f248f6f1352b6be10327dda48a0ffcea58)([#267](https://github.com/thefrontside/simulacrum/pull/267)) Adds the `repositoryOwner` resolver.
+
 ## \[0.3.3]
 
 - [`d38705a`](https://github.com/thefrontside/simulacrum/commit/d38705aaa34ce10a9a57ed418a277c7aa777fb97)([#265](https://github.com/thefrontside/simulacrum/pull/265)) Adding the isArchived and defaultBranchRef as options to return in the query.

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",

--- a/packages/ldap/CHANGELOG.md
+++ b/packages/ldap/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[0.5.5]
+
+- [`7c69bbd`](https://github.com/thefrontside/simulacrum/commit/7c69bbd650c7ab2463192fd117c7ee20cc751eff) Don't resolve `createLDAPServer()` until server is known to be accepting
+  connections.
+
 ## \[0.5.4]
 
 - When creating a person with the person simulator, we now allow passing in a specific `id` to use.

--- a/packages/ldap/package.json
+++ b/packages/ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/ldap-simulator",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Run local LDAP server with specific users for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/ldap-simulator

## [0.5.5]
- [`7c69bbd`](https://github.com/thefrontside/simulacrum/commit/7c69bbd650c7ab2463192fd117c7ee20cc751eff) Don't resolve `createLDAPServer()` until server is known to be accepting
    connections.



# @simulacrum/github-api-simulator

## [0.4.0]
- [`955dd7f`](https://github.com/thefrontside/simulacrum/commit/955dd7f248f6f1352b6be10327dda48a0ffcea58)([#267](https://github.com/thefrontside/simulacrum/pull/267)) Adds the `repositoryOwner` resolver.