### PR TITLE
add simulationRoutes to store, display at base / route

### DIFF
--- a/.changes/foundation-sim-logger.md
+++ b/.changes/foundation-sim-logger.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": minor:feat
+---
+
+All routes now add a log to the simulation state on every visit. This assists in tracking hits on each simulation route.

--- a/.changes/foundation-simulator-route-list.md
+++ b/.changes/foundation-simulator-route-list.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": minor:feat
+---
+
+To improve transparency and flexibility, we now include a page at the root that lists all of the routes, and the ability to signal which response to return.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4784,7 +4784,9 @@
     },
     "node_modules/cors": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -9401,6 +9403,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
+        "cors": "^2.8.5",
         "express": "^4.19.2",
         "fdir": "^6.2.0",
         "openapi-backend": "^5.10.6",
@@ -11947,6 +11950,7 @@
       "requires": {
         "@types/cors": "^2.8.17",
         "ajv-formats": "^3.0.1",
+        "cors": "^2.8.5",
         "express": "^4.19.2",
         "fdir": "^6.2.0",
         "openapi-backend": "^5.10.6",
@@ -13214,6 +13218,7 @@
     },
     "cors": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "requires": {
         "object-assign": "^4",

--- a/packages/foundation/example/extensiveServer/openapi.ts
+++ b/packages/foundation/example/extensiveServer/openapi.ts
@@ -16,6 +16,9 @@ const openapiSchemaFromRealEndpoint = {
           200: {
             description: "All of the dogs",
           },
+          404: {
+            description: "The dogs have gone missing!",
+          },
         },
       },
     },
@@ -127,11 +130,15 @@ function handlers(
   simulationStore: ExtendedSimulationStore
 ): SimulationHandlers {
   return {
-    getDogs: (_c, _r, response) => {
+    getDogs: (_c, request, response, _next, routeMetadata) => {
       let dogs = simulationStore.schema.dogs.select(
         simulationStore.store.getState()
       );
-      response.status(200).json({ dogs });
+      if (routeMetadata.defaultCode === 200) {
+        response.status(200).json({ dogs });
+      } else {
+        response.sendStatus(routeMetadata.defaultCode);
+      }
     },
     putDogs: (c, req, response) => {
       simulationStore.store.dispatch(

--- a/packages/foundation/example/extensiveServer/store.ts
+++ b/packages/foundation/example/extensiveServer/store.ts
@@ -54,6 +54,7 @@ const inputSelectors = ({
 };
 
 export const extendStore = {
+  logs: false,
   actions: inputActions,
   selectors: inputSelectors,
   schema: inputSchema,

--- a/packages/foundation/example/singleFileServer/index.ts
+++ b/packages/foundation/example/singleFileServer/index.ts
@@ -93,6 +93,7 @@ export const simulation = createFoundationSimulationServer({
     },
   ],
   extendStore: {
+    logs: false,
     actions: ({ thunks, schema }) => {
       // TODO attempt to remove this type as a requirement
       let upsertTest = thunks.create<AnyState>(

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "ajv-formats": "^3.0.1",
+    "cors": "^2.8.5",
     "express": "^4.19.2",
     "fdir": "^6.2.0",
     "openapi-backend": "^5.10.6",

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -109,14 +109,32 @@ export function createFoundationSimulationServer<
         .sync();
 
       if (jsonFiles.length > 0) {
+        const simulationRoutes = [];
         for (let jsonFile of jsonFiles) {
-          const route = jsonFile.slice(0, jsonFile.length - 5);
+          const route = `/${jsonFile.slice(0, jsonFile.length - 5)}`;
           const filename = path.join(serveJsonFiles, jsonFile);
-          app.get(`/${route}`, (_req, res) => {
+          app.get(route, (_req, res) => {
             res.setHeader("content-type", "application/json");
             fs.createReadStream(filename).pipe(res);
           });
+
+          simulationRoutes.push(
+            simulationStore.schema.simulationRoutes.add({
+              [`get:${route}`]: {
+                type: "JSON",
+                url: route,
+                method: "get",
+                calls: 0,
+                defaultCode: 200,
+                responses: [200],
+              },
+            })
+          );
         }
+
+        simulationStore.store.dispatch(
+          simulationStore.actions.batchUpdater(simulationRoutes)
+        );
       }
     }
 

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -207,7 +207,9 @@ export function createFoundationSimulationServer<
           const router = init.router;
           const operations = router.getOperations();
           const simulationRoutes = operations.reduce((routes, operation) => {
-            const url = `${router.apiRoot}${operation.path}`;
+            const url = `${router.apiRoot === "/" ? "" : router.apiRoot}${
+              operation.path
+            }`;
             routes[`${operation.method}:${url}`] = {
               type: "OpenAPI",
               url,

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -104,6 +104,7 @@ export function createFoundationSimulationServer<
     let simulationStore = createSimulationStore(extendStore);
 
     app.use((req, res, next) => {
+      // add each response to the internal log
       simulationStore.store.dispatch(
         simulationStore.actions.simulationLog({
           method: req.method,
@@ -278,6 +279,7 @@ export function createFoundationSimulationServer<
       }
     }
 
+    // return simulation helper page
     app.get("/", (req, res) => {
       let routes = simulationStore.schema.simulationRoutes.selectTableAsList(
         simulationStore.store.getState()

--- a/packages/foundation/src/routeTemplate.ts
+++ b/packages/foundation/src/routeTemplate.ts
@@ -1,0 +1,85 @@
+import type { SimulationRoute } from "./store/schema";
+
+const responseSubmit = (routeId: string, response: number) => /* HTML */ `<form
+  action=""
+  method="post"
+>
+  <input type="submit" name="${routeId}" value="${response}" />
+</form>`;
+const routeToId = (route: SimulationRoute) => `${route.method}:${route.url}`;
+
+export const generateRoutesHTML = (routes: SimulationRoute[]) => {
+  return /* HTML */ `<!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>Simulation Server Routes</title>
+        <style>
+          html {
+            font-size: 16px;
+            line-height: 1.5;
+            background-color: #fff;
+            color: #000;
+          }
+          body {
+            margin: 0 auto;
+            max-width: 720px;
+            padding: 0 16px;
+            font-family: sans-serif;
+          }
+
+          a {
+            text-decoration: none;
+          }
+
+          .routes {
+            display: grid;
+            grid-template-columns: 20px auto auto auto;
+            column-gap: 15px;
+          }
+          .route-actions {
+            display: flex;
+            gap: 5px;
+          }
+
+          li {
+            margin-bottom: 8px;
+          }
+
+          /* Dark mode styles */
+          @media (prefers-color-scheme: dark) {
+            html {
+              background-color: #1e293b;
+              color: #fff;
+            }
+
+            a {
+            }
+          }
+        </style>
+      </head>
+      <body>
+        <main class="my-12">
+          <h1>Simulation Routes</h1>
+          <div class="routes">
+            ${routes
+              .map(
+                (route) =>
+                  `<span>${route.method.toUpperCase()}</span><a href=${
+                    route.url
+                  }>${route.url}</a><span>returns: ${
+                    route.defaultCode
+                  }, called ${
+                    route.calls
+                  } times</span><div class="route-actions">${route.responses
+                    .map((response) =>
+                      responseSubmit(routeToId(route), response)
+                    )
+                    .join("")}</div>`
+              )
+              .join("\n")}
+          </div>
+        </main>
+      </body>
+    </html>`;
+};

--- a/packages/foundation/src/routeTemplate.ts
+++ b/packages/foundation/src/routeTemplate.ts
@@ -26,8 +26,7 @@ export const generateRoutesHTML = (
           }
           body {
             margin: 0 auto;
-            max-width: 720px;
-            padding: 0 16px;
+            padding: 0 12ch;
             font-family: sans-serif;
           }
 

--- a/packages/foundation/src/routeTemplate.ts
+++ b/packages/foundation/src/routeTemplate.ts
@@ -34,7 +34,7 @@ export const generateRoutesHTML = (routes: SimulationRoute[]) => {
 
           .routes {
             display: grid;
-            grid-template-columns: 1fr 6fr 2fr auto;
+            grid-template-columns: 1fr 5fr 1fr 1fr 2fr;
             column-gap: 15px;
           }
           .route-actions {
@@ -54,6 +54,7 @@ export const generateRoutesHTML = (routes: SimulationRoute[]) => {
             }
 
             a {
+              color: aqua;
             }
           }
         </style>
@@ -62,16 +63,21 @@ export const generateRoutesHTML = (routes: SimulationRoute[]) => {
         <main class="my-12">
           <h1>Simulation Routes</h1>
           <div class="routes">
+            <span>Method</span>
+            <span>URL</span>
+            <span>Status</span>
+            <span>Metrics</span>
+            <span>Response Options</span>
             ${routes
               .map(
                 (route) =>
                   `<span>${route.method.toUpperCase()}</span><a href=${
                     route.url
-                  }>${route.url}</a><span>returns: ${
+                  }>${route.url}</a><span>code ${
                     route.defaultCode
-                  }, called ${
+                  }</span><span>${
                     route.calls
-                  } times</span><div class="route-actions">${route.responses
+                  } calls</span><div class="route-actions">${route.responses
                     .map((response) =>
                       responseSubmit(routeToId(route), response)
                     )

--- a/packages/foundation/src/routeTemplate.ts
+++ b/packages/foundation/src/routeTemplate.ts
@@ -1,4 +1,4 @@
-import type { SimulationRoute } from "./store/schema";
+import type { SimulationLog, SimulationRoute } from "./store/schema";
 
 const responseSubmit = (routeId: string, response: number) => /* HTML */ `<form
   action=""
@@ -8,7 +8,10 @@ const responseSubmit = (routeId: string, response: number) => /* HTML */ `<form
 </form>`;
 const routeToId = (route: SimulationRoute) => `${route.method}:${route.url}`;
 
-export const generateRoutesHTML = (routes: SimulationRoute[]) => {
+export const generateRoutesHTML = (
+  routes: SimulationRoute[],
+  logs: SimulationLog[]
+) => {
   return /* HTML */ `<!DOCTYPE html>
     <html>
       <head>
@@ -61,7 +64,8 @@ export const generateRoutesHTML = (routes: SimulationRoute[]) => {
       </head>
       <body>
         <main class="my-12">
-          <h1>Simulation Routes</h1>
+          <h1>Simulation</h1>
+          <h2>Routes</h2>
           <div class="routes">
             <span>Method</span>
             <span>URL</span>
@@ -84,6 +88,10 @@ export const generateRoutesHTML = (routes: SimulationRoute[]) => {
                     .join("")}</div>`
               )
               .join("\n")}
+          </div>
+          <h2>Logs</h2>
+          <div class="simulation-logs">
+            ${logs.map((log) => `<div>${log.message}</div>`).join("")}
           </div>
         </main>
       </body>

--- a/packages/foundation/src/routeTemplate.ts
+++ b/packages/foundation/src/routeTemplate.ts
@@ -34,7 +34,7 @@ export const generateRoutesHTML = (routes: SimulationRoute[]) => {
 
           .routes {
             display: grid;
-            grid-template-columns: 20px auto auto auto;
+            grid-template-columns: 1fr 6fr 2fr auto;
             column-gap: 15px;
           }
           .route-actions {

--- a/packages/foundation/src/store/index.ts
+++ b/packages/foundation/src/store/index.ts
@@ -74,6 +74,26 @@ export function createSimulationStore<
       yield* next();
     }
   );
+  let simulationLog = thunks.create<{
+    method: string;
+    url: string;
+    query: Record<string, any>;
+    body: any;
+  }>("simulationLog", function* (ctx, next) {
+    const { method, url, query, body } = ctx.payload;
+    const timestamp = Date.now();
+    yield* schema.update(
+      schema.simulationLogs.add({
+        [timestamp]: {
+          timestamp,
+          level: "info",
+          message: `${method} ${url}`,
+          meta: { method, url, query, body },
+        },
+      })
+    );
+    yield* next();
+  });
 
   let additionalTasks = [thunks.bootup];
 
@@ -86,6 +106,7 @@ export function createSimulationStore<
 
   let inputedActions = inputActions({ thunks, store, schema });
   let actions = {
+    simulationLog,
     batchUpdater,
     ...inputedActions,
   };

--- a/packages/foundation/src/store/schema.ts
+++ b/packages/foundation/src/store/schema.ts
@@ -9,7 +9,7 @@ export type ExtendSimulationSchemaInput<T> = ({
 }: ExtendSimulationSchema) => T;
 
 export interface SimulationRoute {
-  type: "OpenAPI" | "Explicit";
+  type: "JSON" | "OpenAPI" | "Explicit";
   url: string;
   method: "get" | "post" | "delete" | "patch";
   calls: number;

--- a/packages/foundation/src/store/schema.ts
+++ b/packages/foundation/src/store/schema.ts
@@ -8,6 +8,13 @@ export type ExtendSimulationSchemaInput<T> = ({
   slice,
 }: ExtendSimulationSchema) => T;
 
+export interface SimulationLog {
+  timestamp: number;
+  level: "debug" | "info" | "error";
+  message: string;
+  meta?: Record<string, any>;
+}
+
 export interface SimulationRoute {
   type: "JSON" | "OpenAPI" | "Explicit";
   url: string;
@@ -25,6 +32,7 @@ export function generateSchemaWithInputSlices<ExtendedSimulationSchema>(
   let schemaAndInitialState = createSchema({
     cache: immerSlice.table({ empty: {} }),
     loaders: immerSlice.loaders(),
+    simulationLogs: immerSlice.table<SimulationLog>(),
     simulationRoutes: immerSlice.table<SimulationRoute>({
       empty: {
         type: "Explicit",

--- a/packages/foundation/src/store/schema.ts
+++ b/packages/foundation/src/store/schema.ts
@@ -8,6 +8,15 @@ export type ExtendSimulationSchemaInput<T> = ({
   slice,
 }: ExtendSimulationSchema) => T;
 
+export interface SimulationRoute {
+  type: "OpenAPI" | "Explicit";
+  url: string;
+  method: "get" | "post" | "delete" | "patch";
+  calls: number;
+  defaultCode: number;
+  responses: number[];
+}
+
 export function generateSchemaWithInputSlices<ExtendedSimulationSchema>(
   inputSchema: ExtendSimulationSchemaInput<ExtendedSimulationSchema>
 ) {
@@ -16,6 +25,16 @@ export function generateSchemaWithInputSlices<ExtendedSimulationSchema>(
   let schemaAndInitialState = createSchema({
     cache: immerSlice.table({ empty: {} }),
     loaders: immerSlice.loaders(),
+    simulationRoutes: immerSlice.table<SimulationRoute>({
+      empty: {
+        type: "Explicit",
+        url: "",
+        method: "get",
+        calls: 0,
+        defaultCode: 200,
+        responses: [200],
+      },
+    }),
     ...slices,
   });
 


### PR DESCRIPTION
## Motivation

To improve transparency and flexibility, we include a page at the root that lists all of the routes, and the ability to signal which response to return.

## Approach

Pipe OpenAPI routes into the simulation store. Return these items through a small form to adjust that state. Also, pipe that state into the OpenAPI handlers to improve the usability.

## Example

![Screenshot 2024-08-27 at 4 49 33 PM](https://github.com/user-attachments/assets/0e963e51-fd0a-4e8f-a3c2-41b04585b578)
