### PR TITLE
handle dynamic schema with hosted default

### DIFF
--- a/.changes/handle-dynamic-schema.md
+++ b/.changes/handle-dynamic-schema.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": patch:bug
+---
+
+_Possibly breaking_ We incorrectly used the hosted schema with an Enterprise endpoint. Correcting this to default to the hosted endpoint with the hosted schema. Use `apiUrl` and `apiSchema` if there is need to adjust for Enterprise use cases.

--- a/.changes/handle-dynamic-schema.md
+++ b/.changes/handle-dynamic-schema.md
@@ -1,5 +1,5 @@
 ---
-"@simulacrum/foundation-simulator": patch:bug
+"@simulacrum/github-api-simulator": patch:bug
 ---
 
 _Possibly breaking_ We incorrectly used the hosted schema with an Enterprise endpoint. Correcting this to default to the hosted endpoint with the hosted schema. Use `apiUrl` and `apiSchema` if there is need to adjust for Enterprise use cases.

--- a/packages/github-api/src/index.ts
+++ b/packages/github-api/src/index.ts
@@ -10,12 +10,17 @@ import {
   type GitHubInitialStore,
   gitubInitialStoreSchema,
 } from "./store/entities";
+import type { SchemaFile } from "./utils";
 
 export type GitHubSimulator = ({
   initialState,
+  apiUrl,
+  apiSchema,
   extend,
 }?: {
   initialState?: GitHubInitialStore;
+  apiUrl?: string;
+  apiSchema?: SchemaFile | string;
   extend?: {
     extendStore?: SimulationInput["extendStore"];
     openapiHandlers?: (
@@ -34,7 +39,12 @@ export const simulation: GitHubSimulator = (args = {}) => {
     port: 3300, // default port
     extendStore: extendStore(parsedInitialState, args?.extend?.extendStore),
     extendRouter,
-    openapi: openapi(parsedInitialState, args?.extend?.openapiHandlers),
+    openapi: openapi(
+      parsedInitialState,
+      args?.apiUrl ?? "/",
+      args?.apiSchema ?? "api.github.com.json",
+      args?.extend?.openapiHandlers
+    ),
   })();
 };
 

--- a/packages/github-api/src/rest/index.ts
+++ b/packages/github-api/src/rest/index.ts
@@ -1,9 +1,7 @@
 import type { SimulationHandlers } from "@simulacrum/foundation-simulator";
 import type { ExtendedSimulationStore } from "../store";
-import { getSchema } from "../utils";
+import { getSchema, type SchemaFile } from "../utils";
 import { blobAsBase64, commitStatusResponse, gitTrees } from "./utils";
-
-let document = getSchema("api.github.com.json");
 
 const handlers =
   (
@@ -192,14 +190,16 @@ const handlers =
 
 export const openapi = (
   initialState: Record<string, any> | undefined,
+  apiRoot: string,
+  apiSchema: SchemaFile | string,
   openapiHandlers:
     | ((simulationStore: ExtendedSimulationStore) => SimulationHandlers)
     | undefined
 ) => [
   {
-    document,
+    document: getSchema(apiSchema),
     handlers: handlers(initialState, openapiHandlers),
-    apiRoot: "/api/v3",
+    apiRoot,
     additionalOptions: {
       // starts up quicker and avoids the precompile step which throws a ton of errors
       //  based on openapi-backend handling of GitHub schema

--- a/packages/github-api/src/utils.ts
+++ b/packages/github-api/src/utils.ts
@@ -1,22 +1,24 @@
 import path from "path";
 import fs from "fs";
 
-type SchemaFile =
-  | "schema.docs-enterprise.graphql"
-  | "schema.docs.graphql"
-  | "api.github.com.json";
+const schemaDefaults = [
+  "schema.docs-enterprise.graphql",
+  "schema.docs.graphql",
+  "api.github.com.json",
+] as const;
+export type SchemaFile = (typeof schemaDefaults)[number];
 
-export function getSchema(schemaFile: SchemaFile) {
+export function getSchema(schemaFile: SchemaFile | string) {
   let root = path.join(__dirname, "..").endsWith("dist")
     ? path.join(__dirname, "..", "..")
     : path.join(__dirname, "..");
 
   const fileString = fs.readFileSync(
-    path.join(root, "schema", schemaFile),
+    (schemaDefaults as unknown as string[]).includes(schemaFile)
+      ? path.join(root, "schema", schemaFile)
+      : schemaFile,
     "utf-8"
   );
 
-  return schemaFile === "api.github.com.json"
-    ? JSON.parse(fileString)
-    : fileString;
+  return schemaFile.endsWith(".json") ? JSON.parse(fileString) : fileString;
 }

--- a/packages/github-api/tests/installations.test.ts
+++ b/packages/github-api/tests/installations.test.ts
@@ -3,7 +3,7 @@ import { simulation } from "../src/index";
 
 let basePort = 3302;
 let host = "http://localhost";
-let url = `${host}:${basePort}/api/v3`;
+let url = `${host}:${basePort}`;
 
 describe.sequential("GET repo endpoints", () => {
   let server;

--- a/packages/github-api/tests/repositories.test.ts
+++ b/packages/github-api/tests/repositories.test.ts
@@ -3,7 +3,7 @@ import { simulation } from "../src/index";
 
 let basePort = 3301;
 let host = "http://localhost";
-let url = `${host}:${basePort}/api/v3`;
+let url = `${host}:${basePort}`;
 
 describe.sequential("GET repo endpoints", () => {
   let server;


### PR DESCRIPTION
## Motivation

We incorrectly used the hosted schema with an Enterprise endpoint. Correcting this to default to the hosted endpoint with the hosted schema. Use `apiUrl` and `apiSchema` if there is need to adjust for Enterprise use cases.

## Approach

Supply defaults which target a hosted version but allow passing more custom options. This supports enterprise and possibly targeting different versions of the schema.


