### PR TITLE
foundation simulator validates response with OpenAPI schema

### DIFF
--- a/.changes/foundation-postresponse-validation.md
+++ b/.changes/foundation-postresponse-validation.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": minor:feat
+---
+
+Based on handler `return` versus `response.status().json()` and the new `verbose` option, log out or return 502 on failed validation of response data based on OpenAPI schema.

--- a/.changes/foundation-verbose-logging.md
+++ b/.changes/foundation-verbose-logging.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": minor:feat
+---
+
+Add `verbose` option to enable contextual logging for debugging purposes.

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -25,6 +25,7 @@
   ],
   "main": "dist/cjs/index.js",
   "exports": {
+    "development": "./src/index.ts",
     "default": "./dist/cjs/index.js"
   },
   "scripts": {


### PR DESCRIPTION
## Motivation

We want to be able to validate responses from a `handler` with our OpenAPI schema (if available). This enables it at the foundation, and can then be adopted by the GitHub API Simulator as well.

## Approach

Use their API to enable it. We have two main uses cases: using `verbose` to see logs, and sending a `502` with errors if the simulator hasn't already sent a response. A handler would need to `return { status: number, data: JSON }` instead of `response.send(number).json(data)` within the handler.

## Example

On validation failure, we might see a `502` with a response of something like:

```json
{
  "status": 502,
  "err": [
    {
      "instancePath": "",
      "schemaPath": "#/oneOf/0/type",
      "keyword": "type",
      "params": {
        "type": "array"
      },
      "message": "must be array"
    },
    {
      "instancePath": "",
      "schemaPath": "#/oneOf",
      "keyword": "oneOf",
      "params": {
        "passingSchemas": null
      },
      "message": "must match exactly one schema in oneOf"
    }
  ],
  "operation": {...}
}
```
