### PR TITLE
Add GitHub Api Simulator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Simulacrum removes these constraints from your process by allowing you to simula
 
 * [auth0](packages/auth0) - [@simulacrum/auth0-simulator](https://www.npmjs.com/package/@simulacrum/auth0-simulator)
 * [ldap](packages/ldap) - [@simulacrum/ldap-simulator](https://www.npmjs.com/package/@simulacrum/ldap-simulator)
+* [github-api](packages/github-api) - [@simulacrum/github-api-simulator](https://www.npmjs.com/package/@simulacrum/github-api-simulator)
 
 ## Usage
 


### PR DESCRIPTION
## Motivation

I sent the creator of http://metz.sh a link to this repo and realized that GitHub API simulator is not listed in the README.