### PR TITLE
starfx 0.14.x in foundation simulator

### DIFF
--- a/.changes/starfx-0-14.md
+++ b/.changes/starfx-0-14.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": patch:deps
+---
+
+Bumping to starfx `0.14.x` to clean up some dependency requirements that came in transitively.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1008,6 +1008,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.20.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -3773,14 +3774,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/http-proxy": {
       "version": "1.17.15",
       "license": "MIT",
@@ -3850,10 +3843,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.9.15",
       "dev": true,
@@ -3863,14 +3852,6 @@
       "version": "1.2.7",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -3889,10 +3870,6 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.12",
@@ -5086,10 +5063,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "license": "MIT"
-    },
     "node_modules/dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
@@ -5271,9 +5244,9 @@
       "license": "MIT"
     },
     "node_modules/effection": {
-      "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/effection/-/effection-3.0.0-beta.3.tgz",
-      "integrity": "sha512-OamLXbd8EdW9z6gIjfJ4c1MJykE/J5Q++j1wC8m6CNXatiETJtdF3lIwgrIRklKjQOYfW47tMgTllmHpHzR3fA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/effection/-/effection-3.5.0.tgz",
+      "integrity": "sha512-PcKRGoP68CM3c/DODTc38xp0rIjfREH7/fBGu4tiHU/aPb/PvSxv3tvWaJt6JxpxqT0jIXvcOyn+yjk46KcNXw==",
       "license": "ISC",
       "engines": {
         "node": ">= 16"
@@ -6585,17 +6558,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
-    },
     "node_modules/html-entities": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
@@ -7300,6 +7262,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8176,36 +8139,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream": {
@@ -8230,6 +8168,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/relay-runtime": {
@@ -8287,7 +8226,9 @@
       "license": "MIT"
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -8416,15 +8357,6 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "node_modules/scuid": {
       "version": "1.1.0",
@@ -8687,6 +8619,33 @@
       "version": "0.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/starfx": {
+      "version": "0.14.4",
+      "resolved": "https://pkg.pr.new/neurosnap/starfx@ede810b",
+      "integrity": "sha512-Ysy9EWIOQHrTzpi2AzP9D8b01f/DHcQEb4E/+lnbgPr5v3pnXU9p3AnLsadQOpSGuXXlDiSxDq5iMcjLzxuUTw==",
+      "license": "MIT",
+      "dependencies": {
+        "effection": "^3.5.0",
+        "immer": "^10.1.1",
+        "reselect": "^5.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18",
+        "react-redux": "9.x"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -9233,15 +9192,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
@@ -9695,8 +9645,7 @@
         "lodash": "^4.17.21",
         "openapi-backend": "^5.11.1",
         "openapi-merge": "^1.3.3",
-        "react-dom": "^17.0 || ^18.0",
-        "starfx": "^0.12.0"
+        "starfx": "https://pkg.pr.new/neurosnap/starfx@ede810b"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -9743,59 +9692,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "packages/foundation/node_modules/react-redux": {
-      "version": "8.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
-    "packages/foundation/node_modules/starfx": {
-      "version": "0.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "effection": "3.0.0-beta.3",
-        "immer": "^10.0.2",
-        "react-redux": "^8.0.5",
-        "reselect": "^4.1.8"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
       }
     },
     "packages/github-api": {

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -47,8 +47,7 @@
     "lodash": "^4.17.21",
     "openapi-backend": "^5.11.1",
     "openapi-merge": "^1.3.3",
-    "starfx": "^0.12.0",
-    "react-dom": "^17.0 || ^18.0"
+    "starfx": "https://pkg.pr.new/neurosnap/starfx@ede810b"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",


### PR DESCRIPTION
## Motivation

In upgrading to `starfx@0.14.x`, we can remove some of the dep tree that came in partially broken through peerDeps.

## Approach

Upgrade here, but more refined tweaks upstream.
