### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/change-pr-375.md
+++ b/.changes/change-pr-375.md
@@ -1,5 +1,0 @@
----
-"@simulacrum/auth0-simulator": patch
----
-
-Include kid (`JWKS.keys[0].kid`) in `SignJWT().setProtectedHeader()` for `access_token` and `id_token` so clients performing JWKS-based signature verification can find the correct public key.

--- a/packages/auth0/CHANGELOG.md
+++ b/packages/auth0/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## \[0.13.1]
+
+- [`d4edee7`](https://github.com/thefrontside/simulacrum/commit/d4edee78aed5b00636b4c38031e8085c4830998d) ([#375](https://github.com/thefrontside/simulacrum/pull/375) by [@joergjaeckel](https://github.com/thefrontside/simulacrum/../../joergjaeckel)) Include kid (`JWKS.keys[0].kid`) in `SignJWT().setProtectedHeader()` for `access_token` and `id_token` so clients performing JWKS-based signature verification can find the correct public key.
+
 ## \[0.13.0]
 
 ### Enhancements

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simulacrum/auth0-simulator",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Run local instance of Auth0 API for local development and integration testing",
   "keywords": [
     "auth0",


### PR DESCRIPTION
# Version Updates

Merging this PR will release new versions of the following packages based on your change files.




# @simulacrum/auth0-simulator

## [0.13.1]
- d4edee7 (#375 by @joergjaeckel) Include kid (`JWKS.keys[0].kid`) in `SignJWT().setProtectedHeader()` for `access_token` and `id_token` so clients performing JWKS-based signature verification can find the correct public key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protected access and ID token headers now include the JWKS key ID (`kid`), improving JWT key identification and validation compatibility.

* **Release Updates**
  * Updated the Auth0 simulator to version 0.13.1.
  * Added release documentation describing the token header improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->