### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/esm-without-lodash.md
+++ b/.changes/esm-without-lodash.md
@@ -1,7 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:enhance
-"@simulacrum/auth0-simulator": minor:enhance
-"@simulacrum/github-api-simulator": minor:enhance
----
-
-POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.

--- a/.changes/express-v5.md
+++ b/.changes/express-v5.md
@@ -1,7 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:enhance
-"@simulacrum/auth0-simulator": minor:enhance
-"@simulacrum/github-api-simulator": minor:enhance
----
-
-POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.

--- a/.changes/main.md
+++ b/.changes/main.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor:feat
----
-
-Add support for passwordless auth

--- a/.changes/refine-tsc-with-safety-and-strictness.md
+++ b/.changes/refine-tsc-with-safety-and-strictness.md
@@ -1,8 +1,0 @@
----
-"@simulacrum/server": patch:enhance
-"@simulacrum/foundation-simulator": patch:enhance
-"@simulacrum/auth0-simulator": patch:enhance
-"@simulacrum/github-api-simulator": patch:enhance
----
-
-Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.

--- a/.changes/server-nodeOptions-spread.md
+++ b/.changes/server-nodeOptions-spread.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/server": patch:bug
----
-
-Properly pass down `nodeOptions`. We were spreading the root options object which meant options like `cwd` were not being picked up.

--- a/.changes/tsdown-all-pkgs.md
+++ b/.changes/tsdown-all-pkgs.md
@@ -1,7 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor:enhance
-"@simulacrum/foundation-simulator": minor:enhance
-"@simulacrum/github-api-simulator": minor:enhance
----
-
-Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.

--- a/.changes/upgrade-starfx-0.15.md
+++ b/.changes/upgrade-starfx-0.15.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:enhance
----
-
-Upgrade to `starfx@0.15.0`. This settles out and upgrades upstream dependencies. You may see `reselect` warnings now showing in your terminal for items with broken memoization.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9049,11 +9049,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.4.1",
+        "@simulacrum/foundation-simulator": "0.5.0",
         "assert-ts": "^0.3.4",
         "base64-url": "^2.3.3",
         "cookie-session": "^2.1.0",
@@ -9082,7 +9082,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
@@ -9103,11 +9103,11 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.4.1",
+        "@simulacrum/foundation-simulator": "0.5.0",
         "assert-ts": "^0.3.4",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.4",
@@ -9133,7 +9133,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@effectionx/context-api": "^0.1.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## \[0.11.0]
+
+### New Features
+
+- [`467e783`](https://github.com/thefrontside/simulacrum/commit/467e783d8330bc729444ef85dab25eada34a51f2) ([#326](https://github.com/thefrontside/simulacrum/pull/326) by [@rparet](https://github.com/thefrontside/simulacrum/../../rparet)) Add support for passwordless auth
+
+### Enhancements
+
+- [`c52b964`](https://github.com/thefrontside/simulacrum/commit/c52b9649ad7505bf41e43a640d05d6ee5b9b73a7) ([#322](https://github.com/thefrontside/simulacrum/pull/322) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.
+- [`95bc2cf`](https://github.com/thefrontside/simulacrum/commit/95bc2cf102839e7f869498f0bf9d7e3f0dce7d84) ([#323](https://github.com/thefrontside/simulacrum/pull/323) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.
+- [`33efe53`](https://github.com/thefrontside/simulacrum/commit/33efe53806407c2b36d6c3c927301473bcf6fd31) ([#329](https://github.com/thefrontside/simulacrum/pull/329) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
+- [`6b452c3`](https://github.com/thefrontside/simulacrum/commit/6b452c3cf3c8bd5f025a1993cf4ad63a5597e242) ([#320](https://github.com/thefrontside/simulacrum/pull/320) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.5.0`
+
 ## \[0.10.2]
 
 - [`496b98b`](https://github.com/thefrontside/simulacrum/commit/496b98b53bff4faf1310bebff1c43fc469cb52c5) ([#313](https://github.com/thefrontside/simulacrum/pull/313) by [@taylorreece](https://www.github.com/taylorreece)) Update the auth0 simulator to include an email claim in the access token when email is present in scope.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "./dist/index.cjs",
   "bin": "bin/start.cjs",
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
-    "@simulacrum/foundation-simulator": "0.4.1",
+    "@simulacrum/foundation-simulator": "0.5.0",
     "@faker-js/faker": "^9.3.0",
     "assert-ts": "^0.3.4",
     "base64-url": "^2.3.3",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.5.0]
+
+### Enhancements
+
+- [`c52b964`](https://github.com/thefrontside/simulacrum/commit/c52b9649ad7505bf41e43a640d05d6ee5b9b73a7) ([#322](https://github.com/thefrontside/simulacrum/pull/322) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.
+- [`95bc2cf`](https://github.com/thefrontside/simulacrum/commit/95bc2cf102839e7f869498f0bf9d7e3f0dce7d84) ([#323](https://github.com/thefrontside/simulacrum/pull/323) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.
+- [`33efe53`](https://github.com/thefrontside/simulacrum/commit/33efe53806407c2b36d6c3c927301473bcf6fd31) ([#329](https://github.com/thefrontside/simulacrum/pull/329) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
+- [`6b452c3`](https://github.com/thefrontside/simulacrum/commit/6b452c3cf3c8bd5f025a1993cf4ad63a5597e242) ([#320](https://github.com/thefrontside/simulacrum/pull/320) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.
+- [`ec6991f`](https://github.com/thefrontside/simulacrum/commit/ec6991f28624cecdf7828fdf1977c6e18747932a) ([#324](https://github.com/thefrontside/simulacrum/pull/324) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Upgrade to `starfx@0.15.0`. This settles out and upgrades upstream dependencies. You may see `reselect` warnings now showing in your terminal for items with broken memoization.
+
 ## \[0.4.1]
 
 ### Bug Fixes

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## \[0.6.0]
+
+### Enhancements
+
+- [`c52b964`](https://github.com/thefrontside/simulacrum/commit/c52b9649ad7505bf41e43a640d05d6ee5b9b73a7) ([#322](https://github.com/thefrontside/simulacrum/pull/322) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.
+- [`95bc2cf`](https://github.com/thefrontside/simulacrum/commit/95bc2cf102839e7f869498f0bf9d7e3f0dce7d84) ([#323](https://github.com/thefrontside/simulacrum/pull/323) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.
+- [`33efe53`](https://github.com/thefrontside/simulacrum/commit/33efe53806407c2b36d6c3c927301473bcf6fd31) ([#329](https://github.com/thefrontside/simulacrum/pull/329) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
+- [`6b452c3`](https://github.com/thefrontside/simulacrum/commit/6b452c3cf3c8bd5f025a1993cf4ad63a5597e242) ([#320](https://github.com/thefrontside/simulacrum/pull/320) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.5.0`
+
 ## \[0.5.7]
 
 ### Bug Fixes

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",
   "bugs": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "0.4.1",
+    "@simulacrum/foundation-simulator": "0.5.0",
     "assert-ts": "^0.3.4",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.7.1]
+
+### Enhancements
+
+- [`33efe53`](https://github.com/thefrontside/simulacrum/commit/33efe53806407c2b36d6c3c927301473bcf6fd31) ([#329](https://github.com/thefrontside/simulacrum/pull/329) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
+
+### Bug Fixes
+
+- [`d035a5b`](https://github.com/thefrontside/simulacrum/commit/d035a5be52fb53621acd148e5bd2a66f613d1773) ([#325](https://github.com/thefrontside/simulacrum/pull/325) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Properly pass down `nodeOptions`. We were spreading the root options object which meant options like `cwd` were not being picked up.
+
 ## \[0.7.0]
 
 ### Enhancements

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Helpers and control plane to handle simulators and observability",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/server

## [0.7.1]
### Enhancements

- 33efe53 (#329 by @jbolda) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
### Bug Fixes

- d035a5b (#325 by @jbolda) Properly pass down `nodeOptions`. We were spreading the root options object which meant options like `cwd` were not being picked up.



# @simulacrum/foundation-simulator

## [0.5.0]
### Enhancements

- c52b964 (#322 by @jbolda) POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.
- 95bc2cf (#323 by @jbolda) POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.
- 33efe53 (#329 by @jbolda) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
- 6b452c3 (#320 by @jbolda) Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.
- ec6991f (#324 by @jbolda) Upgrade to `starfx@0.15.0`. This settles out and upgrades upstream dependencies. You may see `reselect` warnings now showing in your terminal for items with broken memoization.



# @simulacrum/auth0-simulator

## [0.11.0]
### New Features

- 467e783 (#326 by @rparet) Add support for passwordless auth
### Enhancements

- c52b964 (#322 by @jbolda) POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.
- 95bc2cf (#323 by @jbolda) POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.
- 33efe53 (#329 by @jbolda) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
- 6b452c3 (#320 by @jbolda) Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.5.0`



# @simulacrum/github-api-simulator

## [0.6.0]
### Enhancements

- c52b964 (#322 by @jbolda) POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.
- 95bc2cf (#323 by @jbolda) POSSIBLY BREAKING: Update the express v5. If you are using the extended router, you may need to confirm your routes against the express v5 migration guide.
- 33efe53 (#329 by @jbolda) Add additional TypeScript configure in workspace to further refine type checks. Run `tsc` in CI for every package.
- 6b452c3 (#320 by @jbolda) Switch to using `tsdown` to help build both ESM and CJS versions of the package. This also includes helpers to ensure that the published package has all of the required properties and configuration.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.5.0`