### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/github-api-fix-bin.md
+++ b/.changes/github-api-fix-bin.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:bug
----
-
-The bin file was not specified so running with `npx` directly was broken.

--- a/.changes/react-dom-in-foundation.md
+++ b/.changes/react-dom-in-foundation.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": patch:bug
----
-
-Due to upstream dep requirements, the `react-redux` depends on `react-dom`. Including it as a dependency to resolve this issue, but we will work to remove it from the dependency chain as that code path is not utilized in this library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9356,7 +9356,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
@@ -9472,11 +9472,11 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.2.0",
+        "@simulacrum/foundation-simulator": "0.2.1",
         "assert-ts": "^0.3.4",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.4",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.2.1]
+
+### Bug Fixes
+
+- [`6a6fc71`](https://github.com/thefrontside/simulacrum/commit/6a6fc716cfdb7ae50baea6504e25c389acbeeb8f) Due to upstream dep requirements, the `react-redux` depends on `react-dom`. Including it as a dependency to resolve this issue, but we will work to remove it from the dependency chain as that code path is not utilized in this library.
+
 ## \[0.2.0]
 
 ### New Features

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.5.1]
+
+### Bug Fixes
+
+- [`2741f00`](https://github.com/thefrontside/simulacrum/commit/2741f00faef7d7ac0af317261699e7b98cf72300) The bin file was not specified so running with `npx` directly was broken.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.2.1`
+
 ## \[0.5.0]
 
 ### Enhancements

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "main": "dist/cjs/index.js",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "0.2.0",
+    "@simulacrum/foundation-simulator": "0.2.1",
     "assert-ts": "^0.3.4",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/foundation-simulator

## [0.2.1]
### Bug Fixes

- 6a6fc71 Due to upstream dep requirements, the `react-redux` depends on `react-dom`. Including it as a dependency to resolve this issue, but we will work to remove it from the dependency chain as that code path is not utilized in this library.



# @simulacrum/github-api-simulator

## [0.5.1]
### Bug Fixes

- 2741f00 The bin file was not specified so running with `npx` directly was broken.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.2.1`