### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/foundation-simulator-initial.md
+++ b/.changes/foundation-simulator-initial.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor
----
-
-This simulator is a base to iteratively build a simulator for use in published simulators in `@simulacrum` scope or custom implementations elsewhere. This includes the components likely to be used in each simulator (server, router, data store) and pieces to enable quickly spinning up a simulator to get started as through an OpenAPI spec.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14924,7 +14924,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## \[0.1.0]
+
+- [`58ae1d9`](https://github.com/thefrontside/simulacrum/commit/58ae1d9d5719775a7595ec9bbf55b2c015a892bf) This simulator is a base to iteratively build a simulator for use in published simulators in `@simulacrum` scope or custom implementations elsewhere. This includes the components likely to be used in each simulator (server, router, data store) and pieces to enable quickly spinning up a simulator to get started as through an OpenAPI spec.

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/foundation-simulator

## [0.1.0]
- 58ae1d9 This simulator is a base to iteratively build a simulator for use in published simulators in `@simulacrum` scope or custom implementations elsewhere. This includes the components likely to be used in each simulator (server, router, data store) and pieces to enable quickly spinning up a simulator to get started as through an OpenAPI spec.