### PR TITLE
run fmt after versioning

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -45,6 +45,8 @@ jobs:
       # covector
       - run: pnpm install --no-frozen-lockfile
         if: steps.covector.outputs.commandRan == 'version'
+      - run: pnpm run fmt
+        if: steps.covector.outputs.commandRan == 'version'
 
       - name: Create Pull Request With Versions Bumped
         id: cpr


### PR DESCRIPTION
## Motivation

When covector runs the version step, we get a format that falls out of compliance with `pnpm run fmt`.

## Approach

Run the `pnpm run fmt` afterwards which will fix it.