### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/auth0-migration-to-foundation.md
+++ b/.changes/auth0-migration-to-foundation.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor:enhance
----
-
-Rebuild Auth0 Simulator on top of the Foundation simulator. This simplifies the configuration required to run it. It also provides some flexibility for the future in handling the data store, and building out other APIs.

--- a/.changes/foundation-ssl-cert.md
+++ b/.changes/foundation-ssl-cert.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:feat
----
-
-Now allows setting the server as https with a certificate applied in the home directory. Use the `protocol` to enable the search for the SSL certificate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9593,7 +9593,7 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "assert-ts": "^0.3.4",
@@ -9664,7 +9664,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
@@ -9780,11 +9780,11 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.3.1",
+        "@simulacrum/foundation-simulator": "0.4.0",
         "assert-ts": "^0.3.4",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.4",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.10.0]
+
+### Enhancements
+
+- [`2a51566`](https://github.com/thefrontside/simulacrum/commit/2a5156698652f9a4ae206d0e0a9b379c140ff0b0) Rebuild Auth0 Simulator on top of the Foundation simulator. This simplifies the configuration required to run it. It also provides some flexibility for the future in handling the data store, and building out other APIs.
+
 ## \[0.9.0]
 
 - Add the `refresh_token` flow

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "dist/index.js",
   "bin": "bin/start.js",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.4.0]
+
+### New Features
+
+- [`774c860`](https://github.com/thefrontside/simulacrum/commit/774c860d91896c1cfdad64b283dcab836b57441d) Now allows setting the server as https with a certificate applied in the home directory. Use the `protocol` to enable the search for the SSL certificate.
+
 ## \[0.3.1]
 
 ### Enhancements

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.5.6]
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.4.0`
+
 ## \[0.5.5]
 
 ### Bug Fixes

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",
   "bugs": {
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "0.3.1",
+    "@simulacrum/foundation-simulator": "0.4.0",
     "assert-ts": "^0.3.4",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/foundation-simulator

## [0.4.0]
### New Features

- 774c860 Now allows setting the server as https with a certificate applied in the home directory. Use the `protocol` to enable the search for the SSL certificate.



# @simulacrum/auth0-simulator

## [0.10.0]
### Enhancements

- 2a51566 Rebuild Auth0 Simulator on top of the Foundation simulator. This simplifies the configuration required to run it. It also provides some flexibility for the future in handling the data store, and building out other APIs.



# @simulacrum/github-api-simulator

## [0.5.6]
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.4.0`