### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/handle-dynamic-schema.md
+++ b/.changes/handle-dynamic-schema.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:bug
----
-
-_Possibly breaking_ We incorrectly used the hosted schema with an Enterprise endpoint. Correcting this to default to the hosted endpoint with the hosted schema. Use `apiUrl` and `apiSchema` if there is need to adjust for Enterprise use cases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9472,7 +9472,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.3]
+
+### Bug Fixes
+
+- [`e565f7b`](https://github.com/thefrontside/simulacrum/commit/e565f7b9f32390cd18d38001650a9e4c757fd608) *Possibly breaking* We incorrectly used the hosted schema with an Enterprise endpoint. Correcting this to default to the hosted endpoint with the hosted schema. Use `apiUrl` and `apiSchema` if there is need to adjust for Enterprise use cases.
+
 ## \[0.5.2]
 
 ### Bug Fixes

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": false,
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/github-api-simulator

## [0.5.3]
### Bug Fixes

- e565f7b *Possibly breaking* We incorrectly used the hosted schema with an Enterprise endpoint. Correcting this to default to the hosted endpoint with the hosted schema. Use `apiUrl` and `apiSchema` if there is need to adjust for Enterprise use cases.