### PR TITLE
server should spread nodeOptions into the same

### DIFF
--- a/.changes/server-nodeOptions-spread.md
+++ b/.changes/server-nodeOptions-spread.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": patch:bug
+---
+
+Properly pass down `nodeOptions`. We were spreading the root options object which meant options like `cwd` were not being picked up.

--- a/packages/server/src/process.ts
+++ b/packages/server/src/process.ts
@@ -9,6 +9,7 @@ export function useProcess(
 ): Operation<TinyProcess> {
   let [command, ...args] = cmd.split(/\s+/);
   return x(command, args, {
-    nodeOptions: { ...options, detached: true },
+    ...options,
+    nodeOptions: { ...options?.nodeOptions, detached: true },
   });
 }


### PR DESCRIPTION
## Motivation

 The `cwd` options wasn't picked up.

## Approach

Properly  pass down and spread the `nodeOptions` into the `nodeOptions`.
