### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/auth0-rules-global-fetch.md
+++ b/.changes/auth0-rules-global-fetch.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor:enhance
----
-
-Pass in global fetch to rules runner.

--- a/.changes/deprioritize-initial-store-updates-in-foundation.md
+++ b/.changes/deprioritize-initial-store-updates-in-foundation.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": patch:bug
----
-
-Order initial log dispatching to help avoid the race condition made more prevalent by more direct sync vs async handling in effection v4.

--- a/.changes/oxc-enabled.md
+++ b/.changes/oxc-enabled.md
@@ -1,8 +1,0 @@
----
-"@simulacrum/server": housekeeping
-"@simulacrum/foundation-simulator": housekeeping
-"@simulacrum/auth0-simulator": housekeeping
-"@simulacrum/github-api-simulator": housekeeping
----
-
-Enabling oxfmt and oxlint for more consistency.

--- a/.changes/pnpm-with-mise.md
+++ b/.changes/pnpm-with-mise.md
@@ -1,8 +1,0 @@
----
-"@simulacrum/server": housekeeping
-"@simulacrum/foundation-simulator": housekeeping
-"@simulacrum/auth0-simulator": housekeeping
-"@simulacrum/github-api-simulator": housekeeping
----
-
-Swap to pnpm within monorepo.

--- a/.changes/starfx-with-effection-v4.md
+++ b/.changes/starfx-with-effection-v4.md
@@ -1,7 +1,0 @@
----
-"@simulacrum/foundation-simulator": minor:enhance
-"@simulacrum/auth0-simulator": minor:enhance
-"@simulacrum/github-api-simulator": minor:enhance
----
-
-Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.

--- a/.changes/use-service-graph.md
+++ b/.changes/use-service-graph.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/server": minor:feat
----
-
-Define a graph of services and simulators to more easily run through the CLI helper or with a helper in tests.

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.12.0]
+
+- [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.
+- [`a3a8108`](https://github.com/thefrontside/simulacrum/commit/a3a8108f58e2523a3700b19900abbc53552c3e15) ([#357](https://github.com/thefrontside/simulacrum/pull/357) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Swap to pnpm within monorepo.
+
+### Enhancements
+
+- [`a3a8108`](https://github.com/thefrontside/simulacrum/commit/a3a8108f58e2523a3700b19900abbc53552c3e15) ([#357](https://github.com/thefrontside/simulacrum/pull/357) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Pass in global fetch to rules runner.
+- [`fd1d673`](https://github.com/thefrontside/simulacrum/commit/fd1d6734ead5b723e8d83962775851517778b695) ([#350](https://github.com/thefrontside/simulacrum/pull/350) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.
+
 ## \[0.11.4]
 
 - [`86957dd`](https://github.com/thefrontside/simulacrum/commit/86957dd0e8ecd8a6bc536fd289df5e393c1774e3) ([#352](https://github.com/thefrontside/simulacrum/pull/352) by [@a-kriya](https://github.com/thefrontside/simulacrum/../../a-kriya)) preserve user-provided id in initialState instead of overwriting

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "keywords": [
     "auth0",
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "workspace:^",
+    "@simulacrum/foundation-simulator": "^0",
     "@simulacrum/server": "workspace:^",
     "assert-ts": "^0.3.4",
     "base64-url": "^2.3.3",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## \[0.7.0]
+
+- [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.
+- [`a3a8108`](https://github.com/thefrontside/simulacrum/commit/a3a8108f58e2523a3700b19900abbc53552c3e15) ([#357](https://github.com/thefrontside/simulacrum/pull/357) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Swap to pnpm within monorepo.
+
+### Enhancements
+
+- [`fd1d673`](https://github.com/thefrontside/simulacrum/commit/fd1d6734ead5b723e8d83962775851517778b695) ([#350](https://github.com/thefrontside/simulacrum/pull/350) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.
+
+### Bug Fixes
+
+- [`872388e`](https://github.com/thefrontside/simulacrum/commit/872388edb084b65a624e2fae7c8deb8878e87965) Order initial log dispatching to help avoid the race condition made more prevalent by more direct sync vs async handling in effection v4.
+
 ## \[0.6.1]
 
 - [`d4f2be5`](https://github.com/thefrontside/simulacrum/commit/d4f2be576503e2fd374b996c26e33682d592e5ac) ([#349](https://github.com/thefrontside/simulacrum/pull/349) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Skip simulator asset minification. Also remove usage of `String.raw`. This was breaking the `/login` view in the Auth0 simulator with the way `tsdown` was escaping the strings.

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Base simulator to build simulators for integration testing.",
   "keywords": [
     "emulation",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.7.0]
+
+- [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.
+- [`a3a8108`](https://github.com/thefrontside/simulacrum/commit/a3a8108f58e2523a3700b19900abbc53552c3e15) ([#357](https://github.com/thefrontside/simulacrum/pull/357) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Swap to pnpm within monorepo.
+
+### Enhancements
+
+- [`fd1d673`](https://github.com/thefrontside/simulacrum/commit/fd1d6734ead5b723e8d83962775851517778b695) ([#350](https://github.com/thefrontside/simulacrum/pull/350) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.
+
 ## \[0.6.4]
 
 - [`86957dd`](https://github.com/thefrontside/simulacrum/commit/86957dd0e8ecd8a6bc536fd289df5e393c1774e3) ([#352](https://github.com/thefrontside/simulacrum/pull/352) by [@a-kriya](https://github.com/thefrontside/simulacrum/../../a-kriya)) preserve user-provided id in initialState instead of overwriting

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Provides common functionality to frontend app and plugins.",
   "keywords": [
     "emulation",
@@ -72,7 +72,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
     "@graphql-tools/utils": "^10.9.1",
-    "@simulacrum/foundation-simulator": "workspace:^",
+    "@simulacrum/foundation-simulator": "^0",
     "assert-ts": "^0.3.4",
     "express": "^5.2.1",
     "graphql": "^16.9.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## \[0.9.0]
+
+- [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.
+- [`a3a8108`](https://github.com/thefrontside/simulacrum/commit/a3a8108f58e2523a3700b19900abbc53552c3e15) ([#357](https://github.com/thefrontside/simulacrum/pull/357) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Swap to pnpm within monorepo.
+
+### New Features
+
+- [`e81d6b9`](https://github.com/thefrontside/simulacrum/commit/e81d6b993fb64e4300588227645b162ec75c8f62) Define a graph of services and simulators to more easily run through the CLI helper or with a helper in tests.
+
 ## \[0.8.0]
 
 - [`d3850c6`](https://github.com/thefrontside/simulacrum/commit/d3850c657ea45c9e67790b63fb4341a95818c664) ([#345](https://github.com/thefrontside/simulacrum/pull/345) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Bump server to `effection` v4. With the tight dependency fitting into an `effection` runtime, bumping with a minor despite no specific breaking changes directly in this package. Additionally, we swapped to `@effectionx/process` and pulled in some other helpers. This was to prevent edge cases which were noted as part of the upgrade.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Helpers and control plane to handle simulators and observability",
   "keywords": [
     "emulation",
@@ -43,7 +43,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./bin/run-simulation-child.ts": "./bin/run-simulation-child.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -52,7 +51,6 @@
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs"
       },
-      "./bin/run-simulation-child.ts": "./bin/run-simulation-child.ts",
       "./package.json": "./package.json"
     }
   },
@@ -77,5 +75,8 @@
   "devDependencies": {
     "@simulacrum/foundation-simulator": "workspace:^",
     "@types/picomatch": "^4.0.3"
+  },
+  "inlinedDependencies": {
+    "starfx": "0.16.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^9.3.0
         version: 9.9.0
       '@simulacrum/foundation-simulator':
-        specifier: workspace:^
-        version: link:../foundation
+        specifier: ^0
+        version: 0.6.1(ajv@8.18.0)(picomatch@4.0.4)
       '@simulacrum/server':
         specifier: workspace:^
         version: link:../server
@@ -145,8 +145,8 @@ importers:
         specifier: ^10.9.1
         version: 10.11.0(graphql@16.13.2)
       '@simulacrum/foundation-simulator':
-        specifier: workspace:^
-        version: link:../foundation
+        specifier: ^0
+        version: 0.6.1(ajv@8.18.0)(picomatch@4.0.4)
       assert-ts:
         specifier: ^0.3.4
         version: 0.3.4
@@ -1409,6 +1409,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@simulacrum/foundation-simulator@0.6.1':
+    resolution: {integrity: sha512-y7H63RBg+9ky+0V5X9qPhD6jrYxkEX2kSKbVc9wLqHw1uNCsT/HzSSXUljaJlFxpaQe1dSUo1vSWE+1cgt2gKw==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1926,6 +1929,10 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effection@3.6.1:
+    resolution: {integrity: sha512-ogsuH/cgxfOOaVUf53pYqhPJth4WhPlva0hGb4Roh6cZhttMoanMqwADkDk9ych28lKuQgntpCszbFRyRFifqg==}
+    engines: {node: '>= 16'}
+
   effection@4.0.2:
     resolution: {integrity: sha512-O8WMGP10nPuJDwbNGILcaCNWS+CvDYjcdsUSD79nWZ+WtUQ8h1MEV7JJwCSZCSeKx8+TdEaZ/8r6qPTR2o/o8w==}
     engines: {node: '>= 16'}
@@ -2202,6 +2209,9 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
   immer@11.1.4:
     resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
@@ -2896,6 +2906,20 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  starfx@0.15.0:
+    resolution: {integrity: sha512-qoTrShVhtx5kdydPxN6Z6iu+J/GchQqg/7RF2TOdYZTY+AQ7g4tDLbPTn1ch2ijIv0F9U3NcwPfrmzNkyez1lA==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      react-redux: 9.x
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-redux:
+        optional: true
 
   starfx@0.16.0:
     resolution: {integrity: sha512-RFADvJf25hO/wIobZh43ALRo2qELOzb8FlvXlzQbpinNkDEPUWdftCz7Q2uh85vpU+BaJmH/gd/Qo/iIN5nTXw==}
@@ -4495,6 +4519,25 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@simulacrum/foundation-simulator@0.6.1(ajv@8.18.0)(picomatch@4.0.4)':
+    dependencies:
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      cors: 2.8.6
+      defu: 6.1.4
+      express: 5.2.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      http-proxy-middleware: 3.0.5
+      lodash: 4.17.23
+      openapi-backend: 5.16.1
+      starfx: 0.15.0
+    transitivePeerDependencies:
+      - ajv
+      - picomatch
+      - react
+      - react-dom
+      - react-redux
+      - supports-color
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -5026,6 +5069,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effection@3.6.1: {}
+
   effection@4.0.2: {}
 
   electron-to-chromium@1.5.329: {}
@@ -5361,6 +5406,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  immer@10.2.0: {}
 
   immer@11.1.4: {}
 
@@ -6107,6 +6154,12 @@ snapshots:
       tslib: 2.8.1
 
   stackback@0.0.2: {}
+
+  starfx@0.15.0:
+    dependencies:
+      effection: 3.6.1
+      immer: 10.2.0
+      reselect: 5.1.1
 
   starfx@0.16.0:
     dependencies:


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/server

## [0.9.0]
- 9ef139f (#359 by @jbolda) Enabling oxfmt and oxlint for more consistency.
- a3a8108 (#357 by @jbolda) Swap to pnpm within monorepo.
### New Features

- e81d6b9 Define a graph of services and simulators to more easily run through the CLI helper or with a helper in tests.



# @simulacrum/foundation-simulator

## [0.7.0]
- 9ef139f (#359 by @jbolda) Enabling oxfmt and oxlint for more consistency.
- a3a8108 (#357 by @jbolda) Swap to pnpm within monorepo.
### Enhancements

- fd1d673 (#350 by @jbolda) Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.
### Bug Fixes

- 872388e Order initial log dispatching to help avoid the race condition made more prevalent by more direct sync vs async handling in effection v4.



# @simulacrum/auth0-simulator

## [0.12.0]
- 9ef139f (#359 by @jbolda) Enabling oxfmt and oxlint for more consistency.
- a3a8108 (#357 by @jbolda) Swap to pnpm within monorepo.
### Enhancements

- a3a8108 (#357 by @jbolda) Pass in global fetch to rules runner.
- fd1d673 (#350 by @jbolda) Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.



# @simulacrum/github-api-simulator

## [0.7.0]
- 9ef139f (#359 by @jbolda) Enabling oxfmt and oxlint for more consistency.
- a3a8108 (#357 by @jbolda) Swap to pnpm within monorepo.
### Enhancements

- fd1d673 (#350 by @jbolda) Upgrades the foundation simulator to `starfx@0.16.0` which in turn upgrades to `effection@^4`. Highly unlikely to be a breaking change, but bumping a minor for safety.