### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/user-memberships-org-res-fix.md
+++ b/.changes/user-memberships-org-res-fix.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/github-api-simulator": patch:bug
----
-
-The `/user/memberships/orgs` endpoint didn't return data per the schema. Fix and validate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9472,7 +9472,7 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.5]
+
+### Bug Fixes
+
+- [`ade6ca6`](https://github.com/thefrontside/simulacrum/commit/ade6ca69238094d96236bdfbbe06285cb80bf100) The `/user/memberships/orgs` endpoint didn't return data per the schema. Fix and validate.
+
 ## \[0.5.4]
 
 ### Enhancements

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/github-api-simulator

## [0.5.5]
### Bug Fixes

- ade6ca6 The `/user/memberships/orgs` endpoint didn't return data per the schema. Fix and validate.