### PR TITLE
add API and move GH sim helper page route

### DIFF
--- a/.changes/change-default-simulation-helper-page.md
+++ b/.changes/change-default-simulation-helper-page.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": patch:enhance
+---
+
+Add API to pass in a page route for the default simulation helper page. This allows for those services which define a valid route returned at the root.

--- a/.changes/gh-simulation-helper-page-moved.md
+++ b/.changes/gh-simulation-helper-page-moved.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/github-api-simulator": patch:bug
+---
+
+Change the default simulation helper page to `/simulation` to avoid the conflict with the default GitHub route at the root, `/`.

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -74,6 +74,7 @@ export function createFoundationSimulationServer<
   ExtendedSimulationSelectors
 >({
   port = 9000,
+  simulationContextPage = "/",
   verbose,
   proxyAndSave,
   delayResponses,
@@ -82,7 +83,8 @@ export function createFoundationSimulationServer<
   extendStore,
   extendRouter,
 }: {
-  port: number;
+  port?: number;
+  simulationContextPage?: string;
   verbose?: boolean;
   proxyAndSave?: string;
   delayResponses?: number | { minimum: number; maximum: number };
@@ -349,7 +351,7 @@ export function createFoundationSimulationServer<
     }
 
     // return simulation helper page
-    app.get("/", (req, res) => {
+    app.get(simulationContextPage, (req, res) => {
       let routes = simulationStore.schema.simulationRoutes.selectTableAsList(
         simulationStore.store.getState()
       );
@@ -362,7 +364,7 @@ export function createFoundationSimulationServer<
         res.status(200).send(generateRoutesHTML(routes, logs));
       }
     });
-    app.post("/", (req, res) => {
+    app.post(simulationContextPage, (req, res) => {
       const formValue = req.body;
       const entries = {} as Record<string, Partial<SimulationRoute>>;
       for (let [key, value] of Object.entries(formValue)) {
@@ -373,7 +375,7 @@ export function createFoundationSimulationServer<
           simulationStore.schema.simulationRoutes.patch(entries),
         ])
       );
-      res.redirect("/");
+      res.redirect(simulationContextPage);
     });
     // if no extendRouter routes or openapi routes handle this, return 404
     app.all("*", (req, res) => res.status(404).json({ error: "not found" }));

--- a/packages/github-api/README.md
+++ b/packages/github-api/README.md
@@ -14,6 +14,8 @@ See the examples folder for setting this up in your project. Depending on your t
 
 It is built on `@simulaction/foundation-simulator` where we can pull in the GH OpenAPI spec and use their embedded examples to build upon. Every REST endpoint will be handled will return some response.
 
+For a list of all handled routes and a simple logger while running the simulator, visit the `/simulation` route in your browser.
+
 ## API
 
 It may be run directly from the `bin` script.

--- a/packages/github-api/src/index.ts
+++ b/packages/github-api/src/index.ts
@@ -37,6 +37,7 @@ export const simulation: GitHubSimulator = (args = {}) => {
     : gitubInitialStoreSchema.parse(args?.initialState);
   return createFoundationSimulationServer({
     port: 3300, // default port
+    simulationContextPage: "/simulation",
     extendStore: extendStore(parsedInitialState, args?.extend?.extendStore),
     extendRouter,
     openapi: openapi(


### PR DESCRIPTION
## Motivation

When changing the default route in #296, we overwrote the default route for the simulation helper page. Fixing this.

## Approach

- Added an API in the foundation simulator
- Used that API and moved it in the GH simulator
