### PR TITLE
validate and fix repo endpoint responses

### DIFF
--- a/.changes/validate-repo-returns.md
+++ b/.changes/validate-repo-returns.md
@@ -2,4 +2,4 @@
 "@simulacrum/github-api-simulator": patch:bug
 ---
 
-Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, and `/repos/{org}/{repo}/branches` when passing in `initialState`.
+Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, `/repos/{org}/{repo}/branches`, `orgs/{org}/installation`, and `/repos/{owner}/{repo}/installation` when passing in `initialState`.

--- a/.changes/validate-repo-returns.md
+++ b/.changes/validate-repo-returns.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch:bug
+---
+
+Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, and `/repos/{org}/{repo}/branches` when passing in `initialState`.

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -273,23 +273,30 @@ export function createFoundationSimulationServer<
             _req: ExpressRequest,
             res: ExpressResponse
           ) => {
-            const valid = c.api.validateResponse(c.response, c.operation);
-            if (valid.errors) {
-              if (verbose)
-                console.dir(
-                  { errors: valid.errors, operation: c.operation },
-                  { depth: 10 }
-                );
+            if (c?.response?.json) {
+              const valid = c.api.validateResponse(
+                c.response.json,
+                c.operation,
+                c.response.status
+              );
+              if (valid.errors) {
+                if (verbose)
+                  console.dir(
+                    { errors: valid.errors, operation: c.operation },
+                    { depth: 10 }
+                  );
 
-              if (!res.headersSent)
-                res.status(502).json({
-                  status: 502,
-                  err: valid.errors,
-                  operation: c.operation,
-                });
-            } else {
-              if (!res.headersSent)
-                res.status(c.response.status).json(c.response.json);
+                if (!res.headersSent)
+                  res.status(502).json({
+                    status: 502,
+                    err: valid.errors,
+                    response: c.response,
+                    operation: c.operation,
+                  });
+              } else {
+                if (!res.headersSent)
+                  res.status(c.response.status).json(c.response.json);
+              }
             }
           },
         });

--- a/packages/github-api/README.md
+++ b/packages/github-api/README.md
@@ -19,7 +19,7 @@ It is built on `@simulaction/foundation-simulator` where we can pull in the GH O
 It may be run directly from the `bin` script.
 
 ```shell
-npx @simulacrum/foundation-simulator
+npx @simulacrum/github-api-simulator
 ```
 
 If you need deeper control and want to input data, import the server and run it with a Nodejs script. It exports a named function, `simulation`, which you may use to start the server.

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -3,11 +3,7 @@
   "version": "0.5.1",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
-  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thefrontside/simulacrum.git",

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -7,14 +7,16 @@
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/thefrontside/simulacrum.git",
     "directory": "packages/github-api"
   },
   "files": [
-    "dist",
     "README.md",
+    "dist",
+    "src",
     "schema",
     "repository-mock-data"
   ],
@@ -50,14 +52,9 @@
     "typescript": "^5.4.5"
   },
   "exports": {
-    "development": "./src/index.ts",
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    },
-    "./main": {
-      "import": "./dist/esm/main.js",
-      "require": "./dist/cjs/main.js"
     },
     "./github-topics.json": {
       "import": "./repository-mock-data/github-topics.json",
@@ -66,7 +63,8 @@
     "./repository-names.json": {
       "import": "./repository-mock-data/github-topics.json",
       "require": "./repository-mock-data/repository-names.json"
-    }
+    },
+    "development": "./src/index.ts"
   },
   "typesVersions": {
     "*": {

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -28,7 +28,9 @@
     "start": "node --import=tsx ./example/start.ts",
     "start:bin": "node ./bin/start.js",
     "generate": "graphql-codegen",
-    "test": "echo not.....yet"
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "bench": "vitest bench"
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
@@ -48,6 +50,7 @@
     "typescript": "^5.4.5"
   },
   "exports": {
+    "development": "./src/index.ts",
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -52,9 +52,17 @@
     "typescript": "^5.4.5"
   },
   "exports": {
-    "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "development": "./src/index.ts"
+    "exports": {
+      "import": {
+        "types": "./dist/cjs/index.d.ts",
+        "development": "./src/index.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
   },
   "typesVersions": {
     "*": {

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -48,16 +48,14 @@
     "typescript": "^5.4.5"
   },
   "exports": {
-    "exports": {
-      "import": {
-        "types": "./dist/cjs/index.d.ts",
-        "development": "./src/index.ts",
-        "default": "./dist/cjs/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
-      }
+    "import": {
+      "types": "./dist/esm/index.d.ts",
+      "development": "./src/index.ts",
+      "default": "./dist/esm/index.js"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
     }
   },
   "typesVersions": {

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -52,18 +52,8 @@
     "typescript": "^5.4.5"
   },
   "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./github-topics.json": {
-      "import": "./repository-mock-data/github-topics.json",
-      "require": "./repository-mock-data/github-topics.json"
-    },
-    "./repository-names.json": {
-      "import": "./repository-mock-data/github-topics.json",
-      "require": "./repository-mock-data/repository-names.json"
-    },
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js",
     "development": "./src/index.ts"
   },
   "typesVersions": {

--- a/packages/github-api/src/index.ts
+++ b/packages/github-api/src/index.ts
@@ -42,5 +42,6 @@ export {
   githubUserSchema,
   githubOrganizationSchema,
   githubRepositorySchema,
+  githubBranchSchema,
   githubBlobSchema,
 } from "./store/entities";

--- a/packages/github-api/src/rest/index.ts
+++ b/packages/github-api/src/rest/index.ts
@@ -56,10 +56,10 @@ const handlers =
       },
       // GET /repos/{owner}/{repo}/installation - Get a repository installation for the authenticated app
       "apps/get-repo-installation": async (context, _request, response) => {
-        const { org } = context.request.params;
+        const { owner } = context.request.params;
         const install = simulationStore.selectors.getAppInstallation(
           simulationStore.store.getState(),
-          org
+          owner
         );
         return { status: 200, json: install };
       },

--- a/packages/github-api/src/rest/index.ts
+++ b/packages/github-api/src/rest/index.ts
@@ -14,11 +14,10 @@ const handlers =
   ) =>
   (simulationStore: ExtendedSimulationStore): SimulationHandlers => {
     if (!initialState) return {};
-    // L# refer to openapi spec json files
     // note for any cases where it `return`s an object,
     //  that will validate the response per the schema
     return {
-      // L#61612 /user/installations
+      // GET /user/installations
       "apps/list-installations": async (_context, _request, response) => {
         const ghOrgs = simulationStore.selectors.allGithubOrganizations(
           simulationStore.store.getState()
@@ -46,8 +45,26 @@ const handlers =
           },
         };
       },
+      // GET /orgs/{org}/installation - Get an organization installation for the authenticated app
+      "apps/get-org-installation": async (context, _request, response) => {
+        const { org } = context.request.params;
+        const install = simulationStore.selectors.getAppInstallation(
+          simulationStore.store.getState(),
+          org
+        );
+        return { status: 200, json: install };
+      },
+      // GET /repos/{owner}/{repo}/installation - Get a repository installation for the authenticated app
+      "apps/get-repo-installation": async (context, _request, response) => {
+        const { org } = context.request.params;
+        const install = simulationStore.selectors.getAppInstallation(
+          simulationStore.store.getState(),
+          org
+        );
+        return { status: 200, json: install };
+      },
 
-      // L#18386 /orgs/{org}/repos
+      // GET /orgs/{org}/repos
       "repos/list-for-org": async (_context, _request, response) => {
         const repos = simulationStore.selectors.allReposWithOrgs(
           simulationStore.store.getState()
@@ -61,7 +78,7 @@ const handlers =
         );
         return { status: 200, json: branches };
       },
-      // L#36879 /repos/{owner}/{repo}/commits/{ref}/status
+      // GET /repos/{owner}/{repo}/commits/{ref}/status
       "repos/get-combined-status-for-ref": async (
         _context,
         request,
@@ -76,7 +93,7 @@ const handlers =
         });
         response.status(200).json(commitStatus);
       },
-      // L#37116 /repos/{owner}/{repo}/contents/{path}
+      // GET /repos/{owner}/{repo}/contents/{path}
       "repos/get-content": async (context, request, response) => {
         const { owner, repo, path } = context.request.params;
         const blob = simulationStore.selectors.getBlob(
@@ -98,7 +115,7 @@ const handlers =
           response.status(200).json(data);
         }
       },
-      // L#40919 /repos/{owner}/{repo}/git/blobs/{file_sha}
+      // GET /repos/{owner}/{repo}/git/blobs/{file_sha}
       "git/get-blob": async (context, request, response) => {
         const { owner, repo, file_sha } = context.request.params;
         const blob = simulationStore.selectors.getBlob(
@@ -120,7 +137,7 @@ const handlers =
           response.status(200).json(data);
         }
       },
-      // L#41860 /repos/{owner}/{repo}/git/trees/{tree_sha}
+      // GET /repos/{owner}/{repo}/git/trees/{tree_sha}
       "git/get-tree": async (_context, request, response) => {
         const { owner, repo, ref } = request.params;
         const blobs = simulationStore.selectors.getBlobAtOwnerRepo(
@@ -142,7 +159,7 @@ const handlers =
         }
       },
 
-      // L#58975 /user
+      // GET /user
       "users/get-authenticated": async (_context, _request, response) => {
         const users = simulationStore.schema.users.selectTableAsList(
           simulationStore.store.getState()
@@ -157,7 +174,7 @@ const handlers =
         response.status(200).json(data);
       },
 
-      // L#62462 /user/memberships/orgs
+      // GET /user/memberships/orgs
       "orgs/list-memberships-for-authenticated-user": async (
         _context,
         _request,

--- a/packages/github-api/src/store/entities.ts
+++ b/packages/github-api/src/store/entities.ts
@@ -21,40 +21,281 @@ export type GitHubUser = z.infer<typeof githubUserSchema>;
 
 export const githubRepositorySchema = z
   .object({
-    id: z.string().or(z.number()).default(""),
+    id: z.number().optional(),
+    node_id: z.string().optional(),
     name: z.string(),
+    description: z
+      .string()
+      .optional()
+      .default("Generic repository description"),
     owner: z.string(),
     full_name: z.string().optional().default(""),
     packages: z.array(z.string()).optional(),
+
+    pushed_at: z
+      .string()
+      .optional()
+      .default(() => faker.date.recent().toISOString()),
+    updated_at: z
+      .string()
+      .optional()
+      .default(() => faker.date.recent().toISOString()),
+    created_at: z
+      .string()
+      .optional()
+      .default(() => faker.date.recent().toISOString()),
+
+    url: z.string().optional(),
+    html_url: z.string().optional(),
+    archive_url: z.string().optional(),
+    assignees_url: z.string().optional(),
+    blobs_url: z.string().optional(),
+    branches_url: z.string().optional(),
+    collaborators_url: z.string().optional(),
+    comments_url: z.string().optional(),
+    commits_url: z.string().optional(),
+    compare_url: z.string().optional(),
+    contents_url: z.string().optional(),
+    contributors_url: z.string().optional(),
+    deployments_url: z.string().optional(),
+    downloads_url: z.string().optional(),
+    events_url: z.string().optional(),
+    forks_url: z.string().optional(),
+    git_commits_url: z.string().optional(),
+    git_refs_url: z.string().optional(),
+    git_tags_url: z.string().optional(),
+    git_url: z.string().optional(),
+    issue_comment_url: z.string().optional(),
+    issue_events_url: z.string().optional(),
+    issues_url: z.string().optional(),
+    keys_url: z.string().optional(),
+    labels_url: z.string().optional(),
+    languages_url: z.string().optional(),
+    merges_url: z.string().optional(),
+    milestones_url: z.string().optional(),
+    notifications_url: z.string().optional(),
+    pulls_url: z.string().optional(),
+    releases_url: z.string().optional(),
+    ssh_url: z.string().optional(),
+    stargazers_url: z.string().optional(),
+    statuses_url: z.string().optional(),
+    subscribers_url: z.string().optional(),
+    subscription_url: z.string().optional(),
+    tags_url: z.string().optional(),
+    teams_url: z.string().optional(),
+    trees_url: z.string().optional(),
+    clone_url: z.string().optional(),
+    mirror_url: z.string().optional(),
+    hooks_url: z.string().optional(),
+    svn_url: z.string().optional(),
+
+    homepage: z.string().optional(),
+    language: z.nullable(z.string()).optional().default(null),
+    default_branch: z.string().optional().default("main"),
+    visibility: z.enum(["public", "private"]).default("public"),
+    private: z.boolean().optional().default(false),
+    license: z.nullable(z.record(z.string(), z.string())).default(null),
+    fork: z.boolean().optional().default(false),
+    topics: z.array(z.string()).optional().default([]),
+
+    is_template: z.boolean().optional().default(false),
+    has_issues: z.boolean().optional().default(true),
+    has_projects: z.boolean().optional().default(true),
+    has_wiki: z.boolean().optional().default(true),
+    has_pages: z.boolean().optional().default(false),
+    has_downloads: z.boolean().optional().default(true),
+    has_discussions: z.boolean().optional().default(false),
+    archived: z.boolean().optional().default(false),
+    disabled: z.boolean().optional().default(false),
+
+    forks_count: z.number().optional().default(9001),
+    forks: z.number().optional().default(9001),
+    stargazers_count: z.number().optional().default(9001),
+    stargazers: z.number().optional().default(9001),
+    watchers_count: z.number().optional().default(9001),
+    watchers: z.number().optional().default(9001),
+    size: z.number().optional().default(9001),
+    open_issues_count: z.number().optional().default(9001),
+    open_issues: z.number().optional().default(9001),
+
+    permissions: z
+      .object({
+        admin: z.boolean().optional().default(false),
+        push: z.boolean().optional().default(false),
+        pull: z.boolean().optional().default(true),
+      })
+      .optional()
+      .default({ admin: false, push: false, pull: true }),
+
+    security_and_analysis: z
+      .object({
+        advanced_security: z
+          .object({ status: z.string() })
+          .optional()
+          .default({ status: "enabled" }),
+        secret_scanning: z
+          .object({ status: z.string() })
+          .optional()
+          .default({ status: "enabled" }),
+        secret_scanning_push_protection: z
+          .object({ status: z.string() })
+          .optional()
+          .default({ status: "enabled" }),
+        secret_scanning_non_provider_patterns: z
+          .object({ status: z.string() })
+          .optional()
+          .default({ status: "enabled" }),
+      })
+      .optional()
+      .default({
+        advanced_security: {
+          status: "enabled",
+        },
+        secret_scanning: {
+          status: "enabled",
+        },
+        secret_scanning_push_protection: {
+          status: "disabled",
+        },
+        secret_scanning_non_provider_patterns: {
+          status: "disabled",
+        },
+      }),
   })
   .transform((repo) => {
-    repo.id = repo.name;
+    repo.id = faker.number.int();
+    repo.node_id = repo.name;
     repo.full_name = `${repo.owner}/${repo.name}`;
+
+    const host = "localhost:3300";
+    repo.url = `http://${host}/repos/octocat/Hello-World`;
+    repo.html_url = `http://${host}/repos/octocat/Hello-World`;
+    repo.archive_url = `http://${host}/repos/octocat/Hello-World/{archive_format}{/ref}`;
+    repo.assignees_url = `http://${host}/repos/octocat/Hello-World/assignees{/user}`;
+    repo.blobs_url = `http://${host}/repos/octocat/Hello-World/git/blobs{/sha}`;
+    repo.branches_url = `http://${host}/repos/octocat/Hello-World/branches{/branch}`;
+    repo.collaborators_url = `http://${host}/repos/octocat/Hello-World/collaborators{/collaborator}`;
+    repo.comments_url = `http://${host}/repos/octocat/Hello-World/comments{/number}`;
+    repo.commits_url = `http://${host}/repos/octocat/Hello-World/commits{/sha}`;
+    repo.compare_url = `http://${host}/repos/octocat/Hello-World/compare/{base}...{head}`;
+    repo.contents_url = `http://${host}/repos/octocat/Hello-World/contents/{+path}`;
+    repo.contributors_url = `http://${host}/repos/octocat/Hello-World/contributors`;
+    repo.deployments_url = `http://${host}/repos/octocat/Hello-World/deployments`;
+    repo.downloads_url = `http://${host}/repos/octocat/Hello-World/downloads`;
+    repo.events_url = `http://${host}/repos/octocat/Hello-World/events`;
+    repo.forks_url = `http://${host}/repos/octocat/Hello-World/forks`;
+    repo.git_commits_url = `http://${host}/repos/octocat/Hello-World/git/commits{/sha}`;
+    repo.git_refs_url = `http://${host}/repos/octocat/Hello-World/git/refs{/sha}`;
+    repo.git_tags_url = `http://${host}/repos/octocat/Hello-World/git/tags{/sha}`;
+    repo.git_url = `git:github.com/octocat/Hello-World.git`;
+    repo.issue_comment_url = `http://${host}/repos/octocat/Hello-World/issues/comments{/number}`;
+    repo.issue_events_url = `http://${host}/repos/octocat/Hello-World/issues/events{/number}`;
+    repo.issues_url = `http://${host}/repos/octocat/Hello-World/issues{/number}`;
+    repo.keys_url = `http://${host}/repos/octocat/Hello-World/keys{/key_id}`;
+    repo.labels_url = `http://${host}/repos/octocat/Hello-World/labels{/name}`;
+    repo.languages_url = `http://${host}/repos/octocat/Hello-World/languages`;
+    repo.merges_url = `http://${host}/repos/octocat/Hello-World/merges`;
+    repo.milestones_url = `http://${host}/repos/octocat/Hello-World/milestones{/number}`;
+    repo.notifications_url = `http://${host}/repos/octocat/Hello-World/notifications{?since,all,participating}`;
+    repo.pulls_url = `http://${host}/repos/octocat/Hello-World/pulls{/number}`;
+    repo.releases_url = `http://${host}/repos/octocat/Hello-World/releases{/id}`;
+    repo.ssh_url = `git@github.com:octocat/Hello-World.git`;
+    repo.stargazers_url = `http://${host}/repos/octocat/Hello-World/stargazers`;
+    repo.statuses_url = `http://${host}/repos/octocat/Hello-World/statuses/{sha}`;
+    repo.subscribers_url = `http://${host}/repos/octocat/Hello-World/subscribers`;
+    repo.subscription_url = `http://${host}/repos/octocat/Hello-World/subscription`;
+    repo.tags_url = `http://${host}/repos/octocat/Hello-World/tags`;
+    repo.teams_url = `http://${host}/repos/octocat/Hello-World/teams`;
+    repo.trees_url = `http://${host}/repos/octocat/Hello-World/git/trees{/sha}`;
+    repo.clone_url = `http://github.com/octocat/Hello-World.git`;
+    repo.mirror_url = `git:git.example.com/octocat/Hello-World`;
+    repo.hooks_url = `http://${host}/repos/octocat/Hello-World/hooks`;
+    repo.svn_url = `http://svn.github.com/octocat/Hello-World`;
+
+    repo.homepage = `http://${host}`;
+    repo.topics = ["octocat", "atom", "electron", "api"];
+
     return repo;
   });
 export type GitHubRepository = z.infer<typeof githubRepositorySchema>;
 
+export const githubBranchSchema = z.object({
+  name: z.string().optional().default("main"),
+  commit: z
+    .object({ sha: z.string().optional(), url: z.string().optional() })
+    .default({
+      sha: faker.git.commitSha(),
+      // @ts-expect-error
+      url: `https://api.github.com/repos/octocat/Hello-World/commits/${this?.sha}`,
+    }),
+  protected: z.boolean().optional().default(true),
+  protection: z.any().optional(),
+  protection_url: z
+    .string()
+    .optional()
+    .default(
+      "https://api.github.com/repos/octocat/hello-world/branches/master/protection"
+    ),
+});
+export type GitHubBranch = z.infer<typeof githubBranchSchema>;
+
 export const githubOrganizationSchema = z
   .object({
-    id: z.string().or(z.number()).default(""),
+    id: z.number().optional(),
     login: z.string(),
     name: z.string().optional(),
     email: z.string().optional(),
+    node_id: z.string().optional(),
+    type: z.enum(["User", "Organization"]).default("Organization"),
     description: z.string().optional(),
     created_at: z
       .string()
       .default(() => faker.date.recent().toISOString())
       .optional(),
+
     teams: z.union([z.array(z.string()), z.undefined()]),
+    avatar_url: z
+      .string()
+      .optional()
+      .default("https://github.com/images/error/octocat_happy.gif"),
+    gravatar_id: z.string().optional().default(""),
+    site_admin: z.boolean().optional().default(true),
+    url: z.string().optional(),
+    html_url: z.string().optional(),
+    followers_url: z.string().optional(),
+    following_url: z.string().optional(),
+    gists_url: z.string().optional(),
+    starred_url: z.string().optional(),
+    subscriptions_url: z.string().optional(),
+    organizations_url: z.string().optional(),
+    repos_url: z.string().optional(),
+    events_url: z.string().optional(),
+    received_events_url: z.string().optional(),
   })
   .transform((org) => {
-    org.id = org.login;
+    org.id = faker.number.int();
     if (!org?.name) org.name = org.login;
     if (!org.email)
       org.email = faker.internet.email({
         firstName: "org",
         lastName: org.login,
       });
+
+    const host = "localhost:3300";
+    org.url = `https://${host}/users/octocat`;
+    org.html_url = `https://github.com/octocat`;
+    org.followers_url = `https://${host}/users/octocat/followers`;
+    org.following_url = `https://${host}/users/octocat/following{/other_user}`;
+    org.gists_url = `https://${host}/users/octocat/gists{/gist_id}`;
+    org.starred_url = `https://${host}/users/octocat/starred{/owner}{/repo}`;
+    org.subscriptions_url = `https://${host}/users/octocat/subscriptions`;
+    org.organizations_url = `https://${host}/users/octocat/orgs`;
+    org.repos_url = `https://${host}/users/octocat/repos`;
+    org.events_url = `https://${host}/users/octocat/events{/privacy}`;
+    org.received_events_url = `https://${host}/users/octocat/received_events`;
+
+    org.node_id = "MDQ6VXNlcjE=";
+
     return org;
   });
 export type GitHubOrganization = z.infer<typeof githubOrganizationSchema>;
@@ -89,17 +330,19 @@ export type GitHubBlob = z.infer<typeof githubBlobSchema>;
 export const gitubInitialStoreSchema = z.object({
   users: z.array(githubUserSchema),
   repositories: z.array(githubRepositorySchema),
+  branches: z.array(githubBranchSchema),
   organizations: z.array(githubOrganizationSchema),
   blobs: z.array(githubBlobSchema),
 });
 export type GitHubStore = z.output<typeof gitubInitialStoreSchema>;
 export type GitHubInitialStore = z.input<typeof gitubInitialStoreSchema>;
 
-export const convertToObj = <T extends { id: IdProp; [k: string]: any }>(
-  arrayOfObjects: T[]
+export const convertToObj = <T extends { [k: string]: any }>(
+  arrayOfObjects: T[],
+  key: IdProp = "id"
 ): Record<IdProp, T> =>
   arrayOfObjects.reduce((final, obj: T) => {
-    final[obj.id] = obj;
+    final[obj[key]] = obj;
     return final;
   }, {} as Record<IdProp, T>);
 
@@ -109,9 +352,10 @@ export const convertInitialStateToStoreState = (
   if (!initialState) return undefined;
   // TODO try to make this generic?
   const storeObject = {
-    users: convertToObj(initialState.users),
-    repositories: convertToObj(initialState.repositories),
-    organizations: convertToObj(initialState.organizations),
+    users: convertToObj(initialState.users, "login"),
+    repositories: convertToObj(initialState.repositories, "name"),
+    branches: convertToObj(initialState.branches, "name"),
+    organizations: convertToObj(initialState.organizations, "login"),
     blobs: convertToObj(initialState.blobs),
   };
 

--- a/packages/github-api/tests/installations.test.ts
+++ b/packages/github-api/tests/installations.test.ts
@@ -34,11 +34,10 @@ describe.sequential("GET repo endpoints", () => {
     });
   });
 
-  describe.only("/orgs/{org}/installation", () => {
+  describe("/orgs/{org}/installation", () => {
     it("validates with 200 response", async () => {
       let request = await fetch(`${url}/orgs/lovely-org/installation`);
       let response = await request.json();
-      if (request.status === 502) console.dir(response, { depth: 8 });
       expect(request.status).toEqual(200);
       expect(response).toEqual(
         expect.objectContaining({
@@ -56,9 +55,11 @@ describe.sequential("GET repo endpoints", () => {
       let response = await request.json();
       if (request.status === 502) console.dir(response);
       expect(request.status).toEqual(200);
-      expect(response.repositories).toEqual([
-        expect.objectContaining({ name: "awesome-repo" }),
-      ]);
+      expect(response).toEqual(
+        expect.objectContaining({
+          account: expect.objectContaining({ login: "lovely-org" }),
+        })
+      );
     });
   });
 });

--- a/packages/github-api/tests/installations.test.ts
+++ b/packages/github-api/tests/installations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { simulation } from "../src/index";
 
-let basePort = 3301;
+let basePort = 3302;
 let host = "http://localhost";
 let url = `${host}:${basePort}/api/v3`;
 
@@ -23,25 +23,42 @@ describe.sequential("GET repo endpoints", () => {
     await server.ensureClose();
   });
 
-  describe("/orgs/{org}/repos", () => {
+  describe("/installation/repositories", () => {
     it("validates with 200 response", async () => {
-      let request = await fetch(`${url}/orgs/lovel-org/repos`);
+      let request = await fetch(`${url}/installation/repositories`);
       let response = await request.json();
       expect(request.status).toEqual(200);
-      expect(response).toEqual([
+      expect(response.repositories).toEqual([
         expect.objectContaining({ name: "awesome-repo" }),
       ]);
     });
   });
 
-  describe("/repos/{org}/{repo}/branches", () => {
+  describe.only("/orgs/{org}/installation", () => {
+    it("validates with 200 response", async () => {
+      let request = await fetch(`${url}/orgs/lovely-org/installation`);
+      let response = await request.json();
+      if (request.status === 502) console.dir(response, { depth: 8 });
+      expect(request.status).toEqual(200);
+      expect(response).toEqual(
+        expect.objectContaining({
+          account: expect.objectContaining({ login: "lovely-org" }),
+        })
+      );
+    });
+  });
+
+  describe("/repos/{owner}/{repo}/installation", () => {
     it("validates with 200 response", async () => {
       let request = await fetch(
-        `${url}/repos/lovely-org/awesome-repo/branches`
+        `${url}/repos/lovely-org/awesome-repo/installation`
       );
       let response = await request.json();
+      if (request.status === 502) console.dir(response);
       expect(request.status).toEqual(200);
-      expect(response).toEqual([expect.objectContaining({ name: "main" })]);
+      expect(response.repositories).toEqual([
+        expect.objectContaining({ name: "awesome-repo" }),
+      ]);
     });
   });
 });

--- a/packages/github-api/tests/repositories.test.ts
+++ b/packages/github-api/tests/repositories.test.ts
@@ -5,7 +5,7 @@ let basePort = 3300;
 let host = "http://localhost";
 let url = `${host}:${basePort}/api/v3`;
 
-describe.sequential("extensive server - start once", () => {
+describe.sequential("GET repo endpoints", () => {
   let server;
   beforeAll(async () => {
     let app = simulation({

--- a/packages/github-api/tests/repositories.test.ts
+++ b/packages/github-api/tests/repositories.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { simulation } from "../src/index";
+
+let basePort = 3300;
+let host = "http://localhost";
+let url = `${host}:${basePort}/api/v3`;
+
+describe.sequential("extensive server - start once", () => {
+  let server;
+  beforeAll(async () => {
+    let app = simulation({
+      initialState: {
+        users: [],
+        organizations: [{ login: "lovely-org" }],
+        repositories: [{ owner: "lovely-org", name: "awesome-repo" }],
+        branches: [{ name: "main" }],
+        blobs: [],
+      },
+    });
+    server = await app.listen(basePort);
+  });
+  afterAll(async () => {
+    await server.ensureClose();
+  });
+
+  describe("/installation/repositories", () => {
+    it("validates with 200 response", async () => {
+      let request = await fetch(`${url}/installation/repositories`);
+      let response = await request.json();
+      expect(request.status).toEqual(200);
+      expect(response.repositories).toEqual([
+        expect.objectContaining({ name: "awesome-repo" }),
+      ]);
+    });
+  });
+
+  describe("/orgs/{org}/repos", () => {
+    it("validates with 200 response", async () => {
+      let request = await fetch(`${url}/orgs/lovel-org/repos`);
+      let response = await request.json();
+      expect(request.status).toEqual(200);
+      expect(response).toEqual([
+        expect.objectContaining({ name: "awesome-repo" }),
+      ]);
+    });
+  });
+
+  describe("/repos/{org}/{repo}/branches", () => {
+    it("validates with 200 response", async () => {
+      let request = await fetch(
+        `${url}/repos/lovely-org/awesome-repo/branches`
+      );
+      let response = await request.json();
+      expect(request.status).toEqual(200);
+      expect(response).toEqual([expect.objectContaining({ name: "main" })]);
+    });
+  });
+});

--- a/packages/github-api/tsconfig.dist.json
+++ b/packages/github-api/tsconfig.dist.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "rootDir": "src",
-    "noEmit": false
+    "rootDir": "src"
   },
   "exclude": ["test"]
 }

--- a/packages/github-api/tsconfig.dist.json
+++ b/packages/github-api/tsconfig.dist.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noEmit": false
   },
   "exclude": ["test"]
 }

--- a/packages/github-api/tsconfig.esm.json
+++ b/packages/github-api/tsconfig.esm.json
@@ -4,8 +4,7 @@
     "outDir": "dist/esm",
     "rootDir": "src",
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node"
+    "module": "ESNext"
   },
   "exclude": ["test"]
 }


### PR DESCRIPTION
## Motivation

Validate and correct responses with OpenAPI specification for `/installation/repositories`, `/orgs/{org}/repos`, and `/repos/{org}/{repo}/branches` when passing in `initialState`. It wasn't returning the full response per the OpenAPI spec.

## Approach

- Use the new option on the foundation simulator to validate the response.
- Filled out the Zod schema to properly fill in all of the required data for these responses
