### PR TITLE
repo and install endpoints handle 404

### DIFF
--- a/.changes/repo-and-installs-404.md
+++ b/.changes/repo-and-installs-404.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch:enhance
+---
+
+All existing custom routes, repository and installations endpoints, now return a 404 in cases where there are no associated resources to match the real API functionality.

--- a/packages/github-api/tests/installations.test.ts
+++ b/packages/github-api/tests/installations.test.ts
@@ -45,6 +45,11 @@ describe.sequential("GET repo endpoints", () => {
         })
       );
     });
+
+    it("handles non-existant org", async () => {
+      let request = await fetch(`${url}/orgs/doesnt-exist/installation`);
+      expect(request.status).toEqual(404);
+    });
   });
 
   describe("/repos/{owner}/{repo}/installation", () => {
@@ -53,13 +58,33 @@ describe.sequential("GET repo endpoints", () => {
         `${url}/repos/lovely-org/awesome-repo/installation`
       );
       let response = await request.json();
-      if (request.status === 502) console.dir(response);
       expect(request.status).toEqual(200);
       expect(response).toEqual(
         expect.objectContaining({
           account: expect.objectContaining({ login: "lovely-org" }),
         })
       );
+    });
+
+    it("handles non-existant org", async () => {
+      let request = await fetch(
+        `${url}/repos/an-org/awesome-repo/installation`
+      );
+      expect(request.status).toEqual(404);
+    });
+
+    it("handles non-existant repo", async () => {
+      let request = await fetch(
+        `${url}/repos/lovely-org/not-awesome-repo/installation`
+      );
+      expect(request.status).toEqual(404);
+    });
+
+    it("handles non-existant org and repo", async () => {
+      let request = await fetch(
+        `${url}/repos/lovely-but-not/awesome/installation`
+      );
+      expect(request.status).toEqual(404);
     });
   });
 });

--- a/packages/github-api/tests/repositories.test.ts
+++ b/packages/github-api/tests/repositories.test.ts
@@ -11,7 +11,7 @@ describe.sequential("GET repo endpoints", () => {
     let app = simulation({
       initialState: {
         users: [],
-        organizations: [{ login: "lovely-org" }],
+        organizations: [{ login: "lovely-org" }, { login: "empty-org" }],
         repositories: [{ owner: "lovely-org", name: "awesome-repo" }],
         branches: [{ name: "main" }],
         blobs: [],
@@ -25,12 +25,24 @@ describe.sequential("GET repo endpoints", () => {
 
   describe("/orgs/{org}/repos", () => {
     it("validates with 200 response", async () => {
-      let request = await fetch(`${url}/orgs/lovel-org/repos`);
+      let request = await fetch(`${url}/orgs/lovely-org/repos`);
       let response = await request.json();
       expect(request.status).toEqual(200);
       expect(response).toEqual([
         expect.objectContaining({ name: "awesome-repo" }),
       ]);
+    });
+
+    it("handles org with no repos", async () => {
+      let request = await fetch(`${url}/orgs/empty-org/repos`);
+      let response = await request.json();
+      expect(request.status).toEqual(200);
+      expect(response).toEqual([]);
+    });
+
+    it("handles non-existant org", async () => {
+      let request = await fetch(`${url}/orgs/nope-org/repos`);
+      expect(request.status).toEqual(404);
     });
   });
 


### PR DESCRIPTION
## Motivation

We had a few endpoints for handling repositories and GH App installations which didn't correctly return 404 in cases for no resources should exist. Correcting that fact.
