### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/change-default-simulation-helper-page.md
+++ b/.changes/change-default-simulation-helper-page.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": patch:enhance
----
-
-Add API to pass in a page route for the default simulation helper page. This allows for those services which define a valid route returned at the root.

--- a/.changes/fnd-fix-pnpm-resolution.md
+++ b/.changes/fnd-fix-pnpm-resolution.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": patch:bug
----
-
-Fix `exports` in `package.json` and `tsconfig.json` with ESM for improved compatibility with `pnpm`.

--- a/.changes/gh-simulation-helper-page-moved.md
+++ b/.changes/gh-simulation-helper-page-moved.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:bug
----
-
-Change the default simulation helper page to `/simulation` to avoid the conflict with the default GitHub route at the root, `/`.

--- a/.changes/repo-and-installs-404.md
+++ b/.changes/repo-and-installs-404.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:enhance
----
-
-All existing custom routes, repository and installations endpoints, now return a 404 in cases where there are no associated resources to match the real API functionality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9356,7 +9356,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
@@ -9472,11 +9472,11 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.3.0",
+        "@simulacrum/foundation-simulator": "0.3.1",
         "assert-ts": "^0.3.4",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.4",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.3.1]
+
+### Enhancements
+
+- [`0ba82b7`](https://github.com/thefrontside/simulacrum/commit/0ba82b7720f54dbc7faf99a0e2da2ef9212caff5) Add API to pass in a page route for the default simulation helper page. This allows for those services which define a valid route returned at the root.
+
+### Bug Fixes
+
+- [`34ecabd`](https://github.com/thefrontside/simulacrum/commit/34ecabdbb483f494fdff25b2b7a352bdba1079cc) Fix `exports` in `package.json` and `tsconfig.json` with ESM for improved compatibility with `pnpm`.
+
 ## \[0.3.0]
 
 ### New Features

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## \[0.5.4]
+
+### Enhancements
+
+- [`e920b0d`](https://github.com/thefrontside/simulacrum/commit/e920b0dc4803cd228650f27aa52e693b4d662e43) All existing custom routes, repository and installations endpoints, now return a 404 in cases where there are no associated resources to match the real API functionality.
+
+### Bug Fixes
+
+- [`0ba82b7`](https://github.com/thefrontside/simulacrum/commit/0ba82b7720f54dbc7faf99a0e2da2ef9212caff5) Change the default simulation helper page to `/simulation` to avoid the conflict with the default GitHub route at the root, `/`.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.3.1`
+
 ## \[0.5.3]
 
 ### Bug Fixes

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",
   "bugs": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "0.3.0",
+    "@simulacrum/foundation-simulator": "0.3.1",
     "assert-ts": "^0.3.4",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/foundation-simulator

## [0.3.1]
### Enhancements

- 0ba82b7 Add API to pass in a page route for the default simulation helper page. This allows for those services which define a valid route returned at the root.
### Bug Fixes

- 34ecabd Fix `exports` in `package.json` and `tsconfig.json` with ESM for improved compatibility with `pnpm`.



# @simulacrum/github-api-simulator

## [0.5.4]
### Enhancements

- e920b0d All existing custom routes, repository and installations endpoints, now return a 404 in cases where there are no associated resources to match the real API functionality.
### Bug Fixes

- 0ba82b7 Change the default simulation helper page to `/simulation` to avoid the conflict with the default GitHub route at the root, `/`.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.3.1`