### PR TITLE
add support for passwordless

### DIFF
--- a/.changes/main.md
+++ b/.changes/main.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/auth0-simulator": minor:feat
+---
+
+Add support for passwordless auth

--- a/packages/auth0/src/handlers/auth0-handlers.ts
+++ b/packages/auth0/src/handlers/auth0-handlers.ts
@@ -24,7 +24,8 @@ export type Routes =
   | "/login/callback"
   | "/oauth/token"
   | "/v2/logout"
-  | "/userinfo";
+  | "/userinfo"
+  | "/passwordless/start";
 
 export type AuthSession = { username: string; nonce: string };
 
@@ -265,6 +266,54 @@ export const createAuth0Handlers = (
       };
 
       res.status(200).json(userinfo);
+    },
+
+    ["/passwordless/start"]: async function (req, res, next) {
+      logger.log({ "/passwordless/start": { body: req.body } });
+
+      try {
+        const { client_id, connection, email, phone_number, send } = req.body;
+
+        // Validate required fields
+        if (!client_id) {
+          return res.status(400).json({ error: "client_id is required" });
+        }
+
+        if (!connection || (connection !== "email" && connection !== "sms")) {
+          return res.status(400).json({
+            error: "connection must be 'email' or 'sms'",
+          });
+        }
+
+        if (connection === "email" && !email) {
+          return res.status(400).json({
+            error: "email is required when connection is 'email'",
+          });
+        }
+
+        if (connection === "sms" && !phone_number) {
+          return res.status(400).json({
+            error: "phone_number is required when connection is 'sms'",
+          });
+        }
+
+        // Return appropriate response based on connection type
+        if (connection === "email") {
+          res.status(200).json({
+            _id: "000000000000000000000000",
+            email: email,
+            email_verified: false,
+          });
+        } else {
+          res.status(200).json({
+            _id: "000000000000000000000000",
+            phone_number: phone_number,
+            phone_verified: false,
+          });
+        }
+      } catch (error) {
+        next(error);
+      }
     },
   };
 };

--- a/packages/auth0/src/handlers/index.ts
+++ b/packages/auth0/src/handlers/index.ts
@@ -7,8 +7,11 @@ import { defaultErrorHandler } from "../middleware/error-handling.ts";
 import { createAuth0Handlers } from "./auth0-handlers.ts";
 import { createOpenIdHandlers } from "./openid-handlers.ts";
 import path from "path";
+import { fileURLToPath } from "url";
 import { Auth0Configuration } from "../types.ts";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const publicDir = path.join(__dirname, "..", "views", "public");
 export const extendRouter =
   (config: Auth0Configuration, debug = false) =>
@@ -38,6 +41,7 @@ export const extendRouter =
       .post("/usernamepassword/login", auth0["/usernamepassword/login"])
       .post("/login/callback", auth0["/login/callback"])
       .post("/oauth/token", auth0["/oauth/token"])
+      .post("/passwordless/start", auth0["/passwordless/start"])
       .get("/userinfo", auth0["/userinfo"])
       .get("/v2/logout", auth0["/v2/logout"])
       .get("/.well-known/jwks.json", openid["/.well-known/jwks.json"])

--- a/packages/auth0/src/handlers/oauth-handlers.ts
+++ b/packages/auth0/src/handlers/oauth-handlers.ts
@@ -189,7 +189,9 @@ const verifyUserExistsInStore = ({
   let username: string;
   let password: string | undefined;
 
-  if (grant_type === "password") {
+  if (grant_type === "http://auth0.com/oauth/grant-type/passwordless/otp") {
+    username = body.username;
+  } else if (grant_type === "password") {
     username = body.username;
     password = body.password;
   } else {
@@ -197,9 +199,8 @@ const verifyUserExistsInStore = ({
     // but naively using it to handle other cases at the moment
     assert(typeof code !== "undefined", "400::no code in /oauth/token");
     [nonce, username] = decodeBase64(code).split(":");
+    assert(!!username, `400::no nonce in store for ${code}`);
   }
-
-  assert(!!username, `400::no nonce in store for ${code}`);
 
   let user: Auth0User | undefined = personQuery((person) => {
     assert(!!person.email, `500::no email defined on person scenario`);

--- a/packages/auth0/src/types.ts
+++ b/packages/auth0/src/types.ts
@@ -38,7 +38,8 @@ export type GrantType =
   | "password"
   | "client_credentials"
   | "authorization_code"
-  | "refresh_token";
+  | "refresh_token"
+  | "http://auth0.com/oauth/grant-type/passwordless/otp";
 
 export type ScopeConfig =
   | string


### PR DESCRIPTION
## Motivation

Supports simulating Passwordless auth APIs.
Docs: https://auth0.com/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints#post-passwordless-start
 Fixes #207 

## Approach

Minimum viable. Just support the new api at /passwordless/start and make the minimum modifications to /oauth/token to support the new grant type. 

The auth always succeeds unless you supply an email that is not in the store. No support for adding specific codes or phone numbers to users and enforcing them.

Extended the existing tests with support for these modifications.

## Learning

Thanks for a great project - this will really simplify my e2e testing strategy.
