### PR TITLE
foundation simulator handles json serving

### DIFF
--- a/.changes/serve-json-files.md
+++ b/.changes/serve-json-files.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": minor:feat
+---
+
+We now support serving a directly of JSON files through file path routing. Use `serveJsonFiles` to specify the folder which contains the files to serve.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9402,6 +9402,7 @@
       "dependencies": {
         "ajv-formats": "^3.0.1",
         "express": "^4.19.2",
+        "fdir": "^6.2.0",
         "openapi-backend": "^5.10.6",
         "openapi-merge": "^1.3.2",
         "starfx": "^0.12.0"
@@ -9455,11 +9456,39 @@
         "node": ">= 16"
       }
     },
+    "packages/foundation/node_modules/fdir": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.2.0.tgz",
+      "integrity": "sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "packages/foundation/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "packages/foundation/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "packages/foundation/node_modules/react": {
       "version": "18.3.1",
@@ -11919,6 +11948,7 @@
         "@types/cors": "^2.8.17",
         "ajv-formats": "^3.0.1",
         "express": "^4.19.2",
+        "fdir": "^6.2.0",
         "openapi-backend": "^5.10.6",
         "openapi-merge": "^1.3.2",
         "starfx": "^0.12.0",
@@ -11951,10 +11981,23 @@
           "resolved": "https://registry.npmjs.org/effection/-/effection-3.0.0-beta.3.tgz",
           "integrity": "sha512-OamLXbd8EdW9z6gIjfJ4c1MJykE/J5Q++j1wC8m6CNXatiETJtdF3lIwgrIRklKjQOYfW47tMgTllmHpHzR3fA=="
         },
+        "fdir": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.2.0.tgz",
+          "integrity": "sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==",
+          "requires": {}
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+          "optional": true,
+          "peer": true
         },
         "react": {
           "version": "18.3.1",

--- a/packages/foundation/example/extensiveServer/index.ts
+++ b/packages/foundation/example/extensiveServer/index.ts
@@ -5,6 +5,7 @@ import { extendRouter } from "./extend-api";
 
 export const simulation = createFoundationSimulationServer({
   port: 9999,
+  serveJsonFiles: `${__dirname}/jsonFiles`,
   openapi,
   extendStore,
   extendRouter,

--- a/packages/foundation/example/extensiveServer/jsonFiles/route-to-test.json
+++ b/packages/foundation/example/extensiveServer/jsonFiles/route-to-test.json
@@ -1,0 +1,3 @@
+{
+  "status": "quite ok"
+}

--- a/packages/foundation/example/singleFileServer/index.ts
+++ b/packages/foundation/example/singleFileServer/index.ts
@@ -68,6 +68,7 @@ const openapiSchemaWithModificationsForSimulation = {
 
 export const simulation = createFoundationSimulationServer({
   port: 9999,
+  serveJsonFiles: `${__dirname}/jsonFiles`,
   openapi: [
     {
       document: [

--- a/packages/foundation/example/singleFileServer/jsonFiles/route-to-test.json
+++ b/packages/foundation/example/singleFileServer/jsonFiles/route-to-test.json
@@ -1,0 +1,3 @@
+{
+  "status": "quite ok"
+}

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "ajv-formats": "^3.0.1",
     "express": "^4.19.2",
+    "fdir": "^6.2.0",
     "openapi-backend": "^5.10.6",
     "openapi-merge": "^1.3.2",
     "starfx": "^0.12.0"


### PR DESCRIPTION
## Motivation

To best support incremental adoption, we can serve a folder of json files to allow for a quick starting point.

## Approach

Crawl a folder and `app.get` for each JSON file found.
