### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/clamp-foundation-version.md
+++ b/.changes/clamp-foundation-version.md
@@ -1,6 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch:deps
-"@simulacrum/github-api-simulator": patch:deps
----
-
-Workspace deps with pnpm unintentionally expanded the dep range for `@simulacrum/foundation-simulator`. Clamp it down to only exact range defined.

--- a/.changes/dedupe-effectionx-context-api.md
+++ b/.changes/dedupe-effectionx-context-api.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/server": patch:deps
----
-
-Bump `@effectionx/process` to align and dedupe `@effectionx/context-api`.

--- a/.changes/esm-only.md
+++ b/.changes/esm-only.md
@@ -1,8 +1,0 @@
----
-"@simulacrum/server": minor:enhance
-"@simulacrum/foundation-simulator": minor:enhance
-"@simulacrum/auth0-simulator": minor:enhance
-"@simulacrum/github-api-simulator": minor:enhance
----
-
-Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.

--- a/.changes/jsonwebtoken-to-jose.md
+++ b/.changes/jsonwebtoken-to-jose.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": minor:enhance
----
-
-Swap from `jsonwebtoken` to `jose` which provides better compatibility with ESM. This _should_ be a non-breaking change. If tokens are generated differently, we would consider it a bug.

--- a/.changes/starfx-scope-tuple-effection.md
+++ b/.changes/starfx-scope-tuple-effection.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/foundation-simulator": patch:deps
----
-
-Bump `starfx` to fix `scope.set()` error from `effection` tuple change.

--- a/.changes/use-better-pathing.md
+++ b/.changes/use-better-pathing.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/server": patch:bug
----
-
-Fix path resolution in `useSimulation` and default to `shell: true` for `useService`.

--- a/.changes/useSimulation-nodeArgs.md
+++ b/.changes/useSimulation-nodeArgs.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/server": minor:enhance
----
-
-Allow `useSimulation` to set extra `nodeArgs` for spawning a `child_process`. This enables using `--import` or other utilities such as might be required for directly executing TypeScript files on some verisons of node.

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## \[0.13.0]
+
+### Enhancements
+
+- [`3317d15`](https://github.com/thefrontside/simulacrum/commit/3317d1537922042db1cd9994a5916b8d75e249af) ([#365](https://github.com/thefrontside/simulacrum/pull/365) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
+- [`024cc24`](https://github.com/thefrontside/simulacrum/commit/024cc24517fe4e28d9854f25a54591b5d457bd28) ([#369](https://github.com/thefrontside/simulacrum/pull/369) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Swap from `jsonwebtoken` to `jose` which provides better compatibility with ESM. This _should_ be a non-breaking change. If tokens are generated differently, we would consider it a bug.
+
+### Dependencies
+
+- [`b0313de`](https://github.com/thefrontside/simulacrum/commit/b0313decf4cc835b2ffd1c9e516576be166a438e) ([#370](https://github.com/thefrontside/simulacrum/pull/370) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Workspace deps with pnpm unintentionally expanded the dep range for `@simulacrum/foundation-simulator`. Clamp it down to only exact range defined.
+
 ## \[0.12.0]
 
 - [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "keywords": [
     "auth0",
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
-    "@simulacrum/foundation-simulator": "^0.7.0",
+    "@simulacrum/foundation-simulator": "^0.8.0",
     "assert-ts": "^0.3.4",
     "base64-url": "^2.3.3",
     "cookie-session": "^2.1.0",

--- a/packages/foundation/CHANGELOG.md
+++ b/packages/foundation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.8.0]
+
+### Enhancements
+
+- [`3317d15`](https://github.com/thefrontside/simulacrum/commit/3317d1537922042db1cd9994a5916b8d75e249af) ([#365](https://github.com/thefrontside/simulacrum/pull/365) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
+
+### Dependencies
+
+- [`b0313de`](https://github.com/thefrontside/simulacrum/commit/b0313decf4cc835b2ffd1c9e516576be166a438e) ([#370](https://github.com/thefrontside/simulacrum/pull/370) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Bump `starfx` to fix `scope.set()` error from `effection` tuple change.
+
 ## \[0.7.0]
 
 - [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/foundation-simulator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Base simulator to build simulators for integration testing.",
   "keywords": [
     "emulation",

--- a/packages/github-api/CHANGELOG.md
+++ b/packages/github-api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## \[0.8.0]
+
+### Enhancements
+
+- [`3317d15`](https://github.com/thefrontside/simulacrum/commit/3317d1537922042db1cd9994a5916b8d75e249af) ([#365](https://github.com/thefrontside/simulacrum/pull/365) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
+
+### Dependencies
+
+- [`b0313de`](https://github.com/thefrontside/simulacrum/commit/b0313decf4cc835b2ffd1c9e516576be166a438e) ([#370](https://github.com/thefrontside/simulacrum/pull/370) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Workspace deps with pnpm unintentionally expanded the dep range for `@simulacrum/foundation-simulator`. Clamp it down to only exact range defined.
+
 ## \[0.7.0]
 
 - [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.

--- a/packages/github-api/package.json
+++ b/packages/github-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/github-api-simulator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Provides common functionality to frontend app and plugins.",
   "keywords": [
     "emulation",
@@ -66,7 +66,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
     "@graphql-tools/utils": "^10.9.1",
-    "@simulacrum/foundation-simulator": "^0.7.0",
+    "@simulacrum/foundation-simulator": "^0.8.0",
     "assert-ts": "^0.3.4",
     "express": "^5.2.1",
     "graphql": "^16.9.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## \[0.10.0]
+
+### Enhancements
+
+- [`3317d15`](https://github.com/thefrontside/simulacrum/commit/3317d1537922042db1cd9994a5916b8d75e249af) ([#365](https://github.com/thefrontside/simulacrum/pull/365) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
+- [`b0313de`](https://github.com/thefrontside/simulacrum/commit/b0313decf4cc835b2ffd1c9e516576be166a438e) ([#370](https://github.com/thefrontside/simulacrum/pull/370) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Allow `useSimulation` to set extra `nodeArgs` for spawning a `child_process`. This enables using `--import` or other utilities such as might be required for directly executing TypeScript files on some verisons of node.
+
+### Bug Fixes
+
+- [`b0313de`](https://github.com/thefrontside/simulacrum/commit/b0313decf4cc835b2ffd1c9e516576be166a438e) ([#370](https://github.com/thefrontside/simulacrum/pull/370) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Fix path resolution in `useSimulation` and default to `shell: true` for `useService`.
+
+### Dependencies
+
+- [`b0313de`](https://github.com/thefrontside/simulacrum/commit/b0313decf4cc835b2ffd1c9e516576be166a438e) ([#370](https://github.com/thefrontside/simulacrum/pull/370) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Bump `@effectionx/process` to align and dedupe `@effectionx/context-api`.
+
 ## \[0.9.0]
 
 - [`9ef139f`](https://github.com/thefrontside/simulacrum/commit/9ef139f80b0403b4b66163ee7005b552640394c2) ([#359](https://github.com/thefrontside/simulacrum/pull/359) by [@jbolda](https://github.com/thefrontside/simulacrum/../../jbolda)) Enabling oxfmt and oxlint for more consistency.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Helpers and control plane to handle simulators and observability",
   "keywords": [
     "emulation",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         specifier: ^9.3.0
         version: 9.9.0
       '@simulacrum/foundation-simulator':
-        specifier: ^0.7.0
+        specifier: ^0.8.0
         version: link:../foundation
       assert-ts:
         specifier: ^0.3.4
@@ -154,7 +154,7 @@ importers:
         specifier: ^10.9.1
         version: 10.11.0(graphql@16.13.2)
       '@simulacrum/foundation-simulator':
-        specifier: ^0.7.0
+        specifier: ^0.8.0
         version: link:../foundation
       assert-ts:
         specifier: ^0.3.4


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/server

## [0.10.0]
### Enhancements

- 3317d15 (#365 by @jbolda) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
- b0313de (#370 by @jbolda) Allow `useSimulation` to set extra `nodeArgs` for spawning a `child_process`. This enables using `--import` or other utilities such as might be required for directly executing TypeScript files on some verisons of node.
### Bug Fixes

- b0313de (#370 by @jbolda) Fix path resolution in `useSimulation` and default to `shell: true` for `useService`.
### Dependencies

- b0313de (#370 by @jbolda) Bump `@effectionx/process` to align and dedupe `@effectionx/context-api`.



# @simulacrum/foundation-simulator

## [0.8.0]
### Enhancements

- 3317d15 (#365 by @jbolda) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
### Dependencies

- b0313de (#370 by @jbolda) Bump `starfx` to fix `scope.set()` error from `effection` tuple change.



# @simulacrum/auth0-simulator

## [0.13.0]
### Enhancements

- 3317d15 (#365 by @jbolda) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
- 024cc24 (#369 by @jbolda) Swap from `jsonwebtoken` to `jose` which provides better compatibility with ESM. This *should* be a non-breaking change. If tokens are generated differently, we would consider it a bug.
### Dependencies

- b0313de (#370 by @jbolda) Workspace deps with pnpm unintentionally expanded the dep range for `@simulacrum/foundation-simulator`. Clamp it down to only exact range defined.



# @simulacrum/github-api-simulator

## [0.8.0]
### Enhancements

- 3317d15 (#365 by @jbolda) Convert package to ESM only. All LTS are able to import ESM, both from an ESM or CJS context.
### Dependencies

- b0313de (#370 by @jbolda) Workspace deps with pnpm unintentionally expanded the dep range for `@simulacrum/foundation-simulator`. Clamp it down to only exact range defined.