### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/foundation-postresponse-validation.md
+++ b/.changes/foundation-postresponse-validation.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:feat
----
-
-Based on handler `return` versus `response.status().json()` and the new `verbose` option, log out or return 502 on failed validation of response data based on OpenAPI schema.

--- a/.changes/foundation-verbose-logging.md
+++ b/.changes/foundation-verbose-logging.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:feat
----
-
-Add `verbose` option to enable contextual logging for debugging purposes.

--- a/.changes/validate-repo-returns.md
+++ b/.changes/validate-repo-returns.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:bug
----
-
-Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, `/repos/{org}/{repo}/branches`, `orgs/{org}/installation`, and `/repos/{owner}/{repo}/installation` when passing in `initialState`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9356,7 +9356,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
@@ -9472,11 +9472,11 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.2.1",
+        "@simulacrum/foundation-simulator": "0.3.0",
         "assert-ts": "^0.3.4",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.4",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.3.0]
+
+### New Features
+
+- [`07e0560`](https://github.com/thefrontside/simulacrum/commit/07e0560b3289a34dfc1a971aa983e16928cb64bc) Based on handler `return` versus `response.status().json()` and the new `verbose` option, log out or return 502 on failed validation of response data based on OpenAPI schema.
+- [`07e0560`](https://github.com/thefrontside/simulacrum/commit/07e0560b3289a34dfc1a971aa983e16928cb64bc) Add `verbose` option to enable contextual logging for debugging purposes.
+
 ## \[0.2.1]
 
 ### Bug Fixes

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.5.2]
+
+### Bug Fixes
+
+- [`85816d8`](https://github.com/thefrontside/simulacrum/commit/85816d831839a1f525415adc9a24bad4eebd88b5) Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, `/repos/{org}/{repo}/branches`, `orgs/{org}/installation`, and `/repos/{owner}/{repo}/installation` when passing in `initialState`.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.3.0`
+
 ## \[0.5.1]
 
 ### Bug Fixes

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "0.2.1",
+    "@simulacrum/foundation-simulator": "0.3.0",
     "assert-ts": "^0.3.4",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/foundation-simulator

## [0.3.0]
### New Features

- 07e0560 Based on handler `return` versus `response.status().json()` and the new `verbose` option, log out or return 502 on failed validation of response data based on OpenAPI schema.
- 07e0560 Add `verbose` option to enable contextual logging for debugging purposes.



# @simulacrum/github-api-simulator

## [0.5.2]
### Bug Fixes

- 85816d8 Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, `/repos/{org}/{repo}/branches`, `orgs/{org}/installation`, and `/repos/{owner}/{repo}/installation` when passing in `initialState`.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.3.0`