### PR TITLE
Fix Simulation Log From Express v5 Breaking Change

### DIFF
--- a/.changes/express-stack-sim-log.md
+++ b/.changes/express-stack-sim-log.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/foundation-simulator": patch:bug
+---
+
+Fix handling of simulation route log for extended routes which changed and broke in the upgrade to express v5. It changed where the nesting of that route information.

--- a/packages/foundation/example/extensiveServer/extend-api.ts
+++ b/packages/foundation/example/extensiveServer/extend-api.ts
@@ -5,7 +5,7 @@ export const extendRouter = (
   router: Router,
   simulationStore: ExtendedSimulationStore
 ) => {
-  router.get("extended-route", (req, res) => {
+  router.get("/extended-route", (req, res) => {
     let dogs = simulationStore.schema.dogs.select(
       simulationStore.store.getState()
     );

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -177,10 +177,10 @@ export function createFoundationSimulationServer<
     if (extendRouter) {
       extendRouter(app, simulationStore);
 
-      if (app?._router?.stack) {
-        const layers: IRoute[] = app._router.stack
-          .map((stack: ILayer) => stack.route)
-          .filter(Boolean);
+      if (app?.router?.stack) {
+        const layers: IRoute[] = app.router
+          .stack!.map((stack: ILayer) => stack.route)
+          .filter((r): r is IRoute => Boolean(r));
 
         const simulationRoutes = [];
         for (let layer of layers) {


### PR DESCRIPTION
## Motivation

Express v5 had a breaking change in how it stored the route information. This wasn't adjusted in the upgrade to v5, and we are missing extended routes in our route log.

## Approach

Use new variable to grab the information which is the same as before.
