### PR TITLE
Swap to ESM as default, no more lodash

### DIFF
--- a/.changes/esm-without-lodash.md
+++ b/.changes/esm-without-lodash.md
@@ -1,0 +1,7 @@
+---
+"@simulacrum/foundation-simulator": minor:enhance
+"@simulacrum/auth0-simulator": minor:enhance
+"@simulacrum/github-api-simulator": minor:enhance
+---
+
+POSSIBLY BREAKING: Switch to ESM modules with a dual published CJS option. This was enabled by swapping out lodash for defu to merge OpenAPI specifications.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4710,14 +4710,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/atlassian-openapi": {
-      "version": "1.0.18",
-      "license": "MIT",
-      "dependencies": {
-        "jsonpointer": "^5.0.0",
-        "urijs": "^1.19.10"
-      }
-    },
     "node_modules/auto-bind": {
       "version": "4.0.0",
       "dev": true,
@@ -5542,7 +5534,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/depd": {
@@ -7491,13 +7482,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -8133,15 +8117,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/openapi-merge": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "atlassian-openapi": "^1.0.8",
-        "lodash": "^4.17.15",
-        "ts-is-present": "^1.1.1"
       }
     },
     "node_modules/openapi-schema-validator": {
@@ -9466,10 +9441,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/ts-is-present": {
-      "version": "1.2.2",
-      "license": "MIT"
-    },
     "node_modules/ts-log": {
       "version": "2.2.5",
       "dev": true,
@@ -9827,10 +9798,6 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/urijs": {
-      "version": "1.19.11",
-      "license": "MIT"
     },
     "node_modules/urlpattern-polyfill": {
       "version": "8.0.2",
@@ -10256,12 +10223,11 @@
       "dependencies": {
         "ajv-formats": "^3.0.1",
         "cors": "^2.8.5",
+        "defu": "^6.1.4",
         "express": "^4.21.1",
         "fdir": "^6.2.0",
         "http-proxy-middleware": "^3.0.0",
-        "lodash": "^4.17.21",
         "openapi-backend": "^5.11.1",
-        "openapi-merge": "^1.3.3",
         "react-dom": "^17.0 || ^18.0",
         "starfx": "^0.12.0"
       },

--- a/packages/auth0/bin/start.cjs
+++ b/packages/auth0/bin/start.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const auth0APIsimulator = require("../dist/index.js");
+const auth0APIsimulator = require("../dist/index.cjs");
 
 const app = auth0APIsimulator.simulation();
 app.listen(4400, () =>

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -19,7 +19,7 @@
     "mocking",
     "integration testing"
   ],
-  "type": "commonjs",
+  "type": "module",
   "files": [
     "README.md",
     "dist",
@@ -39,12 +39,11 @@
   "dependencies": {
     "ajv-formats": "^3.0.1",
     "cors": "^2.8.5",
+    "defu": "^6.1.4",
     "express": "^4.21.1",
     "fdir": "^6.2.0",
     "http-proxy-middleware": "^3.0.0",
-    "lodash": "^4.17.21",
     "openapi-backend": "^5.11.1",
-    "openapi-merge": "^1.3.3",
     "starfx": "^0.12.0",
     "react-dom": "^17.0 || ^18.0"
   },
@@ -56,8 +55,8 @@
   "exports": {
     ".": {
       "development": "./src/index.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },
@@ -68,14 +67,14 @@
       ]
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.cts",
   "publishConfig": {
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
       },
       "./package.json": "./package.json"
     }

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -9,7 +9,7 @@ import type { ILayer, IRoute } from "express-serve-static-core";
 import { fdir } from "fdir";
 import fs from "node:fs";
 import path from "node:path";
-import { merge } from "lodash";
+import { defu } from "defu";
 import OpenAPIBackend from "openapi-backend";
 import type {
   Handler,
@@ -426,7 +426,7 @@ export function createFoundationSimulationServer<
 const mergeDocumentArray = (
   documents: RecursivePartial<Document>[]
 ): Document => {
-  let document = merge({}, ...documents);
+  let document = defu({}, ...documents);
   return document as Document;
 };
 

--- a/packages/github-api/bin/start.cjs
+++ b/packages/github-api/bin/start.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const githubAPIsimulator = require("../dist/index.js");
+const githubAPIsimulator = require("../dist/index.cjs");
 
 const app = githubAPIsimulator.simulation();
 app.listen(3300, () =>

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -19,7 +19,7 @@
     "mocking",
     "integration testing"
   ],
-  "type": "commonjs",
+  "type": "module",
   "files": [
     "README.md",
     "dist",
@@ -56,8 +56,8 @@
   "exports": {
     ".": {
       "development": "./src/index.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },
@@ -68,14 +68,14 @@
       ]
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.cts",
   "publishConfig": {
     "exports": {
       ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
       },
       "./package.json": "./package.json"
     }


### PR DESCRIPTION
## Motivation

We should be able to switch to ESM as the default.

## Approach

`lodash` was seemingly the remaining blocker and it has now been removed for `defu`.
