### PR TITLE
covector comment on forks

### DIFF
--- a/.github/workflows/covector-comment-on-forks.yaml
+++ b/.github/workflows/covector-comment-on-forks.yaml
@@ -1,0 +1,26 @@
+name: covector comment
+
+on:
+  workflow_run:
+    workflows: [covector status]
+    types:
+      - completed
+
+# note all other permissions are set to none if not specified
+permissions:
+  # to read the action artifacts
+  actions: read
+  # to write the comment
+  pull-requests: write
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.head_repository.full_name != github.repository || github.actor == 'dependabot[bot]')
+    steps:
+      - name: covector status
+        uses: jbolda/covector/packages/action@covector-v0
+        with:
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+          command: "status"

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -18,7 +18,9 @@ jobs:
         uses: jbolda/covector/packages/action@covector-v0
         id: covector
         with:
-          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+          # in a fork, this token is undefined, but internally we would try and fail then fallback
+          # normally with the default GITHUB_TOKEN in a fork it will still be defined, but with limited permissions
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN || 'pr_from_fork' }}
           command: "status"
           comment: true
       - run: echo ${{ steps.covector.outputs.packagesPublished }}


### PR DESCRIPTION
## Motivation

On #313, we noted that the preview package didn't publish because the status comment failed with `undefined` as it was expecting the token to be set, but with fail on the permissions.

## Approach

And new workflow to create the comment, and pass a default value so it is defined.
