### PR TITLE
run versioning on main

### DIFF
--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0 # required for use of git history
       - uses: volta-cli/action@v4
       - name: covector status
-        uses: jbolda/covector/packages/action@release
+        uses: jbolda/covector/packages/action@covector-v0
         id: covector
         with:
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - v0
+      - main
 
 jobs:
   version-or-publish:


### PR DESCRIPTION
## Motivation

We changed the default branch to `main` as the versioning for each package in the repo is independent.
