### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/github-simulator-state-and-REST.md
+++ b/.changes/github-simulator-state-and-REST.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": minor:enhance
----
-
-Rebuilding on top of the foundation simulator to establish a mutable state. Also begin handling REST-based routes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9498,7 +9498,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.0]
+
+### Enhancements
+
+- [`7d39c71`](https://github.com/thefrontside/simulacrum/commit/7d39c71164bf42f3c0ca90a428ccf03532a40eb4) Rebuilding on top of the foundation simulator to establish a mutable state. Also begin handling REST-based routes.
+
 ## \[0.4.0]
 
 - [`955dd7f`](https://github.com/thefrontside/simulacrum/commit/955dd7f248f6f1352b6be10327dda48a0ffcea58)([#267](https://github.com/thefrontside/simulacrum/pull/267)) Adds the `repositoryOwner` resolver.

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/github-api-simulator

## [0.5.0]
### Enhancements

- 7d39c71 Rebuilding on top of the foundation simulator to establish a mutable state. Also begin handling REST-based routes.