### PR TITLE
ESM dirname and fix openapi-backend import

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,3 +15,6 @@ jobs:
 
       - name: Run linters
         run: npm run lint
+
+      - name: Run tsc
+        run: npm run tsc

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "clean": "npm run clean --workspaces",
     "test": "npm run test --workspaces",
     "prepack": "npm run prepack --workspaces",
-    "lint": "npm run lint --workspaces -- --fix",
+    "lint": "npm run lint --workspaces --if-present -- --fix",
+    "tsc": "npm run tsc --workspaces --if-present",
     "covector": "npx covector"
   },
   "repository": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,10 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean": "echo nothing to do",
     "prepack": "echo \"tsc --build\"",
     "build": "npm run prepack",
-    "lint": "echo noop",
     "test": "echo client is used to test server"
   },
   "dependencies": {},

--- a/packages/foundation/example/extensiveServer/index.ts
+++ b/packages/foundation/example/extensiveServer/index.ts
@@ -5,7 +5,7 @@ import { extendRouter } from "./extend-api.ts";
 
 export const simulation = createFoundationSimulationServer({
   port: 9999,
-  serveJsonFiles: `${__dirname}/jsonFiles`,
+  serveJsonFiles: `${import.meta.dirname}/jsonFiles`,
   openapi,
   extendStore,
   extendRouter,

--- a/packages/foundation/example/singleFileServer/index.ts
+++ b/packages/foundation/example/singleFileServer/index.ts
@@ -68,7 +68,7 @@ const openapiSchemaWithModificationsForSimulation = {
 
 export const simulation = createFoundationSimulationServer({
   port: 9999,
-  serveJsonFiles: `${__dirname}/jsonFiles`,
+  serveJsonFiles: `${import.meta.dirname}/jsonFiles`,
   openapi: [
     {
       document: [

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -33,6 +33,7 @@
     "test:watch": "vitest watch",
     "bench": "vitest bench",
     "lint": "echo \"eventually run \"eslint src example\" but it currently fails to parse\"",
+    "tsc": "tsc --noEmit",
     "prepack": "npm run build",
     "build": "tsdown"
   },

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -11,7 +11,7 @@ import { fdir } from "fdir";
 import fs from "node:fs";
 import path from "node:path";
 import { defu } from "defu";
-import OpenAPIBackend from "openapi-backend";
+import { OpenAPIBackend } from "openapi-backend";
 import type {
   Handler,
   Request,

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -35,6 +35,7 @@
     "test:watch": "vitest watch",
     "bench": "vitest bench",
     "lint": "echo noop",
+    "tsc": "tsc --noEmit",
     "prepack": "npm run generate && npm run build",
     "build": "tsdown",
     "generate": "graphql-codegen"

--- a/packages/github-api/src/rest/index.ts
+++ b/packages/github-api/src/rest/index.ts
@@ -20,6 +20,7 @@ const handlers =
         const ghOrgs = simulationStore.selectors.allGithubOrganizations(
           simulationStore.store.getState()
         );
+        // @ts-expect-error this shouldn't be an any TODO fix
         const data = ghOrgs.map((org, index) => ({
           id: index,
           account: org,
@@ -194,6 +195,7 @@ const handlers =
         );
         return {
           status: 200,
+          // @ts-expect-error this shouldn't be an any TODO fix
           json: organizations.map((organization) => ({
             url: `${organization.url}/memberships`,
             state: "active",

--- a/packages/github-api/src/utils.ts
+++ b/packages/github-api/src/utils.ts
@@ -9,7 +9,7 @@ const schemaDefaults = [
 export type SchemaFile = (typeof schemaDefaults)[number];
 
 export function getSchema(schemaFile: SchemaFile | string) {
-  let root = path.join(__dirname, "..");
+  let root = path.join(import.meta.dirname, "..");
 
   const fileString = fs.readFileSync(
     (schemaDefaults as unknown as string[]).includes(schemaFile)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,9 +8,7 @@
     "prepack": "echo \"parcel build\"",
     "start": "parcel serve",
     "watch": "parcel watch",
-    "build": "npm run prepack",
-    "lint": "echo noop",
-    "clean": "echo skip"
+    "build": "npm run prepack"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Motivation

With the ESM upgrade, two items weren't flagged in initial testing through the preview packages and tests.

## Approach

- Fix the `__dirname` usage and use named import for `openapi-backend`.
- Start running tsc hopefully flag some of this in CI
