### PR TITLE
run-simulation-child.ts as bundle entry

### DIFF
--- a/.changes/run-simulation-child-bundled.md
+++ b/.changes/run-simulation-child-bundled.md
@@ -1,0 +1,5 @@
+---
+"@simulacrum/server": patch:bug
+---
+
+`run-simulation-child.js` was not properly bundled. Add as entrypoint which adds it as a `bin` and includes it in bundling. The `bin` should be usuable, but will likely only be used directly within the lib.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,9 +19,11 @@
     "url": "git+https://github.com/thefrontside/simulacrum.git",
     "directory": "packages/server"
   },
+  "bin": {
+    "server": "./src/run-simulation-child.ts"
+  },
   "files": [
     "README.md",
-    "bin",
     "dist",
     "src"
   ],
@@ -40,11 +42,19 @@
       "development": "./src/index.ts",
       "default": "./dist/index.mjs"
     },
+    "./run-simulation-child": {
+      "development": "./src/run-simulation-child.ts",
+      "default": "./dist/run-simulation-child.mjs"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
+    "bin": {
+      "server": "./dist/run-simulation-child.mjs"
+    },
     "exports": {
       ".": "./dist/index.mjs",
+      "./run-simulation-child": "./dist/run-simulation-child.mjs",
       "./package.json": "./package.json"
     }
   },

--- a/packages/server/src/simulation.ts
+++ b/packages/server/src/simulation.ts
@@ -1,15 +1,14 @@
 import { resource, until, spawn, withResolvers } from "effection";
-import { useAttributes } from "./logging.ts";
 import type { Operation } from "effection";
 import { daemon, Stdio } from "@effectionx/process";
-import { logger } from "./logging.ts";
+import { useAttributes, logger } from "./logging.ts";
 import type {
   FoundationSimulator,
   FoundationSimulatorListening,
 } from "@simulacrum/foundation-simulator";
 import { SimulacrumEndpoint } from "./service-graph.ts";
-import { fileURLToPath } from "node:url";
 import { withOperationMetadata } from "./operation-metadata.ts";
+import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
 type UseSimulationOptions = {
@@ -60,13 +59,13 @@ function useSimulationInProcess<L extends object = Record<string, unknown>>(
 }
 
 const runnerPathTs = fileURLToPath(new URL("./run-simulation-child.ts", import.meta.url));
-const runnerPathJs = fileURLToPath(new URL("./run-simulation-child.js", import.meta.url));
+const runnerPathJs = fileURLToPath(new URL("./run-simulation-child.mjs", import.meta.url));
 const runnerResolvedPath = existsSync(runnerPathTs) ? runnerPathTs : runnerPathJs;
 
 /**
  * Spawn a child Node process to run a simulation factory.
  *
- * This runs `./run-simulation-child.js <modulePath>` in a separate Node
+ * This runs `./run-simulation-child.mjs <modulePath>` in a separate Node
  * process and reads the first JSON line printed to stdout to discover the
  * child's listening port. Optionally the simulacrum gateway port will be
  * passed to the child so it can fetch `globalData`.

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   name: "server",
-  entry: "./src/index.ts",
+  entry: ["./src/index.ts", "./src/run-simulation-child.ts"],
   deps: {
     // if we unbundle, we want to skip this as well
     skipNodeModulesBundle: true,


### PR DESCRIPTION
## Motivation

This file was not included in our bundled output. Add it as an entry so it is included.
