### PR TITLE
meta workflow falls back to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           # in a fork, this token is undefined, but internally we would try and fail then fallback
           # normally with the default GITHUB_TOKEN in a fork it will still be defined, but with limited permissions
-          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN || 'pr_from_fork' }}
+          # as a fallback we use the GITHUB_TOKEN which should then throw the appropriate error expected by covector
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           command: "status"
           comment: true
       - run: echo ${{ steps.covector.outputs.packagesPublished }}


### PR DESCRIPTION
## Motivation

Noticed in #326 that our forks still aren't correctly publishing preview packages.

## Approach

The failure mode expected is through using a GITHUB_TOKEN from the fork. Try falling back to that token instead.
