### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/express-stack-sim-log.md
+++ b/.changes/express-stack-sim-log.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": patch:bug
----
-
-Fix handling of simulation route log for extended routes which changed and broke in the upgrade to express v5. It changed where the nesting of that route information.

--- a/.changes/types-version-fix.md
+++ b/.changes/types-version-fix.md
@@ -1,8 +1,0 @@
----
-"@simulacrum/server": patch:bug
-"@simulacrum/foundation-simulator": patch:bug
-"@simulacrum/auth0-simulator": patch:bug
-"@simulacrum/github-api-simulator": patch:bug
----
-
-Fix `typesVersion` pointing to old directories. Update `tsdown`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6925,11 +6925,11 @@
     },
     "packages/auth0": {
       "name": "@simulacrum/auth0-simulator",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.5.0",
+        "@simulacrum/foundation-simulator": "0.5.1",
         "assert-ts": "^0.3.4",
         "base64-url": "^2.3.3",
         "cookie-session": "^2.1.0",
@@ -6957,7 +6957,7 @@
     },
     "packages/foundation": {
       "name": "@simulacrum/foundation-simulator",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "ajv-formats": "^3.0.1",
@@ -6977,11 +6977,11 @@
     },
     "packages/github-api": {
       "name": "@simulacrum/github-api-simulator",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "@simulacrum/foundation-simulator": "0.5.0",
+        "@simulacrum/foundation-simulator": "0.5.1",
         "assert-ts": "^0.3.4",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.4",
@@ -7007,7 +7007,7 @@
     },
     "packages/server": {
       "name": "@simulacrum/server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@effectionx/context-api": "^0.1.0",

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.11.1]
+
+### Bug Fixes
+
+- [`356bfdd`](https://github.com/thefrontside/simulacrum/commit/356bfddfd55203d0f444922e6fcef087ed461252) Fix `typesVersion` pointing to old directories. Update `tsdown`.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.5.1`
+
 ## \[0.11.0]
 
 ### New Features

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "main": "./dist/index.cjs",
   "bin": "bin/start.cjs",
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/thefrontside/simulacrum#readme",
   "dependencies": {
-    "@simulacrum/foundation-simulator": "0.5.0",
+    "@simulacrum/foundation-simulator": "0.5.1",
     "@faker-js/faker": "^9.3.0",
     "assert-ts": "^0.3.4",
     "base64-url": "^2.3.3",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## \[0.5.1]
+
+### Bug Fixes
+
+- [`3465b2b`](https://github.com/thefrontside/simulacrum/commit/3465b2be92d47ecc432fe5ecc4a7cc5337c6298c) ([#332](https://github.com/thefrontside/simulacrum/pull/332) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Fix handling of simulation route log for extended routes which changed and broke in the upgrade to express v5. It changed where the nesting of that route information.
+- [`356bfdd`](https://github.com/thefrontside/simulacrum/commit/356bfddfd55203d0f444922e6fcef087ed461252) Fix `typesVersion` pointing to old directories. Update `tsdown`.
+
 ## \[0.5.0]
 
 ### Enhancements

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Base simulator to build simulators for integration testing.",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.6.1]
+
+### Bug Fixes
+
+- [`356bfdd`](https://github.com/thefrontside/simulacrum/commit/356bfddfd55203d0f444922e6fcef087ed461252) Fix `typesVersion` pointing to old directories. Update `tsdown`.
+
+### Dependencies
+
+- Upgraded to `@simulacrum/foundation-simulator@0.5.1`
+
 ## \[0.6.0]
 
 ### Enhancements

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Provides common functionality to frontend app and plugins.",
   "license": "Apache-2.0",
   "bugs": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "0.5.0",
+    "@simulacrum/foundation-simulator": "0.5.1",
     "assert-ts": "^0.3.4",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.7.2]
+
+### Bug Fixes
+
+- [`356bfdd`](https://github.com/thefrontside/simulacrum/commit/356bfddfd55203d0f444922e6fcef087ed461252) Fix `typesVersion` pointing to old directories. Update `tsdown`.
+
 ## \[0.7.1]
 
 ### Enhancements

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Helpers and control plane to handle simulators and observability",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/server

## [0.7.2]
### Bug Fixes

- 356bfdd Fix `typesVersion` pointing to old directories. Update `tsdown`.



# @simulacrum/foundation-simulator

## [0.5.1]
### Bug Fixes

- 3465b2b (#332 by @jbolda) Fix handling of simulation route log for extended routes which changed and broke in the upgrade to express v5. It changed where the nesting of that route information.
- 356bfdd Fix `typesVersion` pointing to old directories. Update `tsdown`.



# @simulacrum/auth0-simulator

## [0.11.1]
### Bug Fixes

- 356bfdd Fix `typesVersion` pointing to old directories. Update `tsdown`.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.5.1`



# @simulacrum/github-api-simulator

## [0.6.1]
### Bug Fixes

- 356bfdd Fix `typesVersion` pointing to old directories. Update `tsdown`.
### Dependencies

- Upgraded to `@simulacrum/foundation-simulator@0.5.1`